### PR TITLE
glyph inspector using fonts directly

### DIFF
--- a/tools/fonts/inspector/glyphs.html
+++ b/tools/fonts/inspector/glyphs.html
@@ -133,6 +133,11 @@
     <script>
       let ctx;
 
+      function codepoint2decimal(codepoint) {
+        // Return the decimal value of 'XXXX' of codepoint, which has a string format 'U+XXXX'
+        return parseInt(codepoint.substring(2), 16)
+      }
+
       function chooseFont(fontName) {
         document.getElementById('title').innerText = 'Glyph Inspector – ' + fontName;
         
@@ -162,14 +167,15 @@
         var y = 250;
 
         const arr = Object.keys(SMuFLGlyphInfo).sort(function(a,b) { 
-          return parseInt(SMuFLGlyphInfo[a].codepoint.substring(2), 16) - parseInt(SMuFLGlyphInfo[b].codepoint.substring(2), 16); 
+          return codepoint2decimal(SMuFLGlyphInfo[a].codepoint) - codepoint2decimal(SMuFLGlyphInfo[b].codepoint); 
         } );
         arr.forEach((glyphName, index) => {
           // Show the glyph name.
-          const code = parseInt(SMuFLGlyphInfo[glyphName].codepoint.substring(2), 16);
+          const code = codepoint2decimal(SMuFLGlyphInfo[glyphName].codepoint);
           ctx.fillStyle = '#222';
           ctx.strokeStyle = '#222';
           ctx.font = '8pt Arial';
+          // if the name has more than 25 characters, break it up into two lines.
           if (glyphName.length > 25) {
             ctx.fillText(glyphName.slice(0,22)+'...', x, y + 50);
             ctx.fillText(glyphName.slice(22 - glyphName.length), x, y + 60);

--- a/tools/fonts/inspector/glyphs.html
+++ b/tools/fonts/inspector/glyphs.html
@@ -10,28 +10,70 @@
     <title>Glyph Inspector</title>
     <meta charset="utf-8" />
     <style type="text/css">
+      @font-face {
+        font-family: Bravura;
+        src: url(https://unpkg.com/vexflow-fonts@1.0.5/bravura/Bravura_1.392.woff2);
+      }
+      @font-face {
+        font-family: GonvilleSmufl;
+        src: url(https://unpkg.com/vexflow-fonts@1.0.5/gonvillesmufl/GonvilleSmufl_1.100.woff2);
+      }
+      @font-face {
+        font-family: Gootville;
+        src: url(https://unpkg.com/vexflow-fonts@1.0.5/gootville/Gootville_1.3.woff2);
+      }
+      @font-face {
+        font-family: Leland;
+        src: url(https://unpkg.com/vexflow-fonts@1.0.5/leland/Leland_0.75.woff2);
+      }
+      @font-face {
+        font-family: Petaluma;
+        src: url(https://unpkg.com/vexflow-fonts@1.0.5/petaluma/Petaluma_1.065.woff2);
+      }
+      @font-face {
+        font-family: MuseJazz;
+        src: url(https://unpkg.com/vexflow-fonts@1.0.5/musejazz/MuseJazz_1.0.woff2);
+      }
+      @font-face {
+        font-family: FinaleAsh;
+        src: url(https://unpkg.com/vexflow-fonts@1.0.5/finale/FinaleAsh_1.7.woff2);
+      }
+      @font-face {
+        font-family: FinaleJazz;
+        src: url(https://unpkg.com/vexflow-fonts@1.0.5/finale/FinaleJazz_1.9.woff2);
+      }
+      @font-face {
+        font-family: FinaleBroadway;
+        src: url(https://unpkg.com/vexflow-fonts@1.0.5/finale/FinaleBroadway_1.4.woff2);
+      }
+      @font-face {
+        font-family: FinaleMaestro;
+        src: url(https://unpkg.com/vexflow-fonts@1.0.5/finale/FinaleMaestro_2.7.woff2);
+      }
+    
       body {
+        background: white;
+        font-family: Helvetica Neue, Arial, sans-serif;
+        font-size: 18px;
+        color: black;
+        margin: 0px;
+      }
+      canvas {
         background: white;
         font-family: Helvetica Neue, Arial, sans-serif;
         font-size: 18px;
         color: black;
         margin: 40px 40px 80px 40px;
       }
+      
 
       a {
         color: green;
         text-decoration: none;
         border-bottom: dotted 2px;
+        font-size: 20px;
       }
 
-      a.button {
-        color: green;
-        background: #bfb;
-        text-decoration: none;
-        padding: 5px;
-        margin: 2px;
-        border: 5px solid #aea;
-      }
 
       div#error {
         width: 60%;
@@ -40,44 +82,65 @@
         background: #faa;
         border: 15px solid #d99;
       }
+      div {
+        padding: 10px;
+        color: blue;
+        background: #aaf;
+        border: 15px solid #99d;
+        position: fixed;
+      }
+      p {
+        margin: 10px;
+        font-size: 10px;
+      }
+      h1 {
+        margin: 10px;
+        font-size: 40px;
+      }
     </style>
 
-    <script src="../../../build/cjs/vexflow-debug.js"></script>
+    <script src="../config/glyphnames.js"></script>
   </head>
 
   <body>
-    <h1 id="title">Glyph Inspector</h1>
-    <p>
-      <i>Cross indicates render coordinates.</i>
-    </p>
     <div>
-      <a href="#" onclick="chooseFont('Bravura')">Bravura</a> &nbsp;
-      <a href="#" onclick="chooseFont('Gonville')">Gonville</a> &nbsp;
-      <a href="#" onclick="chooseFont('Petaluma')">Petaluma</a> &nbsp;
-      <a href="#" onclick="chooseFont('Leland')">Leland</a> &nbsp;
-      <a href="#" onclick="chooseFont('Custom')">Custom</a> &nbsp;
+      <h1 id="title">Glyph Inspector</h1>
+      <p>
+      <a onclick="chooseFont('Bravura')">Bravura</a> &nbsp;
+      <a onclick="chooseFont('FinaleAsh')">FinaleAsh</a> &nbsp;
+      <a onclick="chooseFont('FinaleBroadway')">FinaleBroadway</a> &nbsp;
+      <a onclick="chooseFont('FinaleJazz')">FinaleJazz</a> &nbsp;
+      <a onclick="chooseFont('FinaleMaestro')">FinaleMaestro</a> &nbsp;
+      <a onclick="chooseFont('GonvilleSmufl')">Gonville</a> &nbsp;
+      <a onclick="chooseFont('Gootville')">Gootville</a> &nbsp;
+      <a onclick="chooseFont('MuseJazz')">MuseJazz</a> &nbsp;
+      <a onclick="chooseFont('Petaluma')">Petaluma</a> &nbsp;
+      <a onclick="chooseFont('Leland')">Leland</a> &nbsp;
+      </p>
+      <p>note: Cross indicates render coordinates.</p>
     </div>
     <canvas id="glyphs"></canvas>
+    <span style="font-family: Bravura";"></span>
+    <span style="font-family: FinaleAsh";"></span>
+    <span style="font-family: FinaleBroadway";"></span>
+    <span style="font-family: FinaleJazz";"></span>
+    <span style="font-family: FinaleMaestro";"></span>
+    <span style="font-family: GonvilleSmufl";"></span>
+    <span style="font-family: Gootville";"></span>
+    <span style="font-family: MuseJazz";"></span>
+    <span style="font-family: Petaluma";"></span>
+    <span style="font-family: Leland";"></span>
     <script>
       let ctx;
 
       function chooseFont(fontName) {
         document.getElementById('title').innerText = 'Glyph Inspector – ' + fontName;
-
-        /* Version 4.0.0 */
-        const font = Vex.Flow.setMusicFont(fontName)[0];
-
-        /* Version 3.0.9 */
-        // const font = Vex.Flow.Fonts[fontName]();
-        // Vex.Flow.DEFAULT_FONT_STACK = [font];
-
-        const glyphs = font.getGlyphs();
-
+        
         // Calculate the canvas height programmatically based on the number of glyphs.
-        const canvasWidth = 1200;
-        const ROW_HEIGHT = 150;
-        const COL_WIDTH = 200;
-        const numGlyphs = Object.keys(glyphs).length;
+        const canvasWidth = 3000;
+        const ROW_HEIGHT = 100;
+        const COL_WIDTH = 150;
+        const numGlyphs = Object.keys(SMuFLGlyphInfo).length;
         const numGlyphsPerRow = canvasWidth / COL_WIDTH;
         const numRowsNeeded = Math.ceil(numGlyphs / numGlyphsPerRow);
         const canvasHeight = numRowsNeeded * ROW_HEIGHT;
@@ -96,54 +159,65 @@
         ctx.setTransform(2, 0, 0, 2, 0, 0); // reset the scale to (2, 2)
 
         var x = 0;
-        var y = 50;
-        for (let glyphName in glyphs) {
-          // Show the glyph name.
-          ctx.fillStyle = '#222';
-          ctx.font = '8pt Arial';
-          ctx.fillText(glyphName, x, y + 30);
+        var y = 250;
 
-          const originX = x + 100;
+        const arr = Object.keys(SMuFLGlyphInfo).sort(function(a,b) { 
+          return parseInt(SMuFLGlyphInfo[a].codepoint.substring(2), 16) - parseInt(SMuFLGlyphInfo[b].codepoint.substring(2), 16); 
+        } );
+        arr.forEach((glyphName, index) => {
+          // Show the glyph name.
+          const code = parseInt(SMuFLGlyphInfo[glyphName].codepoint.substring(2), 16);
+          ctx.fillStyle = '#222';
+          ctx.strokeStyle = '#222';
+          ctx.font = '8pt Arial';
+          if (glyphName.length > 25) {
+            ctx.fillText(glyphName.slice(0,22)+'...', x, y + 50);
+            ctx.fillText(glyphName.slice(22 - glyphName.length), x, y + 60);
+          } else
+          ctx.fillText(glyphName, x, y + 50);
+          console.log(glyphName);
+
+          const originX = x + 75;
           const originY = y;
 
           // Show the glyph outline.
           ctx.fillStyle = '#006400';
-          if (glyphs[glyphName].o) {
-            g = new Vex.Flow.Glyph(glyphName, 72, { font: font });
-            g.render(ctx, originX, originY);
-
-            // See the GlyphMetrics interface in glyph.ts.
-            const metrics = g.getMetrics();
-            ctx.save();
-            ctx.font = '8pt monospace';
-            ctx.fillText('w: ' + Math.floor(metrics.width), x, y - 6);
-            ctx.fillText('h: ' + Math.floor(metrics.height), x, y + 6);
-            ctx.restore();
-          }
-          {
-            // draw magenta cross hairs at the glyph's origin
-            ctx.strokeStyle = 'magenta';
-            ctx.beginPath();
-            ctx.moveTo(originX - 6, originY);
-            ctx.lineTo(originX + 6, originY);
-            ctx.moveTo(originX, originY - 6);
-            ctx.lineTo(originX, originY + 6);
-            ctx.stroke();
-          }
+          ctx.font = "30pt "+fontName;
+          ctx.fillText(
+              String.fromCharCode(code),
+              originX,
+              originY
+          );
+          // See the GlyphMetrics interface in glyph.ts.
+          const metrics = ctx.measureText(String.fromCharCode(code));
+          ctx.save();
+          ctx.font = '8pt monospace';
+          const height = metrics.actualBoundingBoxDescent + metrics.actualBoundingBoxAscent
+          ctx.fillText('code: ' + SMuFLGlyphInfo[glyphName].codepoint.substring(2), x, y + 18);
+          ctx.fillText('w: ' + Math.round(metrics.width), x, y - 6);
+          ctx.fillText('h: ' + Math.round(height), x, y + 6);
+          ctx.restore();
+          // draw magenta cross hairs at the glyph's origin
+          ctx.strokeStyle = 'magenta';
+          ctx.beginPath();
+          ctx.moveTo(originX - 6, originY);
+          ctx.lineTo(originX + 6, originY);
+          ctx.moveTo(originX, originY - 6);
+          ctx.lineTo(originX, originY + 6);
+          ctx.stroke();
 
           // Each column is 200px wide.
           x += COL_WIDTH;
 
           // Wrap around to the next line.
-          if (x > 1000) {
+          if (x > canvasWidth - COL_WIDTH ) {
             x = 0;
 
             // Each row is 150px high.
             y += ROW_HEIGHT;
           }
-        }
+        });
       }
-      chooseFont('Bravura');
     </script>
   </body>
 </html>


### PR DESCRIPTION
This inspector helps a lot to see the difference between glyphs as the position of them stay the same when selecting another font.

Just a tool update, no visual differences.