### PR TITLE
annotation (v5)

### DIFF
--- a/src/tables.ts
+++ b/src/tables.ts
@@ -23,7 +23,6 @@ export const CommonMetrics: Record<string, any> = {
   },
 
   Annotation: {
-    fontFamily: 'Arial, sans-serif',
     fontSize: 10,
   },
 

--- a/tests/annotation_tests.ts
+++ b/tests/annotation_tests.ts
@@ -15,7 +15,6 @@ import { Beam } from '../src/beam';
 import { Bend } from '../src/bend';
 import { ElementStyle } from '../src/element';
 import { Flow } from '../src/flow';
-import { Font, FontStyle, FontWeight } from '../src/font';
 import { Formatter } from '../src/formatter';
 import { ModifierPosition } from '../src/modifier';
 import { Registry } from '../src/registry';
@@ -23,6 +22,7 @@ import { ContextBuilder } from '../src/renderer';
 import { Stave } from '../src/stave';
 import { StaveNote, StaveNoteStruct } from '../src/stavenote';
 import { Stem } from '../src/stem';
+import { Tables } from '../src/tables';
 import { TabNote, TabNoteStruct } from '../src/tabnote';
 import { TabStave } from '../src/tabstave';
 import { Tickable } from '../src/tickable';
@@ -84,7 +84,7 @@ function lyrics(options: TestOptions): void {
       const verse = Math.floor(ix / 3);
       const noteGroupID = 'n' + (ix % 3);
       const noteGroup = registry.getElementById(noteGroupID) as Tickable;
-      const lyricsAnnotation = f.Annotation({ text }).setFont('Roboto Slab', fontSize);
+      const lyricsAnnotation = f.Annotation({ text }).setFontSize(fontSize);
       lyricsAnnotation.setPosition(ModifierPosition.BELOW);
       noteGroup.addModifier(lyricsAnnotation, verse);
     });
