### PR TITLE
bend (v5)

### DIFF
--- a/src/bend.ts
+++ b/src/bend.ts
@@ -1,9 +1,9 @@
 // Copyright (c) 2023-present VexFlow contributors: https://github.com/vexflow/vexflow/graphs/contributors
 // MIT License
 
+import { Element } from './element';
 import { Modifier } from './modifier';
 import { ModifierContextState } from './modifiercontext';
-import { TextFormatter } from './textformatter';
 import { Category, isTabNote } from './typeguard';
 import { RuntimeError } from './util';
 
@@ -55,9 +55,7 @@ export class Bend extends Modifier {
     return true;
   }
 
-  protected text: string;
   protected tap: string;
-  protected release: boolean;
   protected phrase: BendPhrase[];
 
   public renderOptions: {
@@ -96,17 +94,12 @@ export class Bend extends Modifier {
    *     width: 8;
    *   }]
    * ```
-   * @param text text for bend ("Full", "Half", etc.) (DEPRECATED)
-   * @param release if true, render a release. (DEPRECATED)
-   * @param phrase if set, ignore "text" and "release", and use the more sophisticated phrase specified
    */
-  constructor(text: string, release: boolean = false, phrase?: BendPhrase[]) {
+  constructor(phrase: BendPhrase[]) {
     super();
 
-    this.text = text;
-    this.release = release;
+    this.xShift = 0;
     this.tap = '';
-
     this.renderOptions = {
       lineWidth: 1.5,
       lineStyle: '#777777',
@@ -114,13 +107,7 @@ export class Bend extends Modifier {
       releaseWidth: 8,
     };
 
-    if (phrase) {
-      this.phrase = phrase;
-    } else {
-      // Backward compatibility
-      this.phrase = [{ type: Bend.UP, text: this.text }];
-      if (this.release) this.phrase.push({ type: Bend.DOWN, text: '' });
-    }
+    this.phrase = phrase;
 
     this.updateWidth();
   }
@@ -137,20 +124,20 @@ export class Bend extends Modifier {
     return this;
   }
 
-  /** Get text provided in the constructor. */
-  getText(): string {
-    return this.text;
-  }
   getTextHeight(): number {
-    const textFormatter = TextFormatter.create(this.textFont);
-    return textFormatter.maxHeight;
+    const element = new Element(Category.Bend);
+    element.setText(this.phrase[0].text);
+    element.measureText();
+    return element.getHeight();
   }
 
   /** Recalculate width. */
   protected updateWidth(): this {
-    const textFormatter = TextFormatter.create(this.textFont);
     const measureText = (text: string) => {
-      return textFormatter.getWidthForTextInPx(text);
+      const element = new Element(Category.Bend);
+      element.setText(text);
+      element.measureText();
+      return element.getWidth();
     };
 
     let totalWidth = 0;
@@ -185,7 +172,6 @@ export class Bend extends Modifier {
     const stave = note.checkStave();
     const spacing = stave.getSpacingBetweenLines();
     const lowestY = note.getYs().reduce((a, b) => (a < b ? a : b));
-
     // this.textLine is relative to top string in the group.
     const bendHeight = start.y - ((this.textLine + 1) * spacing + start.y - lowestY) + 3;
     const annotationY = start.y - ((this.textLine + 1) * spacing + start.y - lowestY) - 1;

--- a/src/tables.ts
+++ b/src/tables.ts
@@ -28,7 +28,6 @@ export const CommonMetrics: Record<string, any> = {
   },
 
   Bend: {
-    fontFamily: 'Arial, sans-serif',
     fontSize: 10,
   },
 

--- a/tests/annotation_tests.ts
+++ b/tests/annotation_tests.ts
@@ -121,7 +121,7 @@ function simple(options: TestOptions, contextBuilder: ContextBuilder): void {
     tabNote({
       positions: [{ str: 2, fret: 10 }],
       duration: 'h',
-    }).addModifier(new Bend('Full').setTap('T'), 0),
+    }).addModifier(new Bend([{ type: Bend.UP, text: 'Full' }]).setTap('T'), 0),
   ];
 
   Formatter.FormatAndDraw(ctx, stave, notes);

--- a/tests/bend_tests.ts
+++ b/tests/bend_tests.ts
@@ -6,11 +6,11 @@
 import { TestOptions, VexFlowTests } from './vexflow_test_helpers';
 
 import { Bend, BendPhrase } from '../src/bend';
-import { Font } from '../src/font';
 import { Formatter } from '../src/formatter';
 import { ModifierContext } from '../src/modifiercontext';
 import { Note } from '../src/note';
 import { ContextBuilder } from '../src/renderer';
+import { Tables } from '../src/tables';
 import { TabNote, TabNoteStruct } from '../src/tabnote';
 import { TabStave } from '../src/tabstave';
 import { TickContext } from '../src/tickcontext';
@@ -30,8 +30,7 @@ const BendTests = {
 
 // Helper functions for creating TabNote and Bend objects.
 const note = (noteStruct: TabNoteStruct) => new TabNote(noteStruct);
-const bendWithText = (text: string, release = false) => new Bend(text, release);
-const bendWithPhrase = (phrase: BendPhrase[]) => new Bend('', false, phrase);
+const bendWithPhrase = (phrase: BendPhrase[]) => new Bend(phrase);
 
 /**
  * Bend two strings at a time.
@@ -41,7 +40,7 @@ function doubleBends(options: TestOptions, contextBuilder: ContextBuilder): void
   ctx.scale(1.5, 1.5);
 
   ctx.font = '10pt Arial';
-  const stave = new TabStave(10, 10, 450).addTabGlyph().setContext(ctx).draw();
+  const stave = new TabStave(10, 10, 450).addClef('tab').setContext(ctx).draw();
 
   const notes = [
     note({
@@ -51,8 +50,8 @@ function doubleBends(options: TestOptions, contextBuilder: ContextBuilder): void
       ],
       duration: 'q',
     })
-      .addModifier(bendWithText('Full'), 0)
-      .addModifier(bendWithText('1/2'), 1),
+      .addModifier(bendWithPhrase([{ type: Bend.UP, text: 'Full' }]), 0)
+      .addModifier(bendWithPhrase([{ type: Bend.UP, text: '1/2' }]), 1),
 
     note({
       positions: [
@@ -61,8 +60,8 @@ function doubleBends(options: TestOptions, contextBuilder: ContextBuilder): void
       ],
       duration: 'q',
     })
-      .addModifier(bendWithText('1/4'), 0)
-      .addModifier(bendWithText('1/4'), 1),
+      .addModifier(bendWithPhrase([{ type: Bend.UP, text: '1/4' }]), 0)
+      .addModifier(bendWithPhrase([{ type: Bend.UP, text: '1/4' }]), 1),
 
     // This note is not visible because it is pushed off to the right by the ctx.scale(1.5, 1.5) at the top.
     note({
@@ -82,7 +81,7 @@ function doubleBendsWithRelease(options: TestOptions, contextBuilder: ContextBui
   ctx.scale(1.0, 1.0);
   ctx.setBackgroundFillStyle('#FFF');
   ctx.setFont('Arial', VexFlowTests.Font.size);
-  const stave = new TabStave(10, 10, 550).addTabGlyph().setContext(ctx).draw();
+  const stave = new TabStave(10, 10, 550).addClef('tab').setContext(ctx).draw();
 
   const notes = [
     note({
@@ -92,8 +91,20 @@ function doubleBendsWithRelease(options: TestOptions, contextBuilder: ContextBui
       ],
       duration: 'q',
     })
-      .addModifier(bendWithText('1/2', true), 0)
-      .addModifier(bendWithText('Full', true), 1),
+      .addModifier(
+        bendWithPhrase([
+          { type: Bend.UP, text: '1/2' },
+          { type: Bend.DOWN, text: '' },
+        ]),
+        0
+      )
+      .addModifier(
+        bendWithPhrase([
+          { type: Bend.UP, text: 'Full' },
+          { type: Bend.DOWN, text: '' },
+        ]),
+        1
+      ),
 
     note({
       positions: [
@@ -103,9 +114,27 @@ function doubleBendsWithRelease(options: TestOptions, contextBuilder: ContextBui
       ],
       duration: 'q',
     })
-      .addModifier(bendWithText('1/4', true), 0)
-      .addModifier(bendWithText('Monstrous', true), 1)
-      .addModifier(bendWithText('1/4', true), 2),
+      .addModifier(
+        bendWithPhrase([
+          { type: Bend.UP, text: '1/4' },
+          { type: Bend.DOWN, text: '' },
+        ]),
+        0
+      )
+      .addModifier(
+        bendWithPhrase([
+          { type: Bend.UP, text: 'Monstrous' },
+          { type: Bend.DOWN, text: '' },
+        ]),
+        1
+      )
+      .addModifier(
+        bendWithPhrase([
+          { type: Bend.UP, text: '1/4' },
+          { type: Bend.DOWN, text: '' },
+        ]),
+        2
+      ),
 
     note({
       positions: [{ str: 4, fret: 7 }],
@@ -134,7 +163,7 @@ function reverseBends(options: TestOptions, contextBuilder: ContextBuilder): voi
 
   ctx.setFont('10pt Arial');
 
-  const stave = new TabStave(10, 10, 450).addTabGlyph().setContext(ctx).draw();
+  const stave = new TabStave(10, 10, 450).addClef('tab').setContext(ctx).draw();
 
   const notes = [
     note({
@@ -144,8 +173,8 @@ function reverseBends(options: TestOptions, contextBuilder: ContextBuilder): voi
       ],
       duration: 'w',
     })
-      .addModifier(bendWithText('Full'), 1)
-      .addModifier(bendWithText('1/2'), 0),
+      .addModifier(bendWithPhrase([{ type: Bend.UP, text: 'Full' }]), 1)
+      .addModifier(bendWithPhrase([{ type: Bend.UP, text: '1/2' }]), 0),
 
     note({
       positions: [
@@ -154,8 +183,8 @@ function reverseBends(options: TestOptions, contextBuilder: ContextBuilder): voi
       ],
       duration: 'w',
     })
-      .addModifier(bendWithText('1/4'), 1)
-      .addModifier(bendWithText('1/4'), 0),
+      .addModifier(bendWithPhrase([{ type: Bend.UP, text: '1/4' }]), 1)
+      .addModifier(bendWithPhrase([{ type: Bend.UP, text: '1/4' }]), 0),
 
     note({
       positions: [{ str: 4, fret: 7 }],
@@ -184,8 +213,8 @@ function bendPhrase(options: TestOptions, contextBuilder: ContextBuilder): void 
   const ctx = contextBuilder(options.elementId, 500, 240);
   ctx.scale(1.5, 1.5);
 
-  ctx.font = Font.SIZE + 'pt ' + Font.SANS_SERIF; // Optionally use constants defined in Font.
-  const stave = new TabStave(10, 10, 450).addTabGlyph().setContext(ctx).draw();
+  ctx.font = Tables.lookupMetric('Bend.fontSize') + Tables.lookupMetric('Bend.fontFamily'); // Optionally use constants defined in Font.
+  const stave = new TabStave(10, 10, 450).addClef('tab').setContext(ctx).draw();
 
   const phrase1 = [
     { type: Bend.UP, text: 'Full' },
@@ -223,7 +252,7 @@ function whackoBends(options: TestOptions, contextBuilder: ContextBuilder): void
   ctx.scale(1.0, 1.0);
   ctx.setBackgroundFillStyle('#FFF');
   ctx.setFont('Arial', VexFlowTests.Font.size);
-  const stave = new TabStave(10, 10, 350).addTabGlyph().setContext(ctx).draw();
+  const stave = new TabStave(10, 10, 350).addClef('tab').setContext(ctx).draw();
 
   const phrase1 = [
     { type: Bend.UP, text: 'Full' },

--- a/tests/font_tests.ts
+++ b/tests/font_tests.ts
@@ -66,10 +66,13 @@ function setFont(assert: Assert): void {
 }
 
 function fontParsing(assert: Assert): void {
-  const b = new Bend('1/2', true);
+  const b = new Bend([
+    { type: Bend.UP, text: '1/2' },
+    { type: Bend.DOWN, text: '' },
+  ]);
   const bFont = b.fontInfo;
   // Check the default font.
-  assert.equal(bFont?.family, Font.SANS_SERIF);
+  assert.equal(bFont?.family, 'Bravura,Roboto Slab');
   assert.equal(bFont?.size, Font.SIZE);
   assert.equal(bFont?.weight, FontWeight.NORMAL);
   assert.equal(bFont?.style, FontStyle.NORMAL);

--- a/tests/formatter_tests.ts
+++ b/tests/formatter_tests.ts
@@ -491,7 +491,9 @@ function notesWithTab(options: TestOptions): void {
     f.TabStave({ y: y }).addTabGlyph().setNoteStartX(stave.getNoteStartX());
 
     const tabVoice = score.voice([
-      f.TabNote({ positions: [{ str: 3, fret: 6 }], duration: '2' }).addModifier(new Bend('Full'), 0),
+      f
+        .TabNote({ positions: [{ str: 3, fret: 6 }], duration: '2' })
+        .addModifier(new Bend([{ type: Bend.UP, text: 'Full' }]), 0),
       f
         .TabNote({
           positions: [
@@ -500,7 +502,7 @@ function notesWithTab(options: TestOptions): void {
           ],
           duration: '8',
         })
-        .addModifier(new Bend('Unison'), 1),
+        .addModifier(new Bend([{ type: Bend.UP, text: 'Unison' }]), 1),
       f.TabNote({ positions: [{ str: 3, fret: 7 }], duration: '8' }),
       f.TabNote({
         positions: [

--- a/tests/strokes_tests.ts
+++ b/tests/strokes_tests.ts
@@ -344,7 +344,7 @@ function notesWithTab(options: TestOptions): void {
         ],
         duration: '4',
       })
-      .addModifier(new Bend('Full'), 0),
+      .addModifier(new Bend([{ type: Bend.UP, text: 'Full' }]), 0),
     f
       .TabNote({
         positions: [
@@ -353,7 +353,7 @@ function notesWithTab(options: TestOptions): void {
         ],
         duration: '4',
       })
-      .addModifier(new Bend('Unison'), 1),
+      .addModifier(new Bend([{ type: Bend.UP, text: 'Unison' }]), 1),
     f.TabNote({
       positions: [
         { str: 3, fret: 7 },

--- a/tests/style_tests.ts
+++ b/tests/style_tests.ts
@@ -133,7 +133,7 @@ function tab(options: TestOptions, contextBuilder: ContextBuilder): void {
       ],
       duration: 'h',
     })
-      .addModifier(new Bend('Full').setStyle(FS('brown')), 0)
+      .addModifier(new Bend([{ type: Bend.UP, text: 'Full' }]).setStyle(FS('brown')), 0)
       .addStroke(0, new Stroke(1, { allVoices: false }).setStyle(FS('blue'))),
   ];
 

--- a/tests/vibrato_tests.ts
+++ b/tests/vibrato_tests.ts
@@ -93,14 +93,26 @@ function withBend(options: TestOptions, contextBuilder: ContextBuilder): void {
       ],
       duration: 'q',
     })
-      .addModifier(new Bend('1/2', true), 0)
-      .addModifier(new Bend('1/2', true), 1)
+      .addModifier(
+        new Bend([
+          { type: Bend.UP, text: '1/2' },
+          { type: Bend.DOWN, text: '' },
+        ]),
+        0
+      )
+      .addModifier(
+        new Bend([
+          { type: Bend.UP, text: '1/2' },
+          { type: Bend.DOWN, text: '' },
+        ]),
+        1
+      )
       .addModifier(new Vibrato(), 0),
     tabNote({
       positions: [{ str: 2, fret: 10 }],
       duration: 'q',
     })
-      .addModifier(new Bend('Full', false), 0)
+      .addModifier(new Bend([{ type: Bend.UP, text: 'Full' }]), 0)
       .addModifier(new Vibrato().setVibratoWidth(60), 0),
     tabNote({
       positions: [{ str: 2, fret: 10 }],


### PR DESCRIPTION
Deprecated constructor parameters removed. Differences due to fonts, height is now more accurate and this can be seen in the position of the vibratos.

current
![pptr-Vibrato Vibrato_with_Bend Petaluma svg_current](https://github.com/vexflow/vexflow/assets/22865285/b11cafa0-8a9f-47c2-ab7e-6ca6a4f38877)
reference
![pptr-Vibrato Vibrato_with_Bend Petaluma svg_reference](https://github.com/vexflow/vexflow/assets/22865285/92f38205-a997-40fa-a1e5-d7edb71b4a07)
