### PR TITLE
element (v5)

### DIFF
--- a/src/annotation.ts
+++ b/src/annotation.ts
@@ -1,7 +1,5 @@
 // Copyright (c) 2023-present VexFlow contributors: https://github.com/vexflow/vexflow/graphs/contributors
 // MIT License
-import { Element } from './element';
-import { FontInfo } from './font';
 import { Modifier, ModifierPosition } from './modifier';
 import { ModifierContextState } from './modifiercontext';
 import { Stave } from './stave';
@@ -45,8 +43,6 @@ export class Annotation extends Modifier {
   static get CATEGORY(): string {
     return Category.Annotation;
   }
-
-  static TEXT_FONT: Required<FontInfo> = { ...Element.TEXT_FONT };
 
   /** Text annotations can be positioned and justified relative to the note. */
   static HorizontalJustify = AnnotationHorizontalJustify;
@@ -195,7 +191,6 @@ export class Annotation extends Modifier {
     // warning: the default in the constructor is TOP, but in the factory the default is BOTTOM.
     // this is to support legacy application that may expect this.
     this.verticalJustification = AnnotationVerticalJustify.TOP;
-    this.resetFont();
 
     // The default width is calculated from the text.
     this.setWidth(Tables.textWidth(text));

--- a/src/bend.ts
+++ b/src/bend.ts
@@ -31,9 +31,6 @@ export class Bend extends Modifier {
     return 1;
   }
 
-  /** Default text font. */
-  static TEXT_FONT: Required<FontInfo> = { ...Element.TEXT_FONT };
-
   // Arrange bends in `ModifierContext`
   static format(bends: Bend[], state: ModifierContextState): boolean {
     if (!bends || bends.length === 0) return false;
@@ -109,10 +106,9 @@ export class Bend extends Modifier {
     super();
 
     this.text = text;
-    this.xShift = 0;
     this.release = release;
     this.tap = '';
-    this.resetFont();
+
     this.renderOptions = {
       lineWidth: 1.5,
       lineStyle: '#777777',

--- a/src/chordsymbol.ts
+++ b/src/chordsymbol.ts
@@ -9,7 +9,7 @@
 //
 // See `tests/chordsymbol_tests.ts` for usage examples.
 
-import { Font, FontInfo, FontStyle, FontWeight } from './font';
+import { Font, FontInfo } from './font';
 import { Glyph } from './glyph';
 import { Modifier } from './modifier';
 import { ModifierContextState } from './modifiercontext';
@@ -409,26 +409,12 @@ export class ChordSymbol extends Modifier {
 
   constructor() {
     super();
-    this.resetFont();
-  }
-
-  /**
-   * Default text font.
-   * Choose a font family that works well with the current music engraving font.
-   * @override `Element.TEXT_FONT`.
-   */
-  static get TEXT_FONT(): Required<FontInfo> {
-    let family = 'Roboto Slab, Times, serif';
     if (Tables.currentMusicFont().getName() === 'Petaluma') {
       // Fixes Issue #1180
-      family = 'PetalumaScript, Arial, sans-serif';
+      this.textFont.family = 'PetalumaScript, Arial, sans-serif';
     }
-    return {
-      family,
-      size: 12,
-      weight: FontWeight.NORMAL,
-      style: FontStyle.NORMAL,
-    };
+
+    this.textFormatter = TextFormatter.create(this.textFont);
   }
 
   /**

--- a/src/element.ts
+++ b/src/element.ts
@@ -3,11 +3,12 @@
 // @author Mohit Cheppudira
 
 import { BoundingBox } from './boundingbox';
-import { Font, FontInfo, FontStyle, FontWeight } from './font';
+import { Font, FontInfo } from './font';
 import { Registry } from './registry';
 import { RenderContext } from './rendercontext';
+import { Tables } from './tables';
 import { Category } from './typeguard';
-import { defined, prefix } from './util';
+import { defined, prefix, RuntimeError } from './util';
 
 /** Element attributes. */
 export interface ElementAttributes {
@@ -59,12 +60,11 @@ export interface ElementStyle {
  * Element implements a generic base class for VexFlow, with implementations
  * of general functions and properties that can be inherited by all VexFlow elements.
  *
- * The Element is an abstract class that needs to be subclassed to work. It handles
- * style and text-font properties for the Element and any child elements, along with
- * working with the Registry to create unique ids, but does not have any tools for
- * formatting x or y positions or connections to a Stave.
+ * The Element handles style and text-font properties for the Element and any child
+ * elements, along with working with the Registry to create unique ids, but does not
+ * have any tools for formatting x or y positions or connections to a Stave.
  */
-export abstract class Element {
+export class Element {
   static get CATEGORY(): string {
     return Category.Element;
   }
@@ -77,17 +77,6 @@ export abstract class Element {
     return `auto${Element.ID++}`;
   }
 
-  /**
-   * Default font for text. This is not related to music engraving. Instead, see `Flow.setMusicFont(...fontNames)`
-   * to customize the font for musical symbols placed on the score.
-   */
-  static TEXT_FONT: Required<FontInfo> = {
-    family: Font.SANS_SERIF,
-    size: Font.SIZE,
-    weight: FontWeight.NORMAL,
-    style: FontStyle.NORMAL,
-  };
-
   #context?: RenderContext;
   #attrs: ElementAttributes;
 
@@ -97,20 +86,38 @@ export abstract class Element {
   protected registry?: Registry;
 
   /**
-   * Some elements include text.
    * The `textFont` property contains information required to style the text (i.e., font family, size, weight, and style).
-   * It is undefined by default, and can be set using `setFont(...)` or `resetFont()`.
    */
-  protected textFont?: Required<FontInfo>;
+  protected textFont: Required<FontInfo>;
+  protected text = '';
+  protected textMetrics: TextMetrics = {
+    fontBoundingBoxAscent: 0,
+    fontBoundingBoxDescent: 0,
+    actualBoundingBoxAscent: 0,
+    actualBoundingBoxDescent: 0,
+    actualBoundingBoxLeft: 0,
+    actualBoundingBoxRight: 0,
+    width: 0,
+  };
 
-  constructor() {
+  protected width: number = 0;
+  protected yShift: number = 0;
+  protected xShift: number = 0;
+
+  constructor(category?: string) {
     this.#attrs = {
       id: Element.newID(),
-      type: this.getCategory(),
+      type: category ? category : (<typeof Element>this.constructor).CATEGORY,
       class: '',
     };
 
     this.rendered = false;
+    this.textFont = {
+      family: Tables.lookupMetric(`${this.#attrs.type}.fontFamily`),
+      size: Tables.lookupMetric(`${this.#attrs.type}.fontSize`),
+      weight: Tables.lookupMetric(`${this.#attrs.type}.fontWeight`),
+      style: Tables.lookupMetric(`${this.#attrs.type}.fontStyle`),
+    };
 
     // If a default registry exist, then register with it right away.
     Registry.getDefaultRegistry()?.register(this);
@@ -131,7 +138,7 @@ export abstract class Element {
   }
 
   getCategory(): string {
-    return (<typeof Element>this.constructor).CATEGORY;
+    return `${this.#attrs.type}`;
   }
 
   /**
@@ -213,8 +220,9 @@ export abstract class Element {
   }
 
   /** Draw an element. */
-  // eslint-disable-next-line
-  abstract draw(...args: any[]): void;
+  draw(): void {
+    throw new RuntimeError('Element', 'Draw not defined');
+  }
 
   /** Check if it has a class label (An element can have multiple class labels).  */
   hasClass(className: string): boolean {
@@ -351,12 +359,15 @@ export abstract class Element {
    * Each Element subclass may specify its own default by overriding the static `TEXT_FONT` property.
    */
   setFont(font?: string | FontInfo, size?: string | number, weight?: string | number, style?: string): this {
-    // Allow subclasses to override `TEXT_FONT`.
-    const defaultTextFont: Required<FontInfo> = (<typeof Element>this.constructor).TEXT_FONT;
+    const defaultTextFont: Required<FontInfo> = {
+      family: Tables.lookupMetric(`${this.#attrs.type}.fontFamily`),
+      size: Tables.lookupMetric(`${this.#attrs.type}.fontSize`),
+      weight: Tables.lookupMetric(`${this.#attrs.type}.fontWeight`),
+      style: Tables.lookupMetric(`${this.#attrs.type}.fontStyle`),
+    };
 
     const fontIsObject = typeof font === 'object';
     const fontIsString = typeof font === 'string';
-    const fontIsUndefined = font === undefined;
     const sizeWeightStyleAreUndefined = size === undefined && weight === undefined && style === undefined;
 
     if (fontIsObject) {
@@ -365,13 +376,7 @@ export abstract class Element {
     } else if (fontIsString && sizeWeightStyleAreUndefined) {
       // `font` is case 2) CSS font shorthand.
       this.textFont = Font.fromCSSString(font);
-    } else if (fontIsUndefined && sizeWeightStyleAreUndefined) {
-      // All arguments are undefined. Do not check for `arguments.length === 0`,
-      // which fails on the edge case: `setFont(undefined)`.
-      // TODO: See if we can remove this case entirely without introducing a visual diff.
-      // The else case below seems like it should be equivalent to this case.
-      this.textFont = { ...defaultTextFont };
-    } else {
+     } else {
       // `font` is case 3) a font family string (e.g., 'Times New Roman').
       // The other parameters represent the size, weight, and style.
       // It is okay for `font` to be undefined while one or more of the other arguments is provided.
@@ -383,6 +388,7 @@ export abstract class Element {
         style ?? defaultTextFont.style
       );
     }
+    this.measureText();
     return this;
   }
 
@@ -391,28 +397,14 @@ export abstract class Element {
    * 'bold 10pt Arial'.
    */
   getFont(): string {
-    if (!this.textFont) {
-      this.resetFont();
-    }
     return Font.toCSSString(this.textFont);
-  }
-
-  /**
-   * Reset the text font to the style indicated by the static `TEXT_FONT` property.
-   * Subclasses can call this to initialize `textFont` for the first time.
-   */
-  resetFont(): void {
-    this.setFont();
   }
 
   /** Return a copy of the current FontInfo object. */
   get fontInfo(): Required<FontInfo> {
-    if (!this.textFont) {
-      this.resetFont();
-    }
     // We can cast to Required<FontInfo> here, because
     // we just called resetFont() above to ensure this.textFont is set.
-    return { ...this.textFont } as Required<FontInfo>;
+    return this.textFont;
   }
 
   set fontInfo(fontInfo: FontInfo) {
@@ -490,5 +482,96 @@ export abstract class Element {
   set fontWeight(weight: string | number) {
     const fontInfo = this.fontInfo;
     this.setFont(fontInfo.family, fontInfo.size, weight, fontInfo.style);
+  }
+
+  /** Get element width. */
+  getWidth(): number {
+    return this.width;
+  }
+
+  /** Set element width. */
+  setWidth(width: number): this {
+    this.width = width;
+    return this;
+  }
+
+  /** Shift element down `y` pixels. Negative values shift up. */
+  setYShift(y: number): this {
+    this.yShift = y;
+    return this;
+  }
+
+  /** Get shift element `y` */
+  getYShift(): number {
+    return this.yShift;
+  }
+
+  /**
+   * Set shift element right `x` pixels. Negative values shift left.
+   */
+  setXShift(x: number): this {
+    this.xShift = x;
+    return this;
+  }
+
+  /** Get shift element `x` */
+  getXShift(): number {
+    return this.xShift;
+  }
+
+  /**
+   * Set element text
+   */
+  setText(txt: string): this {
+    this.text = txt;
+    return this;
+  }
+
+  /** Get element text */
+  getText(): string {
+    return this.text;
+  }
+
+  /**
+   * Render the element text .
+   */
+  renderText(ctx: RenderContext, xPos: number, yPos: number): void {
+    ctx.save();
+    ctx.setFont(this.textFont);
+    ctx.fillText(this.text, xPos + this.xShift, yPos + this.yShift);
+    ctx.restore();
+  }
+
+  /** Canvas used to measure text */
+  protected static txtCanvas?: HTMLCanvasElement;
+
+  measureText(): TextMetrics {
+    let txtCanvas = Element.txtCanvas;
+    if (!txtCanvas) {
+      // Create the SVG text element that will be used to measure text in the event
+      // of a cache miss.
+      txtCanvas = document.createElement('canvas');
+      Element.txtCanvas = txtCanvas;
+    }
+    const context = txtCanvas.getContext('2d');
+    if (!context) throw new RuntimeError('Font', 'No txt context');
+    context.font = Font.toCSSString(Font.validate(this.textFont));
+    this.textMetrics = context.measureText(this.text);
+    this.boundingBox = new BoundingBox(
+      0,
+      -this.textMetrics.actualBoundingBoxAscent,
+      this.textMetrics.width,
+      this.textMetrics.actualBoundingBoxDescent + this.textMetrics.actualBoundingBoxAscent
+    );
+    this.width = this.textMetrics.width;
+    return this.textMetrics;
+  }
+
+  getTextMetrics(): TextMetrics {
+    return this.textMetrics;
+  }
+
+  getHeight() {
+    return this.textMetrics.actualBoundingBoxDescent + this.textMetrics.actualBoundingBoxAscent;
   }
 }

--- a/src/element.ts
+++ b/src/element.ts
@@ -60,9 +60,15 @@ export interface ElementStyle {
  * Element implements a generic base class for VexFlow, with implementations
  * of general functions and properties that can be inherited by all VexFlow elements.
  *
- * The Element handles style and text-font properties for the Element and any child
- * elements, along with working with the Registry to create unique ids, but does not
- * have any tools for formatting x or y positions or connections to a Stave.
+ * The Element handles style and font properties for the Element and any child
+ * elements, along with working with the Registry to create unique ids.
+ *
+ * The `text` is a series of unicode characters (including SMuFL codes).
+ * The `textFont` property contains information required to style the text (i.e., font family, size, weight, and style). 
+ * This font family is a comma separated list of fonts. 
+ * The method `measureText` calculates the `textMetrics` and `ẃidth` of the `text`.
+ * The methos `renderText` will render the text using the context provided at the coordinates provided 
+ * taking `xShift` and `yShift` into account. 
  */
 export class Element {
   static get CATEGORY(): string {
@@ -86,8 +92,7 @@ export class Element {
   protected registry?: Registry;
 
   /**
-   * The `textFont` property contains information required to style the text (i.e., font family, size, weight, and style).
-   */
+    */
   protected textFont: Required<FontInfo>;
   protected text = '';
   protected textMetrics: TextMetrics = {
@@ -107,7 +112,7 @@ export class Element {
   constructor(category?: string) {
     this.#attrs = {
       id: Element.newID(),
-      type: category ? category : (<typeof Element>this.constructor).CATEGORY,
+      type: category ?? (<typeof Element>this.constructor).CATEGORY,
       class: '',
     };
 
@@ -138,7 +143,7 @@ export class Element {
   }
 
   getCategory(): string {
-    return `${this.#attrs.type}`;
+    return this.#attrs.type;
   }
 
   /**
@@ -495,26 +500,26 @@ export class Element {
     return this;
   }
 
-  /** Shift element down `y` pixels. Negative values shift up. */
-  setYShift(y: number): this {
-    this.yShift = y;
+  /** Shift element down `yShift` pixels. Negative values shift up. */
+  setYShift(yShift: number): this {
+    this.yShift = yShift;
     return this;
   }
 
-  /** Get shift element `y` */
+  /** Get shift element `yShift` */
   getYShift(): number {
     return this.yShift;
   }
 
   /**
-   * Set shift element right `x` pixels. Negative values shift left.
+   * Set shift element right `xShift` pixels. Negative values shift left.
    */
-  setXShift(x: number): this {
-    this.xShift = x;
+  setXShift(xShift: number): this {
+    this.xShift = xShift;
     return this;
   }
 
-  /** Get shift element `x` */
+  /** Get shift element `xShift` */
   getXShift(): number {
     return this.xShift;
   }
@@ -522,8 +527,8 @@ export class Element {
   /**
    * Set element text
    */
-  setText(txt: string): this {
-    this.text = txt;
+  setText(text: string): this {
+    this.text = text;
     return this;
   }
 
@@ -543,15 +548,15 @@ export class Element {
   }
 
   /** Canvas used to measure text */
-  protected static txtCanvas?: HTMLCanvasElement;
+  static #txtCanvas?: HTMLCanvasElement;
 
   measureText(): TextMetrics {
-    let txtCanvas = Element.txtCanvas;
+    let txtCanvas = Element.#txtCanvas;
     if (!txtCanvas) {
       // Create the SVG text element that will be used to measure text in the event
       // of a cache miss.
       txtCanvas = document.createElement('canvas');
-      Element.txtCanvas = txtCanvas;
+      Element.#txtCanvas = txtCanvas;
     }
     const context = txtCanvas.getContext('2d');
     if (!context) throw new RuntimeError('Font', 'No txt context');

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -63,7 +63,6 @@ export interface FactoryOptions {
     height: number;
     background?: string;
   };
-  font?: FontInfo;
 }
 
 // eslint-disable-next-line
@@ -77,9 +76,6 @@ function L(...args: any[]) {
 export class Factory {
   /** To enable logging for this class. Set `Vex.Flow.Factory.DEBUG` to `true`. */
   static DEBUG: boolean = false;
-
-  /** Default text font. */
-  static TEXT_FONT: Required<FontInfo> = { ...Element.TEXT_FONT };
 
   /**
    * Static simplified function to access constructor without providing FactoryOptions
@@ -122,7 +118,6 @@ export class Factory {
         height: 200,
         background: '#FFF',
       },
-      font: Factory.TEXT_FONT,
     };
 
     this.setOptions(options);

--- a/src/flow.ts
+++ b/src/flow.ts
@@ -7,13 +7,7 @@ import { Bend } from './bend';
 import { BoundingBox } from './boundingbox';
 import { BoundingBoxComputation } from './boundingboxcomputation';
 import { CanvasContext } from './canvascontext';
-import {
-  ChordSymbol,
-  ChordSymbolHorizontalJustify,
-  ChordSymbolVerticalJustify,
-  SymbolModifiers,
-  SymbolTypes,
-} from './chordsymbol';
+import { ChordSymbol, ChordSymbolHorizontalJustify, ChordSymbolVerticalJustify, SymbolModifiers } from './chordsymbol';
 import { Clef } from './clef';
 import { ClefNote } from './clefnote';
 import { Crescendo } from './crescendo';
@@ -67,7 +61,7 @@ import { StringNumber } from './stringnumber';
 import { Stroke } from './strokes';
 import { SVGContext } from './svgcontext';
 import { System } from './system';
-import { Tables } from './tables';
+import { CommonMetrics, Tables } from './tables';
 import { TabNote } from './tabnote';
 import { TabSlide } from './tabslide';
 import { TabStave } from './tabstave';
@@ -186,7 +180,6 @@ export class Flow {
   static AnnotationVerticalJustify = AnnotationVerticalJustify;
   static ChordSymbolHorizontalJustify = ChordSymbolHorizontalJustify;
   static ChordSymbolVerticalJustify = ChordSymbolVerticalJustify;
-  static SymbolTypes = SymbolTypes;
   static SymbolModifiers = SymbolModifiers;
   static CurvePosition = CurvePosition;
   static FontWeight = FontWeight;
@@ -229,6 +222,7 @@ export class Flow {
    */
   static setMusicFont(...fontNames: string[]): Font[] {
     // Convert the array of font names into an array of Font objects.
+    CommonMetrics.fontFamily = fontNames.join(',');
     const fonts = fontNames.map((fontName) => Font.load(fontName));
     Tables.MUSIC_FONT_STACK = fonts;
     Glyph.MUSIC_FONT_STACK = fonts.slice();

--- a/src/frethandfinger.ts
+++ b/src/frethandfinger.ts
@@ -3,7 +3,6 @@
 // Class to draws string numbers into the notation.
 
 import { Builder } from './easyscore';
-import { Font, FontInfo, FontStyle, FontWeight } from './font';
 import { Modifier, ModifierPosition } from './modifier';
 import { ModifierContextState } from './modifiercontext';
 import { StemmableNote } from './stemmablenote';
@@ -16,13 +15,6 @@ export class FretHandFinger extends Modifier {
   static get CATEGORY(): string {
     return Category.FretHandFinger;
   }
-
-  static TEXT_FONT: Required<FontInfo> = {
-    family: Font.SANS_SERIF,
-    size: 9,
-    weight: FontWeight.BOLD,
-    style: FontStyle.NORMAL,
-  };
 
   // Arrange fingerings inside a ModifierContext.
   static format(nums: FretHandFinger[], state: ModifierContextState): boolean {
@@ -135,11 +127,9 @@ export class FretHandFinger extends Modifier {
     this.finger = finger;
     this.width = 7;
     this.position = Modifier.Position.LEFT; // Default position above stem or note head
-    this.xShift = 0;
-    this.yShift = 0;
     this.xOffset = 0; // Horizontal offset from default
     this.yOffset = 0; // Vertical offset from default
-    this.resetFont();
+    
   }
 
   setFretHandFinger(finger: string): this {

--- a/src/modifier.ts
+++ b/src/modifier.ts
@@ -58,11 +58,8 @@ export class Modifier extends Element {
   protected note?: Note;
   protected index?: number;
 
-  protected width: number;
   protected textLine: number;
   protected position: ModifierPosition;
-  protected yShift: number;
-  protected xShift: number;
 
   #spacingFromNextModifier: number;
   #modifierContext?: ModifierContext;
@@ -75,25 +72,12 @@ export class Modifier extends Element {
     // The `textLine` is reserved space above or below a stave.
     this.textLine = 0;
     this.position = Modifier.Position.LEFT;
-    this.xShift = 0;
-    this.yShift = 0;
     this.#spacingFromNextModifier = 0;
   }
 
   /** Called when position changes. */
   protected reset(): void {
     // DO NOTHING.
-  }
-
-  /** Get modifier widths. */
-  getWidth(): number {
-    return this.width;
-  }
-
-  /** Set modifier widths. */
-  setWidth(width: number): this {
-    this.width = width;
-    return this;
   }
 
   /** Get attached note (`StaveNote`, `TabNote`, etc.) */

--- a/src/pedalmarking.ts
+++ b/src/pedalmarking.ts
@@ -2,7 +2,6 @@
 // MIT License
 
 import { Element } from './element';
-import { Font, FontInfo, FontStyle, FontWeight } from './font';
 import { Glyph } from './glyph';
 import { RenderContext } from './rendercontext';
 import { StaveNote } from './stavenote';
@@ -41,13 +40,6 @@ export class PedalMarking extends Element {
   static get CATEGORY(): string {
     return Category.PedalMarking;
   }
-
-  static TEXT_FONT: Required<FontInfo> = {
-    family: Font.SERIF,
-    size: 12,
-    weight: FontWeight.BOLD,
-    style: FontStyle.ITALIC,
-  };
 
   protected line: number;
   protected type: number;
@@ -121,8 +113,6 @@ export class PedalMarking extends Element {
     // Custom text for the release/depress markings
     this.customDepressText = '';
     this.customReleaseText = '';
-
-    this.resetFont();
 
     this.renderOptions = {
       bracketHeight: 10,

--- a/src/stave.ts
+++ b/src/stave.ts
@@ -4,7 +4,6 @@
 import { BoundingBox, Bounds } from './boundingbox';
 import { Clef } from './clef';
 import { Element, ElementStyle } from './element';
-import { Font, FontInfo, FontStyle, FontWeight } from './font';
 import { KeySignature } from './keysignature';
 import { Barline, BarlineType } from './stavebarline';
 import { StaveModifier, StaveModifierPosition } from './stavemodifier';
@@ -58,13 +57,6 @@ export class Stave extends Element {
     return Category.Stave;
   }
 
-  static TEXT_FONT: Required<FontInfo> = {
-    family: Font.SANS_SERIF,
-    size: 8,
-    weight: FontWeight.NORMAL,
-    style: FontStyle.NORMAL,
-  };
-
   readonly options: Required<StaveOptions>;
 
   protected startX: number;
@@ -111,7 +103,6 @@ export class Stave extends Element {
     this.measure = 0;
     this.clef = 'treble';
     this.endClef = undefined;
-    this.resetFont();
 
     this.options = {
       verticalBarWidth: 10, // Width around vertical bar end-marker
@@ -328,7 +319,7 @@ export class Stave extends Element {
   }
 
   // Text functions
-  setText(
+  setStaveText(
     text: string,
     position: number,
     options: {

--- a/src/staveconnector.ts
+++ b/src/staveconnector.ts
@@ -2,7 +2,6 @@
 // MIT License
 
 import { Element } from './element';
-import { Font, FontInfo, FontStyle, FontWeight } from './font';
 import { Glyph } from './glyph';
 import { RenderContext } from './rendercontext';
 import { Stave } from './stave';
@@ -59,13 +58,6 @@ export class StaveConnector extends Element {
   static get CATEGORY(): string {
     return Category.StaveConnector;
   }
-
-  static TEXT_FONT: Required<FontInfo> = {
-    family: Font.SERIF,
-    size: 16,
-    weight: FontWeight.NORMAL,
-    style: FontStyle.NORMAL,
-  };
 
   /**
    * SINGLE_LEFT and SINGLE are the same value for compatibility
@@ -133,7 +125,6 @@ export class StaveConnector extends Element {
     this.topStave = topStave;
     this.bottomStave = bottomStave;
     this.type = StaveConnector.type.DOUBLE;
-    this.resetFont();
 
     // 1. Offset Bold Double Left to align with offset Repeat Begin bars
     // 2. Offset BRACE type not to overlap with another StaveConnector

--- a/src/staveline.ts
+++ b/src/staveline.ts
@@ -9,7 +9,6 @@
 // purposes, such as diagrams.
 
 import { Element } from './element';
-import { FontInfo } from './font';
 import { RenderContext } from './rendercontext';
 import { StaveNote } from './stavenote';
 import { Tables } from './tables';
@@ -53,9 +52,6 @@ export class StaveLine extends Element {
   static get CATEGORY(): string {
     return Category.StaveLine;
   }
-
-  /** Default text font. */
-  static TEXT_FONT: Required<FontInfo> = { ...Element.TEXT_FONT };
 
   // Text Positioning
   static readonly TextVerticalPosition = {
@@ -107,7 +103,6 @@ export class StaveLine extends Element {
     this.setNotes(notes);
 
     this.text = '';
-    this.resetFont();
 
     this.renderOptions = {
       // Space to add to the left or the right

--- a/src/staverepetition.ts
+++ b/src/staverepetition.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2023-present VexFlow contributors: https://github.com/vexflow/vexflow/graphs/contributors
 // @author: Larry Kuhns 2011
 
-import { Font, FontInfo, FontStyle, FontWeight } from './font';
+import { Font } from './font';
 import { Glyph } from './glyph';
 import { Stave } from './stave';
 import { StaveModifier } from './stavemodifier';
@@ -12,13 +12,6 @@ export class Repetition extends StaveModifier {
   static get CATEGORY(): string {
     return Category.Repetition;
   }
-
-  static TEXT_FONT: Required<FontInfo> = {
-    family: Font.SERIF,
-    size: Tables.NOTATION_FONT_SCALE / 3,
-    weight: FontWeight.BOLD,
-    style: FontStyle.NORMAL,
-  };
 
   static readonly type = {
     NONE: 1, // no coda or segno
@@ -48,8 +41,6 @@ export class Repetition extends StaveModifier {
     this.x = x;
     this.xShift = 0;
     this.yShift = yShift;
-
-    this.resetFont();
   }
 
   setShiftX(x: number): this {

--- a/src/stavesection.ts
+++ b/src/stavesection.ts
@@ -1,7 +1,6 @@
 // Copyright (c) 2023-present VexFlow contributors: https://github.com/vexflow/vexflow/graphs/contributors
 // @author: Larry Kuhns 2011
 
-import { Font, FontInfo, FontStyle, FontWeight } from './font';
 import { Stave } from './stave';
 import { StaveModifier } from './stavemodifier';
 import { TextFormatter } from './textformatter';
@@ -11,13 +10,6 @@ export class StaveSection extends StaveModifier {
   static get CATEGORY(): string {
     return Category.StaveSection;
   }
-
-  static TEXT_FONT: Required<FontInfo> = {
-    family: Font.SANS_SERIF,
-    size: 10,
-    weight: FontWeight.BOLD,
-    style: FontStyle.NORMAL,
-  };
 
   protected section: string;
   protected shiftX: number;
@@ -33,7 +25,6 @@ export class StaveSection extends StaveModifier {
     this.shiftX = 0;
     this.shiftY = shiftY;
     this.drawRect = drawRect;
-    this.resetFont();
   }
 
   setStaveSection(section: string): this {

--- a/src/stavetempo.ts
+++ b/src/stavetempo.ts
@@ -1,7 +1,6 @@
 // Copyright (c) 2023-present VexFlow contributors: https://github.com/vexflow/vexflow/graphs/contributors
 // @author: Radosaw Eichler 2012
 
-import { Font, FontInfo, FontStyle, FontWeight } from './font';
 import { Glyph } from './glyph';
 import { Stave } from './stave';
 import { StaveModifier, StaveModifierPosition } from './stavemodifier';
@@ -21,13 +20,6 @@ export class StaveTempo extends StaveModifier {
     return Category.StaveTempo;
   }
 
-  static TEXT_FONT: Required<FontInfo> = {
-    family: Font.SERIF,
-    size: 14,
-    weight: FontWeight.BOLD,
-    style: FontStyle.NORMAL,
-  };
-
   protected tempo: StaveTempoOptions;
   protected shiftX: number;
   protected shiftY: number;
@@ -42,7 +34,6 @@ export class StaveTempo extends StaveModifier {
     this.x = x;
     this.shiftX = 10;
     this.shiftY = shiftY;
-    this.resetFont();
   }
 
   setTempo(tempo: StaveTempoOptions): this {

--- a/src/stavetext.ts
+++ b/src/stavetext.ts
@@ -1,7 +1,6 @@
 // Copyright (c) 2023-present VexFlow contributors: https://github.com/vexflow/vexflow/graphs/contributors
 // @author: Taehoon Moon 2014
 
-import { Font, FontInfo, FontStyle, FontWeight } from './font';
 import { Stave } from './stave';
 import { StaveModifier, StaveModifierPosition } from './stavemodifier';
 import { TextJustification, TextNote } from './textnote';
@@ -12,13 +11,6 @@ export class StaveText extends StaveModifier {
   static get CATEGORY(): string {
     return Category.StaveText;
   }
-
-  static TEXT_FONT: Required<FontInfo> = {
-    family: Font.SERIF,
-    size: 16,
-    weight: FontWeight.NORMAL,
-    style: FontStyle.NORMAL,
-  };
 
   protected options: {
     shiftX: number;
@@ -46,8 +38,6 @@ export class StaveText extends StaveModifier {
       justification: TextNote.Justification.CENTER,
       ...options,
     };
-
-    this.resetFont();
   }
 
   setStaveText(text: string): this {

--- a/src/stavetie.ts
+++ b/src/stavetie.ts
@@ -4,7 +4,6 @@
 // ties include: regular ties, hammer ons, pull offs, and slides.
 
 import { Element } from './element';
-import { FontInfo } from './font';
 import { Note } from './note';
 import { Category } from './typeguard';
 import { RuntimeError } from './util';
@@ -24,9 +23,6 @@ export class StaveTie extends Element {
     return Category.StaveTie;
   }
 
-  /** Default text font. */
-  static TEXT_FONT: Required<FontInfo> = { ...Element.TEXT_FONT };
-
   public renderOptions: {
     cp2: number;
     lastXShift: number;
@@ -36,8 +32,6 @@ export class StaveTie extends Element {
     textShiftX: number;
     yShift: number;
   };
-
-  protected text?: string;
 
   // notes is initialized by the constructor via this.setNotes(notes).
   protected notes!: TieNotes;
@@ -56,7 +50,7 @@ export class StaveTie extends Element {
    *
    * @param text
    */
-  constructor(notes: TieNotes, text?: string) {
+  constructor(notes: TieNotes, text = '') {
     super();
     this.setNotes(notes);
     this.text = text;
@@ -69,8 +63,6 @@ export class StaveTie extends Element {
       yShift: 7,
       tieSpacing: 0,
     };
-
-    this.resetFont();
   }
 
   setDirection(direction: number): this {
@@ -168,7 +160,7 @@ export class StaveTie extends Element {
    * @param firstX specified in pixels
    * @param lastX specified in pixels
    */
-  renderText(firstX: number, lastX: number): void {
+  renderTieText(firstX: number, lastX: number): void {
     if (!this.text) return;
     const ctx = this.checkContext();
     let centerX = (firstX + lastX) / 2;
@@ -238,7 +230,7 @@ export class StaveTie extends Element {
       direction: stemDirection,
     });
 
-    this.renderText(firstX, lastX);
+    this.renderTieText(firstX, lastX);
     return true;
   }
 }

--- a/src/stavevolta.ts
+++ b/src/stavevolta.ts
@@ -1,7 +1,6 @@
 // Copyright (c) 2023-present VexFlow contributors: https://github.com/vexflow/vexflow/graphs/contributors
 // @author: Larry Kuhns 2011
 
-import { Font, FontInfo, FontStyle, FontWeight } from './font';
 import { Stave } from './stave';
 import { StaveModifier } from './stavemodifier';
 import { Category } from './typeguard';
@@ -23,13 +22,6 @@ export class Volta extends StaveModifier {
     return VoltaType;
   }
 
-  static TEXT_FONT: Required<FontInfo> = {
-    family: Font.SANS_SERIF,
-    size: 9,
-    weight: FontWeight.BOLD,
-    style: FontStyle.NORMAL,
-  };
-
   protected volta: number;
   protected number: string;
 
@@ -41,7 +33,6 @@ export class Volta extends StaveModifier {
     this.x = x;
     this.yShift = yShift;
     this.number = number;
-    this.resetFont();
   }
 
   setShiftY(y: number): this {

--- a/src/stringnumber.ts
+++ b/src/stringnumber.ts
@@ -4,7 +4,6 @@
 // This file implements the `StringNumber` class which renders string
 // number annotations beside notes.
 
-import { Font, FontInfo, FontStyle, FontWeight } from './font';
 import { Modifier, ModifierPosition } from './modifier';
 import { ModifierContextState } from './modifiercontext';
 import { Note } from './note';
@@ -26,13 +25,6 @@ export class StringNumber extends Modifier {
   static get CATEGORY(): string {
     return Category.StringNumber;
   }
-
-  static TEXT_FONT: Required<FontInfo> = {
-    family: Font.SANS_SERIF,
-    size: Font.SIZE,
-    weight: FontWeight.BOLD,
-    style: FontStyle.NORMAL,
-  };
 
   static get metrics(): StringNumberMetrics {
     return (
@@ -178,7 +170,6 @@ export class StringNumber extends Modifier {
     this.radius = 8;
     this.drawCircle = true;
     this.setWidth(this.radius * 2 + 4);
-    this.resetFont();
   }
 
   setLineEndType(leg: number): this {

--- a/src/strokes.ts
+++ b/src/strokes.ts
@@ -4,7 +4,6 @@
 // This file implements the `Stroke` class which renders chord strokes
 // that can be arpeggiated, brushed, rasquedo, etc.
 
-import { Font, FontInfo, FontStyle, FontWeight } from './font';
 import { Glyph } from './glyph';
 import { Modifier } from './modifier';
 import { ModifierContextState } from './modifiercontext';
@@ -26,13 +25,6 @@ export class Stroke extends Modifier {
     RASQUEDO_DOWN: 5,
     RASQUEDO_UP: 6,
     ARPEGGIO_DIRECTIONLESS: 7, // Arpeggiated chord without upwards or downwards arrow
-  };
-
-  static TEXT_FONT: Required<FontInfo> = {
-    family: Font.SERIF,
-    size: Font.SIZE,
-    weight: FontWeight.BOLD,
-    style: FontStyle.ITALIC,
   };
 
   // Arrange strokes inside `ModifierContext`
@@ -95,8 +87,6 @@ export class Stroke extends Modifier {
     this.renderOptions = {
       fontScale: Tables.NOTATION_FONT_SCALE,
     };
-
-    this.resetFont();
 
     this.setXShift(0);
     this.setWidth(10);
@@ -243,8 +233,14 @@ export class Stroke extends Modifier {
 
     // Draw the rasquedo "R"
     if (this.type === Stroke.Type.RASQUEDO_DOWN || this.type === Stroke.Type.RASQUEDO_UP) {
+      const textFont = {
+        family: Tables.lookupMetric(`Strokes.text.fontFamily`),
+        size: Tables.lookupMetric(`Strokes.text.fontSize`),
+        weight: Tables.lookupMetric(`Strokes.text.fontWeight`),
+        style: Tables.lookupMetric(`Strokes.text.fontStyle`),
+      };
       ctx.save();
-      ctx.setFont(this.textFont);
+      ctx.setFont(textFont);
       ctx.fillText('R', x + textShiftX, textY);
       ctx.restore();
     }

--- a/src/tables.ts
+++ b/src/tables.ts
@@ -9,6 +9,138 @@ import { RuntimeError } from './util';
 
 const RESOLUTION = 16384;
 
+export const CommonMetrics = {
+  fontFamily: 'Bravura',
+  fontSize: 30,
+  fontWeight: 'normal',
+  fontStyle: 'normal',
+
+  Accidental: {
+    cautionary: {
+      fontSize: 28,
+    },
+  },
+
+  Annotation: {
+    fontFamily: 'Arial, sans-serif',
+    fontSize: 10,
+  },
+
+  Bend: {
+    fontFamily: 'Arial, sans-serif',
+    fontSize: 10,
+  },
+
+  ChordSymbol: {
+    fontFamily: 'Roboto Slab, Times, serif',
+    fontSize: 12,
+  },
+
+  FretHandFinger: {
+    fontFamily: 'Arial, sans-serif',
+    fontSize: 9,
+    fontWeight: 'bold',
+  },
+
+  PedalMarking: {
+    fontFamily: 'Times New Roman, serif',
+    fontSize: 12,
+    fontWeight: 'bold',
+    fontStyle: 'italic',
+  },
+
+  Repetition: {
+    fontFamily: 'Times New Roman, serif',
+    fontSize: 13,
+    fontWeight: 'bold',
+  },
+
+  Stave: {
+    fontFamily: 'Arial, sans-serif',
+    fontSize: 8,
+  },
+
+  StaveConnector: {
+    fontFamily: 'Times New Roman, serif',
+    fontSize: 16,
+  },
+
+  StaveLine: {
+    fontFamily: 'Arial, sans-serif',
+    fontSize: 10,
+  },
+
+  StaveSection: {
+    fontFamily: 'Arial, sans-serif',
+    fontSize: 10,
+    fontWeight: 'bold',
+  },
+
+  StaveTempo: {
+    fontFamily: 'Times New Roman, serif',
+    fontSize: 14,
+    fontWeight: 'bold',
+  },
+
+  StaveText: {
+    fontFamily: 'Times New Roman, serif',
+    fontSize: 16,
+  },
+
+  StaveTie: {
+    fontFamily: 'Arial, sans-serif',
+    fontSize: 10,
+  },
+
+  StringNumber: {
+    fontFamily: 'Arial, sans-serif',
+    fontSize: 10,
+    fontWeight: 'bold',
+  },
+
+  Strokes: {
+    text: {
+      fontFamily: 'Times New Roman, serif',
+      fontSize: 10,
+      fontStyle: 'italic',
+      fontWeight: 'bold',
+    },
+  },
+
+  TabNote: {
+    fontSize: 9,
+  },
+
+  TabSlide: {
+    fontFamily: 'Times New Roman, serif',
+    fontSize: 10,
+    fontStyle: 'italic',
+    fontWeight: 'bold',
+  },
+
+  TabTie: {
+    fontFamily: 'Arial, sans-serif',
+    fontSize: 10,
+  },
+
+  TextBracket: {
+    fontFamily: 'Times New Roman, serif',
+    fontSize: 15,
+    fontStyle: 'italic',
+  },
+
+  TextNote: {
+    fontFamily: 'Arial, sans-serif',
+    fontSize: 12,
+  },
+
+  Volta: {
+    fontFamily: 'Arial, sans-serif',
+    fontSize: 9,
+    fontWeight: 'bold',
+  },
+};
+
 /**
  * Map duration numbers to 'ticks', the unit of duration used throughout VexFlow.
  * For example, a quarter note is 4, so it maps to RESOLUTION / 4 = 4096 ticks.
@@ -586,6 +718,41 @@ export class Tables {
     return clefs[clef];
   }
 
+  /**
+   * Use the provided key to look up a value in this font's metrics file (e.g., bravuraMetrics.ts, petalumaMetrics.ts).
+   * @param key is a string separated by periods (e.g., stave.endPaddingMax, clef.lineCount.'5'.shiftY).
+   * @param defaultValue is returned if the lookup fails.
+   * @returns the retrieved value (or `defaultValue` if the lookup fails).
+   */
+  // eslint-disable-next-line
+  static lookupMetric(key: string, defaultValue?: Record<string, any> | number): any {
+    const keyParts = key.split('.');
+
+    let currObj;
+
+    while (!currObj && keyParts.length) {
+      // Start with the top level font metrics object, and keep looking deeper into the object (via each part of the period-delimited key).
+      currObj = CommonMetrics;
+      for (let i = 0; i < keyParts.length; i++) {
+        const keyPart = keyParts[i];
+        const value = currObj[keyPart] as any;
+        if (value === undefined) {
+          // If the key lookup fails, we fall back to undefined.
+          currObj = undefined;
+          break;
+        }
+        // The most recent lookup succeeded, so we drill deeper into the object.
+        currObj = value;
+      }
+      if (keyParts.length > 1) {
+        keyParts[keyParts.length - 2] = keyParts[keyParts.length - 1];
+      }
+      keyParts.pop();
+    }
+
+    // Return the retrieved or default value
+    return currObj ? currObj : defaultValue;
+  }
   /**
    * @param keyOctaveGlyph a string in the format "key/octave" (e.g., "c/5") or "key/octave/custom-note-head-code" (e.g., "g/5/t3").
    * @param clef

--- a/src/tabslide.ts
+++ b/src/tabslide.ts
@@ -4,7 +4,6 @@
 // This class implements varies types of ties between contiguous notes. The
 // ties include: regular ties, hammer ons, pull offs, and slides.
 
-import { Font, FontInfo, FontStyle, FontWeight } from './font';
 import { TieNotes } from './stavetie';
 import { TabNote } from './tabnote';
 import { TabTie } from './tabtie';
@@ -15,13 +14,6 @@ export class TabSlide extends TabTie {
   static get CATEGORY(): string {
     return Category.TabSlide;
   }
-
-  static TEXT_FONT: Required<FontInfo> = {
-    family: Font.SERIF,
-    size: 10,
-    weight: FontWeight.BOLD,
-    style: FontStyle.ITALIC,
-  };
 
   static get SLIDE_UP(): number {
     return 1;
@@ -81,8 +73,6 @@ export class TabSlide extends TabTie {
     this.renderOptions.cp1 = 11;
     this.renderOptions.cp2 = 14;
     this.renderOptions.yShift = 0.5;
-
-    this.resetFont();
   }
 
   /**

--- a/src/textbracket.ts
+++ b/src/textbracket.ts
@@ -6,7 +6,7 @@
 // using this class.
 
 import { Element } from './element';
-import { Font, FontInfo, FontStyle, FontWeight } from './font';
+import { Font } from './font';
 import { Note } from './note';
 import { RenderContext } from './rendercontext';
 import { Renderer } from './renderer';
@@ -39,13 +39,6 @@ export class TextBracket extends Element {
   static get CATEGORY(): string {
     return Category.TextBracket;
   }
-
-  static TEXT_FONT: Required<FontInfo> = {
-    family: Font.SERIF,
-    size: 15,
-    weight: FontWeight.NORMAL,
-    style: FontStyle.ITALIC,
-  };
 
   public renderOptions: {
     dashed: boolean;
@@ -105,8 +98,6 @@ export class TextBracket extends Element {
     this.position = typeof position === 'string' ? TextBracket.PositionString[position] : position;
 
     this.line = 1;
-
-    this.resetFont();
 
     this.renderOptions = {
       dashed: true,

--- a/src/textnote.ts
+++ b/src/textnote.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2023-present VexFlow contributors: https://github.com/vexflow/vexflow/graphs/contributors
 // MIT License
 
-import { Font, FontInfo, FontStyle, FontWeight } from './font';
+import { Font, FontInfo } from './font';
 import { Glyph } from './glyph';
 import { Note, NoteStruct } from './note';
 import { Tables } from './tables';
@@ -34,13 +34,6 @@ export class TextNote extends Note {
   static get CATEGORY(): string {
     return Category.TextNote;
   }
-
-  static TEXT_FONT: Required<FontInfo> = {
-    family: Font.SANS_SERIF,
-    size: 12,
-    weight: FontWeight.NORMAL,
-    style: FontStyle.NORMAL,
-  };
 
   static readonly Justification = TextJustification;
 

--- a/src/tickable.ts
+++ b/src/tickable.ts
@@ -43,8 +43,6 @@ export abstract class Tickable extends Element {
   protected ticks: Fraction;
   protected centerXShift: number;
   protected voice?: Voice;
-  protected width: number;
-  protected xShift: number;
   protected modifierContext?: ModifierContext;
   protected tickContext?: TickContext;
   protected modifiers: Modifier[];
@@ -64,10 +62,6 @@ export abstract class Tickable extends Element {
     this.ticks = new Fraction(0, 1); // Fractional value of ticks
     this.intrinsicTicks = 0; // Floating point value of ticks
     this.tickMultiplier = new Fraction(1, 1);
-
-    // Formatter metrics
-    this.width = 0;
-    this.xShift = 0; // Shift from tick context
 
     this.modifiers = [];
     this.tupletStack = [];
@@ -125,11 +119,6 @@ export abstract class Tickable extends Element {
     return this;
   }
 
-  /** Set width of note. Used by the formatter for positioning. */
-  setWidth(width: number): void {
-    this.width = width;
-  }
-
   /** Get width of note. Used by the formatter for positioning. */
   getWidth(): number {
     if (!this.#preFormatted) {
@@ -137,17 +126,6 @@ export abstract class Tickable extends Element {
     }
 
     return this.width + (this.modifierContext ? this.modifierContext.getWidth() : 0);
-  }
-
-  /** Displace note by `x` pixels. Used by the formatter. */
-  setXShift(x: number): this {
-    this.xShift = x;
-    return this;
-  }
-
-  /** Get the `x` displaced pixels of the note. */
-  getXShift(): number {
-    return this.xShift;
   }
 
   /** Get `x` position of this tick context. */

--- a/tests/font_tests.ts
+++ b/tests/font_tests.ts
@@ -8,11 +8,11 @@ import { TestOptions, VexFlowTests } from './vexflow_test_helpers';
 import { Accidental } from '../src/accidental';
 import { Bend } from '../src/bend';
 import { CanvasContext } from '../src/canvascontext';
-import { Element } from '../src/element';
 import { Flow } from '../src/flow';
 import { Font, FontStyle, FontWeight } from '../src/font';
 import { PedalMarking } from '../src/pedalmarking';
 import { StaveNote } from '../src/stavenote';
+import { CommonMetrics } from '../src/tables';
 import { TextBracket } from '../src/textbracket';
 import { TextNote } from '../src/textnote';
 import { Voice } from '../src/voice';
@@ -46,29 +46,24 @@ function setFont(assert: Assert): void {
   assert.equal(ctx.font, 'italic 100px PetalumaScript');
 
   const voice = new Voice();
-  // Many elements do not override the default Element.TEXT_FONT.
-  assert.propEqual(voice.fontInfo, Element.TEXT_FONT);
   voice.setFont('bold 32pt Arial');
   const fontInfo = voice.fontInfo;
   assert.equal(fontInfo?.size, '32pt');
 
   const flat = new Accidental('b');
-  // eslint-disable-next-line
-  // @ts-ignore access a protected member for testing purposes.
-  assert.equal(flat.textFont, undefined); // The internal instance variable .textFont is undefined by default.
   // Add italic to the default font as defined in Element.TEXT_FONT (since Accidental does not override TEXT_FONT).
-  flat.setFont(undefined, undefined, undefined, FontStyle.ITALIC);
-  assert.equal(flat.getFont(), 'italic 10pt Arial, sans-serif');
+  flat.setFont(undefined, undefined, undefined, 'italic');
+  assert.equal(flat.getFont(), 'italic 30pt Bravura,Gonville,Custom');
   // Anything that is not set will be reset to the defaults.
-  flat.setFont(undefined, undefined, FontWeight.BOLD, undefined);
-  assert.equal(flat.getFont(), 'bold 10pt Arial, sans-serif');
-  flat.setFont(undefined, undefined, FontWeight.BOLD, FontStyle.ITALIC);
-  assert.equal(flat.getFont(), 'italic bold 10pt Arial, sans-serif');
-  flat.setFont(undefined, undefined, FontWeight.BOLD, 'oblique');
-  assert.equal(flat.getFont(), 'oblique bold 10pt Arial, sans-serif');
+  flat.setFont(undefined, undefined, 'bold', undefined);
+  assert.equal(flat.getFont(), 'bold 30pt Bravura,Gonville,Custom');
+  flat.setFont(undefined, undefined, 'bold', 'italic');
+  assert.equal(flat.getFont(), 'italic bold 30pt Bravura,Gonville,Custom');
+  flat.setFont(undefined, undefined, 'bold', 'oblique');
+  assert.equal(flat.getFont(), 'oblique bold 30pt Bravura,Gonville,Custom');
   // '' is equivalent to 'normal'. Neither will be included in the CSS font string.
   flat.setFont(undefined, undefined, 'normal', '');
-  assert.equal(flat.getFont(), '10pt Arial, sans-serif');
+  assert.equal(flat.getFont(), '30pt Bravura,Gonville,Custom');
 }
 
 function fontParsing(assert: Assert): void {
@@ -135,10 +130,7 @@ function setTextFontToGeorgia(options: TestOptions): void {
     factory.StaveNote({ keys: ['c/4', 'f/4', 'a/4'], stemDirection: -1, duration: 'q' }),
   ]);
 
-  const defaultFont = TextNote.TEXT_FONT;
-
-  // Set the default before we instantiate TextNote objects with the factory.
-  TextNote.TEXT_FONT = {
+  const defaultFont = {
     family: 'Georgia, Courier New, serif',
     size: 14,
     weight: 'bold',
@@ -148,7 +140,7 @@ function setTextFontToGeorgia(options: TestOptions): void {
   const voice2 = score.voice([
     factory
       .TextNote({ text: 'Here are some fun lyrics...', duration: 'w' })
-      .setJustification(TextNote.Justification.LEFT),
+      .setJustification(TextNote.Justification.LEFT).setFont(defaultFont),
   ]);
 
   const formatter = factory.Formatter();
@@ -156,8 +148,6 @@ function setTextFontToGeorgia(options: TestOptions): void {
 
   factory.draw();
 
-  // Restore the previous default, or else it will affect the rest of the tests.
-  TextNote.TEXT_FONT = defaultFont;
   options.assert.ok(true);
 }
 function setMusicFontToPetaluma(options: TestOptions): void {

--- a/tests/stave_tests.ts
+++ b/tests/stave_tests.ts
@@ -747,10 +747,10 @@ function configureAllLines(options: TestOptions, contextBuilder: ContextBuilder)
 function drawStaveText(options: TestOptions, contextBuilder: ContextBuilder): void {
   const ctx = contextBuilder(options.elementId, 900, 140);
   const stave = new Stave(300, 10, 300);
-  stave.setText('Violin', Modifier.Position.LEFT);
-  stave.setText('Right Text', Modifier.Position.RIGHT);
-  stave.setText('Above Text', Modifier.Position.ABOVE);
-  stave.setText('Below Text', Modifier.Position.BELOW);
+  stave.setStaveText('Violin', Modifier.Position.LEFT);
+  stave.setStaveText('Right Text', Modifier.Position.RIGHT);
+  stave.setStaveText('Above Text', Modifier.Position.ABOVE);
+  stave.setStaveText('Below Text', Modifier.Position.BELOW);
   stave.setContext(ctx).draw();
 
   options.assert.ok(true, 'all pass');
@@ -759,14 +759,20 @@ function drawStaveText(options: TestOptions, contextBuilder: ContextBuilder): vo
 function drawStaveTextMultiLine(options: TestOptions, contextBuilder: ContextBuilder): void {
   const ctx = contextBuilder(options.elementId, 900, 200);
   const stave = new Stave(300, 40, 300);
-  stave.setText('Violin', Modifier.Position.LEFT, { shiftY: -10 });
-  stave.setText('2nd line', Modifier.Position.LEFT, { shiftY: 10 });
-  stave.setText('Right Text', Modifier.Position.RIGHT, { shiftY: -10 });
-  stave.setText('2nd line', Modifier.Position.RIGHT, { shiftY: 10 });
-  stave.setText('Above Text', Modifier.Position.ABOVE, { shiftY: -10 });
-  stave.setText('2nd line', Modifier.Position.ABOVE, { shiftY: 10 });
-  stave.setText('Left Below Text', Modifier.Position.BELOW, { shiftY: -10, justification: TextJustification.LEFT });
-  stave.setText('Right Below Text', Modifier.Position.BELOW, { shiftY: 10, justification: TextJustification.RIGHT });
+  stave.setStaveText('Violin', Modifier.Position.LEFT, { shiftY: -10 });
+  stave.setStaveText('2nd line', Modifier.Position.LEFT, { shiftY: 10 });
+  stave.setStaveText('Right Text', Modifier.Position.RIGHT, { shiftY: -10 });
+  stave.setStaveText('2nd line', Modifier.Position.RIGHT, { shiftY: 10 });
+  stave.setStaveText('Above Text', Modifier.Position.ABOVE, { shiftY: -10 });
+  stave.setStaveText('2nd line', Modifier.Position.ABOVE, { shiftY: 10 });
+  stave.setStaveText('Left Below Text', Modifier.Position.BELOW, {
+    shiftY: -10,
+    justification: TextJustification.LEFT,
+  });
+  stave.setStaveText('Right Below Text', Modifier.Position.BELOW, {
+    shiftY: 10,
+    justification: TextJustification.RIGHT,
+  });
   stave.setContext(ctx).draw();
 
   options.assert.ok(true, 'all pass');
@@ -775,8 +781,8 @@ function drawStaveTextMultiLine(options: TestOptions, contextBuilder: ContextBui
 function factoryAPI(options: TestOptions): void {
   const f = VexFlowTests.makeFactory(options, 900, 200);
   const stave = f.Stave({ x: 300, y: 40, width: 300 });
-  stave.setText('Violin', Modifier.Position.LEFT, { shiftY: -10 });
-  stave.setText('2nd line', Modifier.Position.LEFT, { shiftY: 10 });
+  stave.setStaveText('Violin', Modifier.Position.LEFT, { shiftY: -10 });
+  stave.setStaveText('2nd line', Modifier.Position.LEFT, { shiftY: 10 });
   f.draw();
 
   options.assert.ok(true, 'all pass');

--- a/tests/staveconnector_tests.ts
+++ b/tests/staveconnector_tests.ts
@@ -418,7 +418,7 @@ function drawCombined(options: TestOptions, contextBuilder: ContextBuilder): voi
   const stave5 = new Stave(150, 370, 300);
   const stave6 = new Stave(150, 460, 300);
   const stave7 = new Stave(150, 560, 300);
-  stave1.setText('Violin', Modifier.Position.LEFT);
+  stave1.setStaveText('Violin', Modifier.Position.LEFT);
   stave1.setContext(ctx);
   stave2.setContext(ctx);
   stave3.setContext(ctx);


### PR DESCRIPTION
Here we go...

`Element` is the base of vexflow 5. An `Element` has a member `text` which is a series of unicode characters (including SmufL codes). This text is drawn using the `textFont` which is normally a comma separated list of fonts. Element calls internally `measureText` to calculate the `metrics`, `height` and `ẃidth` of the `text`

`renderText` will render the `text` using the context provided at the coordinates provided. Internally `Element` will apply the `xShift` and `yShift`. 

So far no visual differences. The default fonts are moved to `commonMetrics`.