@@ -134,7 +134,8 @@ function standard(options: TestOptions, contextBuilder: ContextBuilder): void {
 
   const stave = new Stave(10, 10, 450).addClef('treble').setContext(ctx).draw();
 
-  const annotation = (text: string) => new Annotation(text).setFont(Font.SERIF, FONT_SIZE, 'normal', 'italic');
+  const annotation = (text: string) =>
+    new Annotation(text).setFont(Tables.lookupMetric('Annotation.fontFamily'), FONT_SIZE, 'normal', 'italic');
 
   const notes = [
     staveNote({ keys: ['c/4', 'e/4'], duration: 'h' }).addModifier(annotation('quiet'), 0),
@@ -151,7 +152,9 @@ function styling(options: TestOptions, contextBuilder: ContextBuilder): void {
   const stave = new Stave(10, 10, 450).addClef('treble').setContext(ctx).draw();
 
   const annotation = (text: string, style: ElementStyle) =>
-    new Annotation(text).setFont(Font.SERIF, FONT_SIZE, 'normal', 'italic').setStyle(style);
+    new Annotation(text)
+      .setFont(Tables.lookupMetric('Annotation.fontFamily'), FONT_SIZE, 'normal', 'italic')
+      .setStyle(style);
 
   const notes = [
     staveNote({ keys: ['c/4', 'e/4'], duration: 'h' }).addModifier(annotation('quiet', { fillStyle: '#0F0' }), 0),
@@ -170,7 +173,7 @@ function harmonic(options: TestOptions, contextBuilder: ContextBuilder): void {
   ctx.scale(1.5, 1.5);
 
   ctx.font = '10pt Arial';
-  const stave = new TabStave(10, 10, 450).addTabGlyph().setContext(ctx).draw();
+  const stave = new TabStave(10, 10, 450).addClef('tab').setContext(ctx).draw();
 
   const notes = [
     tabNote({
@@ -184,7 +187,10 @@ function harmonic(options: TestOptions, contextBuilder: ContextBuilder): void {
       positions: [{ str: 2, fret: 9 }],
       duration: 'h',
     })
-      .addModifier(new Annotation('(8va)').setFont(Font.SERIF, FONT_SIZE, FontWeight.NORMAL, FontStyle.ITALIC), 0)
+      .addModifier(
+        new Annotation('(8va)').setFont(Tables.lookupMetric('Annotation.fontFamily'), FONT_SIZE, 'normal', 'italic'),
+        0
+      )
       .addModifier(new Annotation('A.H.'), 0),
   ];
 
@@ -195,11 +201,11 @@ function harmonic(options: TestOptions, contextBuilder: ContextBuilder): void {
 function picking(options: TestOptions, contextBuilder: ContextBuilder): void {
   const ctx = contextBuilder(options.elementId, 500, 240);
 
-  ctx.setFont(Font.SANS_SERIF, FONT_SIZE);
-  const stave = new TabStave(10, 10, 450).addTabGlyph().setContext(ctx).draw();
+  ctx.setFont(Tables.lookupMetric('fontFamily'), FONT_SIZE);
+  const stave = new TabStave(10, 10, 450).addClef('tab').setContext(ctx).draw();
 
   const annotation = (text: string) =>
-    new Annotation(text).setFont(Font.SERIF, FONT_SIZE, FontWeight.NORMAL, FontStyle.ITALIC);
+    new Annotation(text).setFont(Tables.lookupMetric('Annotation.fontFamily'), FONT_SIZE, 'normal', 'italic');
 
   const notes = [
     tabNote({
@@ -239,7 +245,7 @@ function placement(options: TestOptions, contextBuilder: ContextBuilder): void {
   const stave = new Stave(10, 50, 750).addClef('treble').setContext(ctx).draw();
 
   const annotation = (text: string, fontSize: number, vj: number) =>
-    new Annotation(text).setFont(Font.SERIF, fontSize).setVerticalJustification(vj);
+    new Annotation(text).setFontSize(fontSize).setVerticalJustification(vj);
 
   const notes = [
     staveNote({ keys: ['e/4'], duration: 'q', stemDirection: Stem.DOWN })
@@ -303,7 +309,7 @@ function bottom(options: TestOptions, contextBuilder: ContextBuilder): void {
   const stave = new Stave(10, 10, 300).addClef('treble').setContext(ctx).draw();
 
   const annotation = (text: string) =>
-    new Annotation(text).setFont(Font.SERIF, FONT_SIZE).setVerticalJustification(Annotation.VerticalJustify.BOTTOM);
+    new Annotation(text).setFontSize(FONT_SIZE).setVerticalJustification(Annotation.VerticalJustify.BOTTOM);
 
   const notes = [
     staveNote({ keys: ['f/4'], duration: 'w' }).addModifier(annotation('F'), 0),
@@ -350,7 +356,7 @@ function justificationStemUp(options: TestOptions, contextBuilder: ContextBuilde
 
   const annotation = (text: string, hJustification: number, vJustification: number) =>
     new Annotation(text)
-      .setFont(Font.SANS_SERIF, FONT_SIZE)
+      .setFontSize(FONT_SIZE)
       .setJustification(hJustification)
       .setVerticalJustification(vJustification);
 
@@ -376,7 +382,7 @@ function justificationStemDown(options: TestOptions, contextBuilder: ContextBuil
 
   const annotation = (text: string, hJustification: number, vJustification: number) =>
     new Annotation(text)
-      .setFont(Font.SANS_SERIF, FONT_SIZE)
+      .setFontSize(FONT_SIZE)
       .setJustification(hJustification)
       .setVerticalJustification(vJustification);
 

--- a/tests/beam_tests.ts
+++ b/tests/beam_tests.ts
@@ -20,6 +20,7 @@ import {
   TabNoteStruct,
   Voice,
 } from '../src/index';
+import { Tables } from '../src/tables';
 
 const BeamTests = {
   Start(): void {
@@ -771,7 +772,7 @@ function complexWithAnnotation(options: TestOptions): void {
   ];
 
   const font = {
-    family: Font.SERIF,
+    family: Tables.lookupMetric('Annotation.fontFamily'),
     size: 14,
     weight: FontWeight.BOLD,
     style: FontStyle.ITALIC,


### PR DESCRIPTION
Annotations follow now the specified font. Several layout improvements as well.

Some visual changes with Petluma.

current
![pptr-Annotation Lyrics Petaluma svg_current](https://github.com/vexflow/vexflow/assets/22865285/8020099a-02e5-435a-9b9e-dc0d77643bb5)
reference
![pptr-Annotation Lyrics Petaluma svg_reference](https://github.com/vexflow/vexflow/assets/22865285/68e1d54d-7be4-477c-8904-958962ae7b7f)

current
![pptr-Annotation Bottom_Annotations_with_Beams Petaluma svg_current](https://github.com/vexflow/vexflow/assets/22865285/7616ea06-48be-4a11-9743-08efd863594b)
reference
![pptr-Annotation Bottom_Annotations_with_Beams Petaluma svg_reference](https://github.com/vexflow/vexflow/assets/22865285/f778fed6-ed40-47a4-aa38-6db06d9fb480)

current
![pptr-Beam Complex_Beams_with_Annotations Petaluma svg_current](https://github.com/vexflow/vexflow/assets/22865285/3c7c3024-2f28-45d4-a631-29dfcbffcd03)
reference
![pptr-Beam Complex_Beams_with_Annotations Petaluma svg_reference](https://github.com/vexflow/vexflow/assets/22865285/e63f3b43-0b0c-40a6-a3d6-37d938049ca7)
