### PR TITLE
Skip building the docs.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -462,7 +462,7 @@ module.exports = (grunt) => {
     'webpack:prodAndDebug',
     'build:esm',
     'build:types',
-    'build:docs',
+    // 'build:docs',
   ]);
 
   // grunt test


### PR DESCRIPTION
Do not build the docs. This makes testing and reviewing PRs for v5 easier.

Eventually we will migrate all the docs to its own repository at: https://github.com/vexflow/vexflow-docs