### PR TITLE
Fix: create the temporary directory for downloading NPM releases.

### DIFF
--- a/tools/get_releases.mjs
+++ b/tools/get_releases.mjs
@@ -130,6 +130,8 @@ async function getReleasesForVersion4OrLater() {
     if (fs.existsSync(tempDir)) {
       fs.rmdirSync(tempDir, { recursive: true });
     }
+    // Make the temporary directory.
+    fs.mkdirSync(tempDir);
 
     console.log('\nDownload', ver, 'from npm.');
     execSync(`npm pack vexflow@${ver} --pack-destination ${tempDir} 2> /dev/null`).toString();


### PR DESCRIPTION
The `grunt get:releases:4.2.2` script used to work fine, but perhaps some versions of `npm pack` do not create the directory for you if it doesn't already exist.

This patch fixes the script, to allow for easier visual diffing between our current work and a release that has been published on NPM.

**This patch will also be applied to the 4.x repository** at https://github.com/0xfe/vexflow to help address the PR on visual regression testing: https://github.com/0xfe/vexflow/issues/1508