### PR TITLE
tuplet (v5)

### DIFF
--- a/src/tuplet.ts
+++ b/src/tuplet.ts
@@ -85,7 +85,7 @@ export class Tuplet extends Element {
   protected numNotes: number;
 
   protected bracketed: boolean;
-  protected txtElement: Element;
+  protected textElement: Element;
   // location is initialized by the constructor via setTupletLocation(...).
   protected location!: number;
 
@@ -122,7 +122,7 @@ export class Tuplet extends Element {
 
     this.ratioed =
       this.options.ratioed != undefined ? this.options.ratioed : Math.abs(this.notesOccupied - this.numNotes) > 1;
-    this.txtElement = new Element('Tuplet');
+    this.textElement = new Element('Tuplet');
 
     this.setTupletLocation(this.options.location || Tuplet.LOCATION_TOP);
 
@@ -210,8 +210,8 @@ export class Tuplet extends Element {
       }
       denominator = '\uE88A' /* tupletColon */ + denominator;
     }
-    this.txtElement.setText(numerator + denominator);
-    this.txtElement.measureText();
+    this.textElement.setText(numerator + denominator);
+    this.textElement.measureText();
   }
 
   // determine how many tuplets are nested within this tuplet
@@ -323,16 +323,16 @@ export class Tuplet extends Element {
     yPos = this.getYPosition();
 
     const notationCenterX = xPos + this.width / 2;
-    const notationStartX = notationCenterX - this.txtElement.getWidth() / 2;
+    const notationStartX = notationCenterX - this.textElement.getWidth() / 2;
 
     // draw bracket if the tuplet is not beamed
     if (this.bracketed) {
-      const lineWidth = this.width / 2 - this.txtElement.getWidth() / 2 - 5;
+      const lineWidth = this.width / 2 - this.textElement.getWidth() / 2 - 5;
 
       // only draw the bracket if it has positive length
       if (lineWidth > 0) {
         ctx.fillRect(xPos, yPos, lineWidth, 1);
-        ctx.fillRect(xPos + this.width / 2 + this.txtElement.getWidth() / 2 + 5, yPos, lineWidth, 1);
+        ctx.fillRect(xPos + this.width / 2 + this.textElement.getWidth() / 2 + 5, yPos, lineWidth, 1);
         ctx.fillRect(xPos, yPos + (this.location === Tuplet.LOCATION_BOTTOM ? 1 : 0), 1, this.location * 10);
         ctx.fillRect(
           xPos + this.width,
@@ -344,6 +344,6 @@ export class Tuplet extends Element {
     }
 
     // draw text
-    this.txtElement.renderText(ctx, notationStartX, yPos + this.txtElement.getHeight() / 2);
+    this.textElement.renderText(ctx, notationStartX, yPos + this.textElement.getHeight() / 2);
   }
 }

--- a/src/tuplet.ts
+++ b/src/tuplet.ts
@@ -46,16 +46,14 @@
 
 import { Element } from './element';
 import { Formatter } from './formatter';
-import { Glyph } from './glyph';
 import { Note } from './note';
 import { Stem } from './stem';
 import { StemmableNote } from './stemmablenote';
 import { Tables } from './tables';
 import { Category } from './typeguard';
-import { defined, RuntimeError } from './util';
+import { RuntimeError } from './util';
 
 export interface TupletOptions {
-  beatsOccupied?: number;
   bracketed?: boolean;
   location?: number;
   notesOccupied?: number;
@@ -85,20 +83,14 @@ export class Tuplet extends Element {
 
   protected options: TupletOptions;
   protected numNotes: number;
-  protected point: number;
 
   protected bracketed: boolean;
-  protected yPos: number;
-  protected xPos: number;
-  protected width: number;
-
+  protected txtElement: Element;
   // location is initialized by the constructor via setTupletLocation(...).
   protected location!: number;
 
   protected notesOccupied: number;
   protected ratioed: boolean;
-  protected numeratorGlyphs: Glyph[] = [];
-  protected denominatorGlyphs: Glyph[] = [];
 
   static get LOCATION_TOP(): number {
     return TupletLocation.TOP;
@@ -110,15 +102,9 @@ export class Tuplet extends Element {
     return 15;
   }
 
-  static get metrics(): TupletMetrics {
-    const tupletMetrics = Tables.currentMusicFont().getMetrics().tuplet;
-
-    if (!tupletMetrics) throw new RuntimeError('BadMetrics', `tuplet missing`);
-    return tupletMetrics;
-  }
-
   constructor(notes: Note[], options: TupletOptions = {}) {
     super();
+
     if (!notes || !notes.length) {
       throw new RuntimeError('BadArguments', 'No notes provided for tuplet.');
     }
@@ -127,11 +113,7 @@ export class Tuplet extends Element {
     this.notes = notes;
     this.numNotes = this.options.numNotes != undefined ? this.options.numNotes : notes.length;
 
-    // We accept beatsOccupied, but warn that it's deprecated: the preferred property name is now notesOccupied.
-    if (this.options.beatsOccupied) {
-      this.beatsOccupiedDeprecationWarning();
-    }
-    this.notesOccupied = this.options.notesOccupied || this.options.beatsOccupied || 2;
+    this.notesOccupied = this.options.notesOccupied || 2;
     if (this.options.bracketed != undefined) {
       this.bracketed = this.options.bracketed;
     } else {
@@ -140,10 +122,7 @@ export class Tuplet extends Element {
 
     this.ratioed =
       this.options.ratioed != undefined ? this.options.ratioed : Math.abs(this.notesOccupied - this.numNotes) > 1;
-    this.point = (Tables.NOTATION_FONT_SCALE * 3) / 5;
-    this.yPos = 16;
-    this.xPos = 100;
-    this.width = 200;
+    this.txtElement = new Element('Tuplet');
 
     this.setTupletLocation(this.options.location || Tuplet.LOCATION_TOP);
 
@@ -204,25 +183,6 @@ export class Tuplet extends Element {
     return this.numNotes;
   }
 
-  beatsOccupiedDeprecationWarning(): void {
-    // eslint-disable-next-line
-    console.warn(
-      'beatsOccupied has been deprecated as an option for tuplets. Please use notesOccupied instead.',
-      'Calls to getBeatsOccupied / setBeatsOccupied should now be routed to getNotesOccupied / setNotesOccupied.',
-      'The old methods will be removed in VexFlow 5.0.'
-    );
-  }
-
-  getBeatsOccupied(): number {
-    this.beatsOccupiedDeprecationWarning();
-    return this.getNotesOccupied();
-  }
-
-  setBeatsOccupied(beats: number): void {
-    this.beatsOccupiedDeprecationWarning();
-    return this.setNotesOccupied(beats);
-  }
-
   getNotesOccupied(): number {
     return this.notesOccupied;
   }
@@ -235,19 +195,23 @@ export class Tuplet extends Element {
   }
 
   resolveGlyphs(): void {
-    this.numeratorGlyphs = [];
+    let numerator = '';
+    let denominator = '';
     let n = this.numNotes;
     while (n >= 1) {
-      this.numeratorGlyphs.unshift(new Glyph('timeSig' + (n % 10), this.point));
-      n = parseInt((n / 10).toString(), 10);
+      numerator = String.fromCharCode(0xe880 /* tuplet0 */ + (n % 10)) + numerator;
+      n = Math.floor(n / 10);
     }
-
-    this.denominatorGlyphs = [];
-    n = this.notesOccupied;
-    while (n >= 1) {
-      this.denominatorGlyphs.unshift(new Glyph('timeSig' + (n % 10), this.point));
-      n = parseInt((n / 10).toString(), 10);
+    if (this.ratioed) {
+      n = this.notesOccupied;
+      while (n >= 1) {
+        denominator = String.fromCharCode(0xe880 /* tuplet0 */ + (n % 10)) + denominator;
+        n = Math.floor(n / 10);
+      }
+      denominator = '\uE88A' /* tupletColon */ + denominator;
     }
+    this.txtElement.setText(numerator + denominator);
+    this.txtElement.measureText();
   }
 
   // determine how many tuplets are nested within this tuplet
@@ -288,7 +252,7 @@ export class Tuplet extends Element {
     const firstNote = this.notes[0];
     let yPosition;
     if (this.location === Tuplet.LOCATION_TOP) {
-      yPosition = firstNote.checkStave().getYForLine(0) - Tuplet.metrics.topModifierOffset;
+      yPosition = firstNote.checkStave().getYForLine(0) - 1.5 * Tables.STAVE_LINE_DISTANCE;
 
       // check modifiers above note to see if they will collide with tuplet beam
       for (let i = 0; i < this.notes.length; ++i) {
@@ -298,12 +262,12 @@ export class Tuplet extends Element {
         if (mc) {
           modLines = Math.max(modLines, mc.getState().topTextLine);
         }
-        const modY = note.getYForTopText(modLines) - Tuplet.metrics.noteHeadOffset;
+        const modY = note.getYForTopText(modLines) - 2 * Tables.STAVE_LINE_DISTANCE;
         if (note.hasStem() || note.isRest()) {
           const topY =
             note.getStemDirection() === Stem.UP
-              ? note.getStemExtents().topY - Tuplet.metrics.stemOffset
-              : note.getStemExtents().baseY - Tuplet.metrics.noteHeadOffset;
+              ? note.getStemExtents().topY - Tables.STAVE_LINE_DISTANCE
+              : note.getStemExtents().baseY - 2 * Tables.STAVE_LINE_DISTANCE;
           yPosition = Math.min(topY, yPosition);
           if (modLines > 0) {
             yPosition = Math.min(modY, yPosition);
@@ -311,7 +275,7 @@ export class Tuplet extends Element {
         }
       }
     } else {
-      let lineCheck = Tuplet.metrics.bottomLine; // tuplet default on line 4
+      let lineCheck = 4; // tuplet default on line 4
       // check modifiers below note to see if they will collide with tuplet beam
       this.notes.forEach((nn) => {
         const mc = nn.getModifierContext();
@@ -319,14 +283,14 @@ export class Tuplet extends Element {
           lineCheck = Math.max(lineCheck, mc.getState().textLine + 1);
         }
       });
-      yPosition = firstNote.checkStave().getYForLine(lineCheck) + Tuplet.metrics.noteHeadOffset;
+      yPosition = firstNote.checkStave().getYForLine(lineCheck) + 2 * Tables.STAVE_LINE_DISTANCE;
 
       for (let i = 0; i < this.notes.length; ++i) {
         if (this.notes[i].hasStem() || this.notes[i].isRest()) {
           const bottomY =
             this.notes[i].getStemDirection() === Stem.UP
-              ? this.notes[i].getStemExtents().baseY + Tuplet.metrics.noteHeadOffset
-              : this.notes[i].getStemExtents().topY + Tuplet.metrics.stemOffset;
+              ? this.notes[i].getStemExtents().baseY + 2 * Tables.STAVE_LINE_DISTANCE
+              : this.notes[i].getStemExtents().topY + Tables.STAVE_LINE_DISTANCE;
           if (bottomY > yPosition) {
             yPosition = bottomY;
           }
@@ -339,6 +303,8 @@ export class Tuplet extends Element {
 
   draw(): void {
     const ctx = this.checkContext();
+    let xPos = 0;
+    let yPos = 0;
     this.setRendered();
 
     // determine x value of left bound of tuplet
@@ -346,72 +312,38 @@ export class Tuplet extends Element {
     const lastNote = this.notes[this.notes.length - 1] as StemmableNote;
 
     if (!this.bracketed) {
-      this.xPos = firstNote.getStemX();
-      this.width = lastNote.getStemX() - this.xPos;
+      xPos = firstNote.getStemX();
+      this.width = lastNote.getStemX() - xPos;
     } else {
-      this.xPos = firstNote.getTieLeftX() - 5;
-      this.width = lastNote.getTieRightX() - this.xPos + 5;
+      xPos = firstNote.getTieLeftX() - 5;
+      this.width = lastNote.getTieRightX() - xPos + 5;
     }
 
     // determine y value for tuplet
-    this.yPos = this.getYPosition();
+    yPos = this.getYPosition();
 
-    const addGlyphWidth = (width: number, glyph: Glyph) => width + defined(glyph.getMetrics().width);
-
-    // calculate total width of tuplet notation
-    let width = this.numeratorGlyphs.reduce(addGlyphWidth, 0);
-    if (this.ratioed) {
-      width = this.denominatorGlyphs.reduce(addGlyphWidth, width);
-      width += this.point * 0.32;
-    }
-
-    const notationCenterX = this.xPos + this.width / 2;
-    const notationStartX = notationCenterX - width / 2;
+    const notationCenterX = xPos + this.width / 2;
+    const notationStartX = notationCenterX - this.txtElement.getWidth() / 2;
 
     // draw bracket if the tuplet is not beamed
     if (this.bracketed) {
-      const lineWidth = this.width / 2 - width / 2 - 5;
+      const lineWidth = this.width / 2 - this.txtElement.getWidth() / 2 - 5;
 
       // only draw the bracket if it has positive length
       if (lineWidth > 0) {
-        ctx.fillRect(this.xPos, this.yPos, lineWidth, 1);
-        ctx.fillRect(this.xPos + this.width / 2 + width / 2 + 5, this.yPos, lineWidth, 1);
-        ctx.fillRect(this.xPos, this.yPos + (this.location === Tuplet.LOCATION_BOTTOM ? 1 : 0), 1, this.location * 10);
+        ctx.fillRect(xPos, yPos, lineWidth, 1);
+        ctx.fillRect(xPos + this.width / 2 + this.txtElement.getWidth() / 2 + 5, yPos, lineWidth, 1);
+        ctx.fillRect(xPos, yPos + (this.location === Tuplet.LOCATION_BOTTOM ? 1 : 0), 1, this.location * 10);
         ctx.fillRect(
-          this.xPos + this.width,
-          this.yPos + (this.location === Tuplet.LOCATION_BOTTOM ? 1 : 0),
+          xPos + this.width,
+          yPos + (this.location === Tuplet.LOCATION_BOTTOM ? 1 : 0),
           1,
           this.location * 10
         );
       }
     }
 
-    // draw numerator glyphs
-    const shiftY = Tables.currentMusicFont().lookupMetric('digits.shiftY', 0);
-
-    let xOffset = 0;
-    this.numeratorGlyphs.forEach((glyph) => {
-      glyph.render(ctx, notationStartX + xOffset, this.yPos + this.point / 3 - 2 + shiftY);
-      xOffset += defined(glyph.getMetrics().width);
-    });
-
-    // display colon and denominator if the ratio is to be shown
-    if (this.ratioed) {
-      const colonX = notationStartX + xOffset + this.point * 0.16;
-      const colonRadius = this.point * 0.06;
-      ctx.beginPath();
-      ctx.arc(colonX, this.yPos - this.point * 0.08, colonRadius, 0, Math.PI * 2, false);
-      ctx.closePath();
-      ctx.fill();
-      ctx.beginPath();
-      ctx.arc(colonX, this.yPos + this.point * 0.12, colonRadius, 0, Math.PI * 2, false);
-      ctx.closePath();
-      ctx.fill();
-      xOffset += this.point * 0.32;
-      this.denominatorGlyphs.forEach((glyph) => {
-        glyph.render(ctx, notationStartX + xOffset, this.yPos + this.point / 3 - 2 + shiftY);
-        xOffset += defined(glyph.getMetrics().width);
-      });
-    }
+    // draw text
+    this.txtElement.renderText(ctx, notationStartX, yPos + this.txtElement.getHeight() / 2);
   }
 }


### PR DESCRIPTION
Tuplets ported. They are now using the `tuplet0` .. `tuplet9` &`tupletColon` SMuFL codes. 

Visual differences:

Current
![pptr-Tuplet Simple_Tuplet Bravura svg_current](https://github.com/vexflow/vexflow/assets/22865285/2b9c07e9-f2bb-4688-ba02-963c4965e7c6)
Reference
![pptr-Tuplet Simple_Tuplet Bravura svg_reference](https://github.com/vexflow/vexflow/assets/22865285/9b491ff2-cc4a-49c2-848b-79b3b711cb64)
