### PR TITLE
For now, release alpha versions to NPM as `vxflw-early-access`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "vexflow",
-  "version": "4.2.2",
+  "name": "vxflw-early-access",
+  "version": "5.0.0-alpha.0",
   "description": "A JavaScript library for rendering music notation and guitar tablature.",
   "exports": {
     ".": {


### PR DESCRIPTION
https://www.npmjs.com/package/vxflw-early-access

Once VexFlow 5 is finalized, we will overwrite the 4.2.x on NPM.