### PR TITLE
clef (v5) - extracted from stavemodifier (v5)

### DIFF
--- a/src/clef.ts
+++ b/src/clef.ts
@@ -2,31 +2,11 @@
 // MIT License
 // Co-author: Benjamin W. Bohl
 
-import { Glyph } from './glyph';
 import { Stave } from './stave';
 import { StaveModifier, StaveModifierPosition } from './stavemodifier';
 import { Tables } from './tables';
 import { Category } from './typeguard';
-import { defined, log, upperFirst } from './util';
-
-export interface ClefType {
-  code: string;
-  line: number;
-}
-
-export interface ClefAnnotatiomType extends ClefType {
-  xShift: number;
-  point: number;
-}
-
-export interface ClefMetrics {
-  width: number;
-  annotations: {
-    [key: string]: {
-      [type: string]: { line?: number; shiftX?: number } | number;
-    };
-  };
-}
+import { log } from './util';
 
 // eslint-disable-next-line
 function L(...args: any[]) {
@@ -46,81 +26,68 @@ export class Clef extends StaveModifier {
     return Category.Clef;
   }
 
-  annotation?: ClefAnnotatiomType;
-
   /**
    * The attribute `clef` must be a key from
    * `Clef.types`
    */
-  clef: ClefType = Clef.types['treble'];
-
-  protected attachment?: Glyph;
-  protected size?: string;
-  protected type?: string;
-
-  #glyphCategory!: string;
-
+  code = Clef.types['treble'].code;
+  line = Clef.types['treble'].line;
+  protected size = 'default';
+  protected type = 'treble';
   /**
    * Every clef name is associated with a glyph code from the font file
    * and a default stave line number.
    */
-  static get types(): Record<string, ClefType> {
+  static get types(): Record<string, { code: string; line: number }> {
     return {
       treble: {
-        code: 'gClef',
+        code: '\uE050' /*gClef*/,
         line: 3,
       },
       bass: {
-        code: 'fClef',
+        code: '\uE062' /*fClef*/,
         line: 1,
       },
       alto: {
-        code: 'cClef',
+        code: '\uE05C' /*cClef*/,
         line: 2,
       },
       tenor: {
-        code: 'cClef',
+        code: '\uE05C' /*cClef*/,
         line: 1,
       },
       percussion: {
-        code: 'unpitchedPercussionClef1',
+        code: '\uE069' /*unpitchedPercussionClef1*/,
         line: 2,
       },
       soprano: {
-        code: 'cClef',
+        code: '\uE05C' /*cClef*/,
         line: 4,
       },
       'mezzo-soprano': {
-        code: 'cClef',
+        code: '\uE05C' /*cClef*/,
         line: 3,
       },
       'baritone-c': {
-        code: 'cClef',
+        code: '\uE05C' /*cClef*/,
         line: 0,
       },
       'baritone-f': {
-        code: 'fClef',
+        code: '\uE062' /*fClef*/,
         line: 2,
       },
       subbass: {
-        code: 'fClef',
+        code: '\uE062' /*fClef*/,
         line: 0,
       },
       french: {
-        code: 'gClef',
+        code: '\uE050' /*gClef*/,
         line: 4,
       },
       tab: {
-        code: '6stringTabClef',
+        code: '\uE06D' /*6stringTabClef*/,
         line: 2.5,
       },
-    };
-  }
-
-  static get annotationSmufl(): Record<string, string> {
-    return {
-      '8va': 'timeSig8',
-      '8vb': 'timeSig8',
     };
   }
 
@@ -130,53 +97,40 @@ export class Clef extends StaveModifier {
 
     this.setPosition(StaveModifierPosition.BEGIN);
     this.setType(type, size, annotation);
-    this.setWidth(Glyph.getWidth(this.clef.code, Clef.getPoint(this.size), this.#glyphCategory));
     L('Creating clef:', type);
   }
 
   /** Set clef type, size and annotation. */
   setType(type: string, size: string = 'default', annotation?: string): this {
     this.type = type;
-    this.clef = Clef.types[type];
-    this.size = size;
-
-    // clefDefault or clefSmall
-    this.#glyphCategory = 'clef' + upperFirst(size);
-
-    const musicFont = Tables.currentMusicFont();
+    this.code = Clef.types[type].code;
+    this.line = Clef.types[type].line;
+    if (size === undefined) {
+      this.size = 'default';
+    } else {
+      this.size = size;
+    }
 
     // If an annotation, such as 8va, is specified, add it to the Clef object.
-    if (annotation !== undefined) {
-      const code = Clef.annotationSmufl[annotation];
-      const point = (Clef.getPoint(this.size) / 5) * 3;
-      const prefix = this.#glyphCategory + `.annotations.${annotation}.${this.type}.`;
-      const line = musicFont.lookupMetric(prefix + 'line');
-      const xShift = musicFont.lookupMetric(prefix + 'shiftX');
-
-      this.annotation = { code, point, line, xShift };
-
-      this.attachment = new Glyph(this.annotation.code, this.annotation.point);
-      this.attachment.metrics.xMax = 0;
-      this.attachment.setXShift(this.annotation.xShift);
-    } else {
-      this.annotation = undefined;
+    if (annotation == '8va') {
+      if (this.code == '\uE050' /*gClef*/) this.code = '\uE053' /*gClef8va*/;
+      if (this.code == '\uE062' /*fClef*/) this.code = '\uE065' /*fClef8va*/;
     }
+    if (annotation == '8vb') {
+      if (this.code == '\uE050' /*gClef*/) this.code = '\uE052' /*gClef8vb*/;
+      if (this.code == '\uE062' /*fClef*/) this.code = '\uE064' /*fClef8vb*/;
+    }
+    this.text = this.code;
+    this.textFont.size = Math.floor(Clef.getPoint(this.size));
+    this.measureText();
 
     return this;
-  }
-
-  /** Get clef width. */
-  getWidth(): number {
-    if (this.type === 'tab') {
-      defined(this.stave, 'ClefError', "Can't get width without stave.");
-    }
-    return this.width;
   }
 
   /** Get point for clefs. */
   static getPoint(size?: string): number {
     // for sizes other than 'default', clef is 2/3 of the default value
-    return size == 'default' ? Tables.NOTATION_FONT_SCALE : (Tables.NOTATION_FONT_SCALE / 3) * 2;
+    return size == 'default' ? Tables.lookupMetric('fontSize') : (Tables.lookupMetric('fontSize') / 3) * 2;
   }
 
   /** Set associated stave. */
@@ -194,16 +148,7 @@ export class Clef extends StaveModifier {
     this.applyStyle(ctx);
     ctx.openGroup('clef', this.getAttribute('id'));
 
-    const x = this.x;
-    const y = stave.getYForLine(this.clef.line);
-    Glyph.renderGlyph(ctx, x, y, Clef.getPoint(this.size), this.clef.code, { category: this.#glyphCategory });
-
-    if (this.annotation !== undefined && this.attachment !== undefined) {
-      this.placeGlyphOnLine(this.attachment, stave, this.annotation.line);
-      this.attachment.setStave(stave);
-      this.attachment.setContext(ctx);
-      this.attachment.renderToStave(this.x);
-    }
+    this.renderText(ctx, this.x, stave.getYForLine(this.line));
     ctx.closeGroup();
     this.restoreStyle(ctx);
   }

--- a/src/clef.ts
+++ b/src/clef.ts
@@ -105,11 +105,7 @@ export class Clef extends StaveModifier {
     this.type = type;
     this.code = Clef.types[type].code;
     this.line = Clef.types[type].line;
-    if (size === undefined) {
-      this.size = 'default';
-    } else {
-      this.size = size;
-    }
+    this.size = size ?? 'default';
 
     // If an annotation, such as 8va, is specified, add it to the Clef object.
     if (annotation == '8va') {

--- a/src/clefnote.ts
+++ b/src/clefnote.ts
@@ -2,11 +2,9 @@
 // @author: Taehoon Moon 2014
 // MIT License
 
-import { Clef, ClefAnnotatiomType, ClefType } from './clef';
-import { Glyph } from './glyph';
+import { Clef } from './clef';
 import { Note } from './note';
 import { Category } from './typeguard';
-import { upperFirst } from './util';
 
 /** ClefNote implements clef annotations in measures. */
 export class ClefNote extends Note {
@@ -14,12 +12,7 @@ export class ClefNote extends Note {
     return Category.ClefNote;
   }
 
-  protected clef!: ClefType;
-  protected annotation?: ClefAnnotatiomType;
-  protected type!: string;
-  protected size!: string;
-
-  #glyphCategory!: string;
+  protected clef!: Clef;
 
   constructor(type: string, size: string = 'default', annotation?: string) {
     super({ duration: 'b' });
@@ -28,22 +21,15 @@ export class ClefNote extends Note {
   }
 
   /** Set clef type, size and annotation. */
-  setType(type: string, size: string = 'default', annotation?: string): this {
-    this.type = type;
-    this.size = size;
-    const clef = new Clef(type, size, annotation);
-    this.clef = clef.clef;
-    this.annotation = clef.annotation;
+  setType(type: string, size: string, annotation?: string): this {
+    this.clef = new Clef(type, size, annotation);
+    this.setWidth(this.clef.getWidth());
 
-    const category = 'clefNote' + upperFirst(this.size);
-    this.#glyphCategory = category;
-
-    this.setWidth(Glyph.getWidth(this.clef.code, Clef.getPoint(this.size), category));
     return this;
   }
 
   /** Get associated clef. */
-  getClef(): ClefType {
+  getClef(): Clef {
     return this.clef;
   }
 
@@ -58,20 +44,7 @@ export class ClefNote extends Note {
     const ctx = this.checkContext();
 
     this.setRendered();
-    const absoluteX = this.getAbsoluteX();
 
-    const x = absoluteX;
-    const y = stave.getYForLine(this.clef.line);
-    Glyph.renderGlyph(ctx, x, y, Clef.getPoint(this.size), this.clef.code, { category: this.#glyphCategory });
-
-    // If the Vex.Flow.Clef has an annotation, such as 8va, draw it.
-    if (this.annotation !== undefined) {
-      const attachment = new Glyph(this.annotation.code, this.annotation.point);
-      attachment.setContext(ctx);
-      attachment.setStave(stave);
-      attachment.setYShift(stave.getYForLine(this.annotation.line) - stave.getYForGlyphs());
-      attachment.setXShift(this.annotation.xShift);
-      attachment.renderToStave(absoluteX);
-    }
+    this.clef.renderText(ctx, this.getAbsoluteX(), stave.getYForLine(this.clef.line));
   }
 }

--- a/src/font.ts
+++ b/src/font.ts
@@ -1,4 +1,3 @@
-import { ClefMetrics } from './clef';
 import { NoteHeadMetrics } from './notehead';
 import { OrnamentMetrics } from './ornament';
 import { StringNumberMetrics } from './stringnumber';
@@ -37,8 +36,6 @@ export interface FontMetrics extends Record<string, any> {
   smufl: boolean;
   stave?: Record<string, number>;
   accidental?: Record<string, number>;
-  clefDefault?: ClefMetrics;
-  clefSmall?: ClefMetrics;
   pedalMarking?: Record<string, Record<string, number>>;
   digits?: Record<string, number>;
   articulation?: Record<string, Record<string, number>>;

--- a/src/fonts/common_metrics.ts
+++ b/src/fonts/common_metrics.ts
@@ -14,50 +14,6 @@ export const CommonMetrics = {
     accidentalSpacing: 3,
   },
 
-  clefDefault: {
-    width: 26,
-    annotations: {
-      '8va': {
-        treble: {
-          line: -2,
-          shiftX: 12,
-        },
-      },
-      '8vb': {
-        treble: {
-          line: 6.5,
-          shiftX: 10,
-        },
-        bass: {
-          line: 4,
-          shiftX: 1,
-        },
-      },
-    },
-  },
-
-  clefSmall: {
-    width: 20,
-    annotations: {
-      '8va': {
-        treble: {
-          line: -0.2,
-          shiftX: 8,
-        },
-      },
-      '8vb': {
-        treble: {
-          line: 5.3,
-          shiftX: 6,
-        },
-        bass: {
-          line: 3.1,
-          shiftX: 0.5,
-        },
-      },
-    },
-  },
-
   ornament: {
     brassScoop: {
       xOffset: -12,
@@ -272,14 +228,6 @@ export const CommonMetrics = {
         shiftX: -1,
       },
     },
-    clefDefault: {},
-    clefSmall: {
-      gClef: {
-        shiftY: 1.5,
-      },
-    },
-    clefNoteDefault: {},
-    clefNoteSmall: {},
     strokeStraight: {
       arrowheadBlackDown: {
         shiftX: -4.5,


### PR DESCRIPTION
@ronyeh following your comment I have divided #32 into smaller parts.

This one is clef only. Visual differences:
- slightly smaller clefs
- `fClef8va/b` & `gClef8va/b` glyphs used directly

Note: adding support for `fClef15ma/b` & `gClef15ma/b` is trivial now. 
