### PR TITLE
Small Improvements & Cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-reference
+reference*
 releases
 build
 demos/node/output

--- a/src/chordsymbol.ts
+++ b/src/chordsymbol.ts
@@ -112,27 +112,27 @@ export class ChordSymbol extends Modifier {
   }
 
   // Glyph data
-  static readonly glyphs: Record<string, number> = {
-    diminished: 0xe870 /*csymDiminished*/,
-    dim: 0xe870 /*csymDiminished*/,
-    halfDiminished: 0xe871 /*csymHalfDiminished*/,
-    '+': 0xe872 /*csymAugmented*/,
-    augmented: 0xe872 /*csymAugmented*/,
-    majorSeventh: 0xe873 /*csymMajorSeventh*/,
-    minor: 0xe874 /*csymMinor*/,
-    '-': 0xe874 /*csymMinor*/,
-    '(': 0x0028 /*csymParensLeftTall*/,
-    leftParen: 0x0028 /*csymParensLeftTall*/,
-    ')': 0x0029 /*csymParensRightTall*/,
-    rightParen: 0x0029 /*csymParensRightTall*/,
-    leftBracket: 0xe877 /*csymBracketLeftTall*/,
-    rightBracket: 0xe878 /*csymBracketRightTall*/,
-    leftParenTall: 0x0028 /*csymParensLeftVeryTall*/,
-    rightParenTall: 0x0029 /*csymParensRightVeryTall*/,
-    '/': 0xe87c /*csymDiagonalArrangementSlash*/,
-    over: 0xe87c /*csymDiagonalArrangementSlash*/,
-    '#': 0xed62 /*csimAccidentalSharp*/,
-    b: 0xed60 /*csymAccidentalFlat*/,
+  static readonly glyphs: Record<string, string> = {
+    diminished: '\ue870' /*csymDiminished*/,
+    dim: '\ue870' /*csymDiminished*/,
+    halfDiminished: '\ue871' /*csymHalfDiminished*/,
+    '+': '\ue872' /*csymAugmented*/,
+    augmented: '\ue872' /*csymAugmented*/,
+    majorSeventh: '\ue873' /*csymMajorSeventh*/,
+    minor: '\ue874' /*csymMinor*/,
+    '-': '\ue874' /*csymMinor*/,
+    '(': '\u0028' /*csymParensLeftTall*/,
+    leftParen: '\u0028' /*csymParensLeftTall*/,
+    ')': '\u0029' /*csymParensRightTall*/,
+    rightParen: '\u0029' /*csymParensRightTall*/,
+    leftBracket: '\ue877' /*csymBracketLeftTall*/,
+    rightBracket: '\ue878' /*csymBracketRightTall*/,
+    leftParenTall: '\u0028' /*csymParensLeftVeryTall*/,
+    rightParenTall: '\u0029' /*csymParensRightVeryTall*/,
+    '/': '\ue87c' /*csymDiagonalArrangementSlash*/,
+    over: '\ue87c' /*csymDiagonalArrangementSlash*/,
+    '#': '\ued62' /*csymAccidentalSharp*/,
+    b: '\ued60' /*csymAccidentalFlat*/,
   };
 
   static readonly symbolModifiers = SymbolModifiers;
@@ -315,7 +315,7 @@ export class ChordSymbol extends Modifier {
 
   /** Add a glyph block with superscript modifier. */
   addGlyphSuperscript(glyph: string): this {
-    return this.addTextSuperscript(String.fromCharCode(ChordSymbol.glyphs[glyph]));
+    return this.addTextSuperscript(ChordSymbol.glyphs[glyph]);
   }
 
   /** Add a glyph block. */
@@ -325,7 +325,7 @@ export class ChordSymbol extends Modifier {
       symbolModifier: SymbolModifiers;
     }> = {}
   ): this {
-    return this.addText(String.fromCharCode(ChordSymbol.glyphs[glyph]), params);
+    return this.addText(ChordSymbol.glyphs[glyph], params);
   }
 
   /**
@@ -341,8 +341,9 @@ export class ChordSymbol extends Modifier {
     let str = '';
     for (let i = 0; i < text.length; ++i) {
       const char = text[i];
-      if (ChordSymbol.glyphs[char]) {
-        str += String.fromCharCode(ChordSymbol.glyphs[char]);
+      const glyph = ChordSymbol.glyphs[char];
+      if (glyph) {
+        str += glyph;
       } else {
         // Collect consecutive characters with no glyphs.
         str += char;
@@ -360,7 +361,8 @@ export class ChordSymbol extends Modifier {
       symbolModifier: SymbolModifiers;
     }> = {}
   ): this {
-    return this.addText(String.fromCharCode(0xe874 /*csymMinor*/, 0xe874 /*csymMinor*/), params);
+    // Two csymMinor glyphs next to each other.
+    return this.addText('\ue874\ue874' /*{csymMinor}{csymMinor}*/, params);
   }
 
   /** Set vertical position of text (above or below stave). */

