### PR TITLE
glyphnote (v5)

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -227,7 +227,7 @@ export class Factory {
     return note;
   }
 
-  GlyphNote(glyph: Glyph, noteStruct: NoteStruct, options?: GlyphNoteOptions): GlyphNote {
+  GlyphNote(glyph: string, noteStruct: NoteStruct, options?: GlyphNoteOptions): GlyphNote {
     const note = new GlyphNote(glyph, noteStruct, options);
     if (this.stave) note.setStave(this.stave);
     note.setContext(this.context);

--- a/src/glyphnote.ts
+++ b/src/glyphnote.ts
@@ -2,8 +2,6 @@
 //
 // Any glyph that is set to appear on a Stave and take up musical time and graphical space.
 
-import { BoundingBox } from './boundingbox';
-import { Glyph } from './glyph';
 import { Note, NoteStruct } from './note';
 import { Category } from './typeguard';
 
@@ -18,9 +16,8 @@ export class GlyphNote extends Note {
   }
 
   protected options: Required<GlyphNoteOptions>;
-  protected glyph!: Glyph;
 
-  constructor(glyph: Glyph, noteStruct: NoteStruct, options?: GlyphNoteOptions) {
+  constructor(glyph: string, noteStruct: NoteStruct, options?: GlyphNoteOptions) {
     super(noteStruct);
     this.options = {
       ignoreTicks: false,
@@ -33,14 +30,10 @@ export class GlyphNote extends Note {
     this.setGlyph(glyph);
   }
 
-  setGlyph(glyph: Glyph): this {
-    this.glyph = glyph;
-    this.setWidth(this.glyph.getMetrics().width);
+  setGlyph(glyph: string): this {
+    this.text = glyph;
+    this.measureText();
     return this;
-  }
-
-  getBoundingBox(): BoundingBox | undefined {
-    return this.glyph.getBoundingBox();
   }
 
   preFormat(): this {
@@ -60,11 +53,6 @@ export class GlyphNote extends Note {
     }
   }
 
-  /** Get the glyph width. */
-  getGlyphWidth(): number {
-    return this.glyph.getMetrics().width;
-  }
-
   draw(): void {
     const stave = this.checkStave();
     const ctx = stave.checkContext();
@@ -72,17 +60,8 @@ export class GlyphNote extends Note {
     this.applyStyle(ctx);
     ctx.openGroup('glyphNote', this.getAttribute('id'));
 
-    // Context is set when setStave is called on Note
-    const glyph = this.glyph;
-    if (!glyph.getContext()) {
-      glyph.setContext(ctx);
-    }
-
-    glyph.setStave(stave);
-    glyph.setYShift(stave.getYForLine(this.options.line) - stave.getYForGlyphs());
-
     const x = this.isCenterAligned() ? this.getAbsoluteX() - this.getWidth() / 2 : this.getAbsoluteX();
-    glyph.renderToStave(x);
+    this.renderText(ctx, x, stave.getYForLine(this.options.line));
     this.drawModifiers();
     ctx.closeGroup();
     this.restoreStyle(ctx);

--- a/src/repeatnote.ts
+++ b/src/repeatnote.ts
@@ -1,17 +1,15 @@
 // Copyright (c) 2023-present VexFlow contributors: https://github.com/vexflow/vexflow/graphs/contributors
 
-import { Glyph } from './glyph';
 import { GlyphNote, GlyphNoteOptions } from './glyphnote';
 import { NoteStruct } from './note';
-import { Tables } from './tables';
 import { Category } from './typeguard';
 
 // Map `type` to SMuFL glyph code.
 const CODES: Record<string, string> = {
-  '1': 'repeat1Bar',
-  '2': 'repeat2Bars',
-  '4': 'repeat4Bars',
-  slash: 'repeatBarSlash',
+  '1': '\uE500' /*repeat1Bar*/,
+  '2': '\uE501' /*repeat2Bars*/,
+  '4': '\uE502' /*repeat4Bars*/,
+  slash: '\uE504' /*repeatBarSlash*/,
 };
 
 export class RepeatNote extends GlyphNote {
@@ -20,10 +18,7 @@ export class RepeatNote extends GlyphNote {
   }
 
   constructor(type: string, noteStruct?: NoteStruct, options?: GlyphNoteOptions) {
-    const glyphCode = CODES[type] || 'repeat1Bar';
-    const glyph = new Glyph(glyphCode, Tables.currentMusicFont().lookupMetric('repeatNote.point', 40), {
-      category: 'repeatNote',
-    });
-    super(glyph, { duration: 'q', alignCenter: type !== 'slash', ...noteStruct }, options);
+    const glyphCode = CODES[type] || '\uE500'; /*repeat1Bar*/
+    super(glyphCode, { duration: 'q', alignCenter: type !== 'slash', ...noteStruct }, options);
   }
 }

--- a/tests/glyphnote_tests.ts
+++ b/tests/glyphnote_tests.ts
@@ -6,7 +6,6 @@
 import { TestOptions, VexFlowTests } from './vexflow_test_helpers';
 
 import { ChordSymbol } from '../src/chordsymbol';
-import { Glyph } from '../src/glyph';
 import { Note } from '../src/note';
 import { Registry } from '../src/registry';
 import { StaveConnector } from '../src/staveconnector';
@@ -38,10 +37,10 @@ function chordChanges(options: TestOptions): void {
   const score = f.EasyScore();
 
   const notes = [
-    f.GlyphNote(new Glyph('repeatBarSlash', 40), { duration: 'q' }),
-    f.GlyphNote(new Glyph('repeatBarSlash', 40), { duration: 'q' }),
-    f.GlyphNote(new Glyph('repeatBarSlash', 40), { duration: 'q' }),
-    f.GlyphNote(new Glyph('repeatBarSlash', 40), { duration: 'q' }),
+    f.GlyphNote('\uE504' /*repeatBarSlash*/, { duration: 'q' }),
+    f.GlyphNote('\uE504' /*repeatBarSlash*/, { duration: 'q' }),
+    f.GlyphNote('\uE504' /*repeatBarSlash*/, { duration: 'q' }),
+    f.GlyphNote('\uE504' /*repeatBarSlash*/, { duration: 'q' }),
   ];
   const chord1 = f
     .ChordSymbol()
@@ -84,13 +83,13 @@ function basic(options: TestOptions): void {
   const newStave = (voice: Voice) => system.addStave({ voices: [voice], debugNoteMetrics: options.params.debug });
 
   const voices: Note[][] = [
-    [f.GlyphNote(new Glyph('repeat1Bar', 40), { duration: 'q' }, { line: 4 })],
-    [f.GlyphNote(new Glyph('repeat2Bars', 40), { duration: 'q', alignCenter: true })],
+    [f.GlyphNote('\uE500' /*repeat1Bar*/, { duration: 'q' }, { line: 4 })],
+    [f.GlyphNote('\uE501' /*repeat2Bars*/, { duration: 'q', alignCenter: true })],
     [
-      f.GlyphNote(new Glyph('repeatBarSlash', 40), { duration: '16' }),
-      f.GlyphNote(new Glyph('repeatBarSlash', 40), { duration: '16' }),
-      f.GlyphNote(new Glyph('repeat4Bars', 40), { duration: '16' }),
-      f.GlyphNote(new Glyph('repeatBarSlash', 40), { duration: '16' }),
+      f.GlyphNote('\uE504' /*repeatBarSlash*/, { duration: '16' }),
+      f.GlyphNote('\uE504' /*repeatBarSlash*/, { duration: '16' }),
+      f.GlyphNote('\uE502' /*repeat4Bars*/, { duration: '16' }),
+      f.GlyphNote('\uE504' /*repeatBarSlash*/, { duration: '16' }),
     ],
   ];
 


### PR DESCRIPTION
GlyphNote and RepeatNote with minimal visual changes:

current
![pptr-GlyphNote GlyphNote_RepeatNote Petaluma svg_current](https://github.com/vexflow/vexflow/assets/22865285/ec7228e3-dc0c-413c-8597-c97796c3d9ae)
reference
![pptr-GlyphNote GlyphNote_RepeatNote Petaluma svg_reference](https://github.com/vexflow/vexflow/assets/22865285/dc5ad159-ea78-42f2-847e-626363ae69df)
