### PR TITLE
musejazz hack to show progress

### DIFF
--- a/src/flow.ts
+++ b/src/flow.ts
@@ -237,6 +237,9 @@ export class Flow {
       case 'Petaluma':
         CommonMetrics.fontFamily = 'Petaluma,Bravura,Petaluma Script';
         break;
+      case 'MuseJazz':
+        CommonMetrics.fontFamily = 'MuseJazz,Bravura,Academico';
+        break;
       default:
         CommonMetrics.fontFamily = fontNames.join(',');
     }

--- a/src/fonts/load_all.ts
+++ b/src/fonts/load_all.ts
@@ -7,6 +7,7 @@ import { loadBravura } from './load_bravura';
 import { loadCustom } from './load_custom';
 import { loadGonville } from './load_gonville';
 import { loadLeland } from './load_leland';
+import { loadMuseJazz } from './load_musejazz';
 import { loadPetaluma } from './load_petaluma';
 // ADD_MUSIC_FONT
 // import { loadXXX } from './load_xxx';
@@ -18,6 +19,7 @@ export function loadAllMusicFonts(): void {
   loadPetaluma();
   loadCustom();
   loadLeland();
+  loadMuseJazz();
   // ADD_MUSIC_FONT
   // loadXXX();
 }

--- a/src/fonts/load_musejazz.ts
+++ b/src/fonts/load_musejazz.ts
@@ -1,0 +1,20 @@
+// Copyright (c) 2023-present VexFlow contributors: https://github.com/vexflow/vexflow/graphs/contributors
+// MIT License
+
+// If you are adding a new music engraving font, search for instances of ADD_MUSIC_FONT throughout the code base.
+// To compile your new font into vexflow.js, take a look at src/fonts/load_all.ts
+// You can export a font module which can be dynamically loaded by vexflow-core.js (see: Gruntfile.js).
+
+// ADD_MUSIC_FONT
+// To add a new music engraving font XXX, make a copy of this file and name it load_xxx.ts.
+// Then you will need to generate xxx_glyphs.ts and xxx_metrics.ts.
+// xxx_glyphs.ts is created by tools/fonts/fontgen_smufl.js
+// xxx_metrics.ts is created by hand. You could copy bravura_metrics.ts and modify/remove/add entries where necessary.
+
+import { Font } from '../font';
+import { BravuraFont } from './bravura_glyphs';
+import { CommonMetrics } from './common_metrics';
+
+export function loadMuseJazz() {
+  Font.load('MuseJazz', BravuraFont, CommonMetrics);
+}

--- a/src/glyph.ts
+++ b/src/glyph.ts
@@ -209,6 +209,9 @@ export class Glyph extends Element {
 
     let glyph: FontGlyph;
     let font: Font;
+
+    // HACK to see porting progress
+    if (fontStack[0].getName() == 'MuseJazz') code = 'timeSigMinus';
     for (let i = 0; i < fontStack.length; i++) {
       font = fontStack[i];
       glyph = font.getGlyphs()[code];

--- a/tests/vexflow_test_helpers.ts
+++ b/tests/vexflow_test_helpers.ts
@@ -115,7 +115,7 @@ const SVG_TEST_CONFIG = {
   backend: Renderer.Backends.SVG,
   tagName: 'div',
   testType: 'SVG',
-  fontStacks: ['Bravura', 'Gonville', 'Petaluma', 'Leland'],
+  fontStacks: ['Bravura', 'Gonville', 'Petaluma', 'Leland', 'MuseJazz'],
 };
 
 const SVG_TEXT_CONFIG = {
@@ -199,6 +199,7 @@ export class VexFlowTests {
     Gonville: ['Gonville', 'Bravura', 'Custom'],
     Petaluma: ['Petaluma', 'Gonville', 'Bravura', 'Custom'],
     Leland: ['Leland', 'Bravura', 'Custom'],
+    MuseJazz: ['MuseJazz'],
   };
 
   static set NODE_FONT_STACKS(fontStacks: string[]) {


### PR DESCRIPTION
This is a hack to show the progress of the migration. Glyph.ts returns always a minus symbol. Only the elements ported are visble. i.e.: StaveTempos

![pptr-Stave Tempo_Test MuseJazz svg](https://github.com/vexflow/vexflow/assets/22865285/1d1ae414-0773-4a25-9bf2-2a3213304677)


