### PR TITLE
vibrato (v5)

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2023-present VexFlow contributors: https://github.com/vexflow/vexflow/graphs/contributors
 // MIT License
 // @author Mohit Cheppudira
+// MIT License
 
 import { Accidental } from './accidental';
 import { Annotation, AnnotationHorizontalJustify, AnnotationVerticalJustify } from './annotation';
@@ -589,7 +590,7 @@ export class Factory {
     from: Note | null;
     to: Note | null;
     options: {
-      harsh?: boolean;
+      code?: number;
       line?: number;
     };
   }): VibratoBracket {
@@ -599,7 +600,7 @@ export class Factory {
     });
 
     if (params.options.line) vibratoBracket.setLine(params.options.line);
-    if (params.options.harsh) vibratoBracket.setHarsh(params.options.harsh);
+    if (params.options.code) vibratoBracket.setVibratoCode(params.options.code);
 
     vibratoBracket.setContext(this.context);
     this.renderQ.push(vibratoBracket);

--- a/src/vibratobracket.ts
+++ b/src/vibratobracket.ts
@@ -23,17 +23,10 @@ export class VibratoBracket extends Element {
   }
 
   protected line: number;
+  protected vibrato = new Vibrato();
 
   protected start?: Note;
   protected stop?: Note;
-
-  public renderOptions: {
-    vibratoWidth: number;
-    waveWidth: number;
-    waveHeight: number;
-    waveGirth: number;
-    harsh: boolean;
-  };
 
   /**
    * Either the stop or start note must be set, or both of them.
@@ -47,14 +40,6 @@ export class VibratoBracket extends Element {
     if (bracketData.stop) this.stop = bracketData.stop;
 
     this.line = 1;
-
-    this.renderOptions = {
-      harsh: false,
-      waveHeight: 6,
-      waveWidth: 4,
-      waveGirth: 2,
-      vibratoWidth: 0,
-    };
   }
 
   /** Set line position of the vibrato bracket. */
@@ -63,9 +48,9 @@ export class VibratoBracket extends Element {
     return this;
   }
 
-  /** Set harsh vibrato bracket. */
-  setHarsh(harsh: boolean): this {
-    this.renderOptions.harsh = harsh;
+  /** Set vibrato code. */
+  setVibratoCode(code: number): this {
+    this.vibrato.setVibratoCode(code);
     return this;
   }
 
@@ -88,10 +73,9 @@ export class VibratoBracket extends Element {
       (this.start && this.start.checkStave().getTieEndX() - 10) ||
       0;
 
-    this.renderOptions.vibratoWidth = stopX - startX;
+    this.vibrato.setVibratoWidth(stopX - startX);
 
     L('Rendering VibratoBracket: startX:', startX, 'stopX:', stopX, 'y:', y);
-
-    Vibrato.renderVibrato(ctx, startX, y, this.renderOptions);
+    this.vibrato.renderText(ctx, startX, y);
   }
 }

--- a/tests/vibrato_tests.ts
+++ b/tests/vibrato_tests.ts
@@ -67,11 +67,11 @@ function harsh(options: TestOptions, contextBuilder: ContextBuilder): void {
         { str: 4, fret: 9 },
       ],
       duration: 'h',
-    }).addModifier(new Vibrato().setHarsh(true), 0),
+    }).addModifier(new Vibrato().setVibratoCode(0xeae2), 0),
     tabNote({
       positions: [{ str: 2, fret: 10 }],
       duration: 'h',
-    }).addModifier(new Vibrato().setHarsh(true), 0),
+    }).addModifier(new Vibrato().setVibratoCode(0xeac0), 0),
   ];
 
   Formatter.FormatAndDraw(ctx, stave, notes);
@@ -105,7 +105,7 @@ function withBend(options: TestOptions, contextBuilder: ContextBuilder): void {
     tabNote({
       positions: [{ str: 2, fret: 10 }],
       duration: 'h',
-    }).addModifier(new Vibrato().setVibratoWidth(120).setHarsh(true), 0),
+    }).addModifier(new Vibrato().setVibratoWidth(120).setVibratoCode(0xeae2), 0),
   ];
 
   Formatter.FormatAndDraw(ctx, stave, notes);

--- a/tests/vibratobracket_tests.ts
+++ b/tests/vibratobracket_tests.ts
@@ -51,7 +51,7 @@ const withoutEndNote = createTest('c4/4, c4, c4, c4', (factory, notes) => {
   factory.VibratoBracket({
     from: notes[2] as Note,
     to: null,
-    options: { line: 2, harsh: true },
+    options: { line: 2, code: 0xeae2 },
   });
 });
 
@@ -59,7 +59,7 @@ const withoutStartNote = createTest('c4/4, c4, c4, c4', (factory, notes) => {
   factory.VibratoBracket({
     from: null,
     to: notes[2] as Note,
-    options: { line: 2, harsh: true },
+    options: { line: 2, code: 0xeae2 },
   });
 });
 


### PR DESCRIPTION
I have decided to add some fun with a second topic: vibratos.

SMuFL defines a lot of them and now it is possible to use them, see https://w3c.github.io/smufl/latest/tables/multi-segment-lines.html?highlight=vibrato#multi-segment-lines-ueaa0ueb0f

As an example:

![pptr-Vibrato Harsh_Vibrato Bravura svg_current](https://github.com/vexflow/vexflow/assets/22865285/23230659-fca4-4beb-b9ca-e6d0bc59ebf1)

On the other side, now it is only possible to use the SMuFL glyphs. The run-time path generated vibratos are now out.