### PR TITLE
tremolo (v5)

### DIFF
--- a/src/fonts/common_metrics.ts
+++ b/src/fonts/common_metrics.ts
@@ -156,23 +156,6 @@ export const CommonMetrics = {
     },
   },
 
-  tremolo: {
-    default: {
-      spacing: 7,
-      offsetYStemUp: -8,
-      offsetYStemDown: 8,
-      offsetXStemUp: 11,
-      offsetXStemDown: 1,
-    },
-    grace: {
-      spacing: (7 * 3) / 5,
-      offsetYStemUp: -(8 * 3) / 5,
-      offsetYStemDown: (8 * 3) / 5,
-      offsetXStemUp: 7,
-      offsetXStemDown: 1,
-    },
-  },
-
   staveRepetition: {
     symbolText: {
       offsetX: 12,

--- a/src/tables.ts
+++ b/src/tables.ts
@@ -146,6 +146,10 @@ export const CommonMetrics: Record<string, any> = {
     fontSize: 12,
   },
 
+  Tremolo: {
+    spacing: 7,
+  },
+
   Volta: {
     fontFamily: 'Arial, sans-serif',
     fontSize: 9,

--- a/tests/tremolo_tests.ts
+++ b/tests/tremolo_tests.ts
@@ -13,7 +13,6 @@ const TremoloTests = {
     QUnit.module('Tremolo');
     const run = VexFlowTests.runTests;
     run('Tremolo - Basic', tremoloBasic);
-    run('Tremolo - Big', tremoloBig);
   },
 };
 
@@ -52,61 +51,6 @@ function tremoloBasic(options: TestOptions): void {
   f.draw();
 
   options.assert.ok(true, 'Tremolo - Basic');
-}
-
-function tremoloBig(options: TestOptions): void {
-  const f = VexFlowTests.makeFactory(options, 600, 200);
-  const score = f.EasyScore();
-
-  // bar 1
-  const stave1 = f.Stave({ width: 250 }).setEndBarType(Barline.type.DOUBLE);
-
-  const notes1 = score.notes('e4/4, e4, e4, e4', { stem: 'up' });
-
-  const tremolo1 = new Tremolo(3);
-  tremolo1.extraStrokeScale = 1.7;
-  tremolo1.ySpacingScale = 1.5;
-  const tremolo2 = new Tremolo(2);
-  tremolo2.extraStrokeScale = 1.7;
-  tremolo2.ySpacingScale = 1.5;
-  const tremolo3 = new Tremolo(1);
-  tremolo3.extraStrokeScale = 1.7;
-  tremolo3.ySpacingScale = 1.5;
-  notes1[0].addModifier(tremolo1, 0);
-  notes1[1].addModifier(tremolo2, 0);
-  notes1[2].addModifier(tremolo3, 0);
-
-  const voice1 = score.voice(notes1);
-
-  f.Formatter().joinVoices([voice1]).formatToStave([voice1], stave1);
-
-  // bar 2
-  const stave2 = f
-    .Stave({ x: stave1.getWidth() + stave1.getX(), y: stave1.getY(), width: 300 })
-    .setEndBarType(Barline.type.DOUBLE);
-
-  const notes2 = score.notes('e5/4, e5, e5, e5', { stem: 'down' });
-
-  const tremolo4 = new Tremolo(1);
-  tremolo4.extraStrokeScale = 1.7;
-  tremolo4.ySpacingScale = 1.5;
-  const tremolo5 = new Tremolo(2);
-  tremolo5.extraStrokeScale = 1.7;
-  tremolo5.ySpacingScale = 1.5;
-  const tremolo6 = new Tremolo(3);
-  tremolo6.extraStrokeScale = 1.7;
-  tremolo6.ySpacingScale = 1.5;
-  notes2[1].addModifier(tremolo4, 0);
-  notes2[2].addModifier(tremolo5, 0);
-  notes2[3].addModifier(tremolo6, 0);
-
-  const voice2 = score.voice(notes2);
-
-  f.Formatter().joinVoices([voice2]).formatToStave([voice2], stave2);
-
-  f.draw();
-
-  options.assert.ok(true, 'Tremolo - Big');
 }
 
 VexFlowTests.register(TremoloTests);


### PR DESCRIPTION
Big tremolos removed, they are big enough when following the SMuFL ratio. x & y offsets calculated at run time based on the note position. Y position calculated from end of stem.

current
![pptr-Tremolo Tremolo___Basic Bravura svg_current](https://github.com/vexflow/vexflow/assets/22865285/524436dd-f32f-4be5-8398-8c48870441fe)
reference
![pptr-Tremolo Tremolo___Basic Bravura svg_reference](https://github.com/vexflow/vexflow/assets/22865285/75fbd402-41bf-4dcd-a3af-83484d9688dc)