--- a/src/flow.ts
+++ b/src/flow.ts
@@ -221,7 +221,9 @@ export class Flow {
    * @returns an array of Font objects corresponding to the provided `fontNames`.
    */
   static setMusicFont(...fontNames: string[]): Font[] {
-    // HACK during review to introduce the correct stacks step by step
+    // #FIXME: HACK to facilitate the VexFlow 5 migration.
+    // HACK-BEGIN
+    // Introduce the correct font stacks step by step.
     switch (fontNames[0]) {
       case 'Bravura':
         CommonMetrics.fontFamily = 'Bravura,Roboto Slab';
@@ -238,6 +240,8 @@ export class Flow {
       default:
         CommonMetrics.fontFamily = fontNames.join(',');
     }
+    // HACK-END
+
     // Convert the array of font names into an array of Font objects.
     const fonts = fontNames.map((fontName) => Font.load(fontName));
     Tables.MUSIC_FONT_STACK = fonts;

--- a/src/stavetempo.ts
+++ b/src/stavetempo.ts
@@ -90,7 +90,7 @@ export class StaveTempo extends StaveModifier {
       ctx.setFont(Tables.lookupMetricFontInfo('StaveTempo.glyph'));
       for (let i = 0; i < dots; i++) {
         x += 6;
-        ctx.fillText('\uecb7' /*metAugmentationDot*/, x+ this.xShift, y + 2 + this.yShift);
+        ctx.fillText('\uecb7' /*metAugmentationDot*/, x + this.xShift, y + 2 + this.yShift);
       }
       ctx.setFont(Tables.lookupMetricFontInfo('StaveTempo'));
       ctx.fillText(' = ' + bpm + (name ? ')' : ''), x + 3 + this.xShift, y + this.yShift);

--- a/src/tables.ts
+++ b/src/tables.ts
@@ -9,7 +9,8 @@ import { RuntimeError } from './util';
 
 const RESOLUTION = 16384;
 
-export const CommonMetrics = {
+// eslint-disable-next-line
+export const CommonMetrics: Record<string, any> = {
   fontFamily: 'Bravura',
   fontSize: 30,
   fontWeight: 'normal',
@@ -745,42 +746,38 @@ export class Tables {
 
   /**
    * Use the provided key to look up a value in CommonMetrics.
-   * @param key is a string separated by periods (e.g., Stroke.text.fontFamily).
-   *        The following keys will be tried before using the default value:
-   *          - Stroke.text.fontFamily
-   *          - Stroke.fontFamily
-   *          - fontFamily
+   *
+   * @param key is a string separated by periods (e.g., `Stroke.text.fontFamily`).
    * @param defaultValue is returned if the lookup fails.
    * @returns the retrieved value (or `defaultValue` if the lookup fails).
+   *
+   * For the key `Stroke.text.fontFamily`, check all of the following in order:
+   *   1) CommonMetrics.fontFamily
+   *   2) CommonMetrics.Stroke.fontFamily
+   *   3) CommonMetrics.Stroke.text.fontFamily
+   * Retrieve the value from the most specific key (i.e., prefer #3 over #2 over #1 in the above example).
    */
   // eslint-disable-next-line
-  static lookupMetric(key: string, defaultValue?: any | number): any {
+  static lookupMetric(key: string, defaultValue?: any): any {
     const keyParts = key.split('.');
+    const lastKeyPart = keyParts.pop()!; // Use ! because keyParts is not empty, since ''.split('.') still returns [''].
 
-    let currObj;
+    // Start from root of CommonMetrics and go down as far as possible.
+    let curr = CommonMetrics;
+    let retVal = defaultValue;
 
-    while (!currObj && keyParts.length) {
-      // Start with the top level font metrics object, and keep looking deeper into the object (via each part of the period-delimited key).
-      currObj = CommonMetrics;
-      for (let i = 0; i < keyParts.length; i++) {
-        const keyPart = keyParts[i];
-        const value = currObj[keyPart] as any;
-        if (value === undefined) {
-          // If the key lookup fails, we fall back to undefined.
-          currObj = undefined;
-          break;
-        }
-        // The most recent lookup succeeded, so we drill deeper into the object.
-        currObj = value;
+    while (curr) {
+      // Update retVal whenever we find a value assigned to a more specific key.
+      retVal = curr[lastKeyPart] ?? retVal;
+      const keyPart = keyParts.shift();
+      if (keyPart) {
+        curr = curr[keyPart]; // Go down one level.
+      } else {
+        break;
       }
-      if (keyParts.length > 1) {
-        keyParts[keyParts.length - 2] = keyParts[keyParts.length - 1];
-      }
-      keyParts.pop();
     }
 
-    // Return the retrieved or default value
-    return currObj ? currObj : defaultValue;
+    return retVal;
   }
 
   /**
@@ -960,19 +957,19 @@ export class Tables {
 
   static unicode = {
     // ♯ accidental sharp
-    sharp: String.fromCharCode(0x266f),
+    sharp: '\u266f',
     // ♭ accidental flat
-    flat: String.fromCharCode(0x266d),
+    flat: '\u266d',
     // ♮ accidental natural
-    natural: String.fromCharCode(0x266e),
+    natural: '\u266e',
     // △ major seventh
-    triangle: String.fromCharCode(0x25b3),
+    triangle: '\u25b3',
     // ø half-diminished
-    'o-with-slash': String.fromCharCode(0x00f8),
+    'o-with-slash': '\u00f8',
     // ° diminished
-    degrees: String.fromCharCode(0x00b0),
+    degrees: '\u00b0',
     // ○ diminished
-    circle: String.fromCharCode(0x25cb),
+    circle: '\u25cb',
   };
 
   /**


### PR DESCRIPTION
A number of small improvements, including:

- simpler implementation of `lookupMetric()`
- Use `\uXXXX` unicode strings directly to avoid unnecessary String.fromCharCode().
- Call out migration HACKs with a bigger block comment so we can easily search for them later on.