### PR TITLE
Use loadWebFonts(fontNames) to load only a few fonts. 

### DIFF
--- a/src/font.ts
+++ b/src/font.ts
@@ -373,22 +373,29 @@ export class Font {
   }
 
   /**
-   * Load the web fonts that are used by ChordSymbol. For example, `flow.html` calls:
+   * Load the web fonts that are used by your app.
+   * If fontNames is undefined, all fonts in Font.WEB_FONT_FILES will be loaded.
+   *
+   * For example, `flow.html` calls:
    *   `await Vex.Flow.Font.loadWebFonts();`
    * Alternatively, you may load web fonts with a stylesheet link (e.g., from Google Fonts),
    * and a @font-face { font-family: ... } rule in your CSS.
-   * If you do not load either of these fonts, ChordSymbol will fall back to Times or Arial,
-   * depending on the current music engraving font.
    *
    * You can customize `Font.WEB_FONT_HOST` and `Font.WEB_FONT_FILES` to load different fonts
    * for your app.
    */
-  static async loadWebFonts(): Promise<void> {
+  static async loadWebFonts(fontNames?: string[]): Promise<void> {
+    const allFiles = Font.WEB_FONT_FILES;
+    if (!fontNames) {
+      fontNames = Object.keys(allFiles);
+    }
+
     const host = Font.WEB_FONT_HOST;
-    const files = Font.WEB_FONT_FILES;
-    for (const fontName in files) {
-      const fontPath = files[fontName];
-      Font.loadWebFont(fontName, host + fontPath);
+    for (const fontName of fontNames) {
+      const fontPath = allFiles[fontName];
+      if (fontPath) {
+        Font.loadWebFont(fontName, host + fontPath);
+      }
     }
   }
 

--- a/tests/flow.html
+++ b/tests/flow.html
@@ -1,10 +1,9 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <!-- 
     This page does not work with Safari 13.0.2 due to
     - top level await
     - nullish coalescing operator
-    Use flow-old-browser.html instead.
    -->
   <head>
     <title>VexFlow Tests</title>
@@ -27,8 +26,7 @@
       <p>&nbsp;</p>
       <p>&nbsp;</p>
       <p class="vf-footer">
-        [ <a href="https://vexflow.com">Home</a> ] [ <a href="https://github.com/vexflow/vexflow">GitHub</a> ] [
-        <a href="https://muthanna.com/">0xfe</a> ]
+        [ <a href="https://vexflow.com">Home</a> ] [ <a href="https://github.com/vexflow/vexflow">GitHub</a> ]
       </p>
     </div>
     <script type="module">
@@ -63,7 +61,6 @@
       let vexURL;
       let testsURL;
       let vexPlusTestsURL;
-      let isVersionFourOrNewer = true;
 
       // Determine if we are loading VexFlow from a CDN.
       let cdnURLPath;
@@ -74,28 +71,15 @@
       }
       // If we are loading from a CDN, build the URLs.
       if (typeof cdnURLPath !== 'undefined') {
+        // We only support version 4 or newer.
         const version = ver.split('@')[1];
-        if (parseFloat(version) < 4) {
-          isVersionFourOrNewer = false;
-          vexURL = `${cdnURLPath}vexflow@${version}/releases/vexflow-debug.js`;
-          testsURL = `${cdnURLPath}vexflow@${version}/releases/vexflow-tests.js`;
-        } else {
-          // VexFlow 4 moved the build output from releases/ to build/.
-          vexURL = `${cdnURLPath}vexflow@${version}/build/vexflow-debug.js`;
-          vexPlusTestsURL = `${cdnURLPath}vexflow@${version}/build/vexflow-debug-with-tests.js`;
-        }
+        vexURL = `${cdnURLPath}vexflow@${version}/build/vexflow-debug.js`;
+        vexPlusTestsURL = `${cdnURLPath}vexflow@${version}/build/vexflow-debug-with-tests.js`;
       } else {
         // We are NOT loading from a CDN.
         // We are loading from the local filesystem (vexflow/build/ | vexflow/reference | vexflow/releases/).
         const path = ver;
-
-        // file://.../vexflow/tests/flow.html?ver=releases/3.0.9
-        if (path.startsWith('releases')) {
-          const pathParts = path.split('/');
-          const version = parseFloat(pathParts[1]);
-          isVersionFourOrNewer = version >= 4;
-        }
-        // TODO RONYEH: For versions 4.0.0 or higher, we need to consider the cjs/ and esm/ directories.
+        // TODO RONYEH: We need to consider the cjs/ and esm/ directories.
         vexURL = '../' + path + '/vexflow-debug.js';
         testsURL = '../' + path + '/vexflow-tests.js';
         vexPlusTestsURL = '../' + path + '/vexflow-debug-with-tests.js';
@@ -119,19 +103,10 @@
           const module = await import('../build/esm/entry/vexflow-debug-with-tests.js');
           window.Vex = module.Vex;
         };
-      } else if (isVersionFourOrNewer) {
+      } else {
         console.log('LOADING CJS: VexFlow >= 4.0.0');
         // When loading version >= 4.0.0, only load vexflow-debug-with-tests.js
         loadVexFlow = () => loadScript(vexPlusTestsURL);
-      } else {
-        console.log('LOADING CJS: VexFlow <= 3.0.9');
-        // 3.0.9 depends on jQuery.
-        await loadScript('https://code.jquery.com/jquery-3.6.0.slim.min.js');
-        // 3.0.9 uses module.exports in tabstave_tests.js.
-        window.module = {};
-
-        // When loading versions <= 3.0.9, load vexflow-debug.js and then vexflow-tests.js
-        loadVexFlow = () => loadScript(vexURL).then(() => loadScript(testsURL));
       }
 
       await loadVexFlow();
@@ -140,12 +115,14 @@
 
       // Versions 4.0.0 and newer have support for preloading web fonts.
       // Versions 3.0.9 and older do not support this feature.
-      if (VF.Font.loadWebFonts) {
-        await VF.Font.loadWebFonts();
-        // Optional: view the loaded fonts.
-        // await document.fonts.ready;
-        // document.fonts.forEach((fontFace) => console.log(fontFace));
-      }
+      await VF.Font.loadWebFonts(); // All Fonts
+      // await VF.Font.loadWebFonts(['Bravura']);
+
+      document.fonts.ready.then((fontFaceSet) => {
+        // Any operation that needs to be done only after all used fonts
+        // have finished loading can go here.
+        console.log([...fontFaceSet]);
+      });
 
       // Optionally specify the QUnit module or filter in the fragment identifier.
       if (hashParams) {


### PR DESCRIPTION
Omit the `fontNames` parameter to load all the web fonts compatible with VexFlow.