### PR TITLE
remove glyph in tests

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -17,7 +17,6 @@ import { FontInfo } from './font';
 import { Formatter, FormatterOptions } from './formatter';
 import { FretHandFinger } from './frethandfinger';
 import { GhostNote } from './ghostnote';
-import { Glyph } from './glyph';
 import { GlyphNote, GlyphNoteOptions } from './glyphnote';
 import { GraceNote, GraceNoteStruct } from './gracenote';
 import { GraceNoteGroup } from './gracenotegroup';

--- a/tests/key_clef_tests.ts
+++ b/tests/key_clef_tests.ts
@@ -6,7 +6,7 @@
 
 import { MAJOR_KEYS, MINOR_KEYS, TestOptions, VexFlowTests } from './vexflow_test_helpers';
 
-import { Glyph } from '../src/glyph';
+import { Element } from '../src/element';
 import { KeySignature } from '../src/keysignature';
 import { ContextBuilder } from '../src/renderer';
 import { Stave } from '../src/stave';
@@ -22,13 +22,19 @@ const ClefKeySignatureTests = {
   },
 };
 
+function getWidth(code: number) {
+  const el = new Element();
+  el.setText(String.fromCharCode(code));
+  el.measureText();
+  return el.getWidth();
+}
+
 const fontWidths = () => {
-  const glyphScale = 39; // default font scale
-  const sharpWidth = Glyph.getWidth('accidentalSharp', glyphScale) + 1;
-  const flatWidth = Glyph.getWidth('accidentalFlat', glyphScale) + 1;
+  const sharpWidth = getWidth(0xe262 /*accidentalSharp*/) + 1;
+  const flatWidth = getWidth(0xe260 /*accidentalFlat*/) + 1;
   const ksPadding = 10; // hard-coded in keysignature.ts
-  const naturalWidth = Glyph.getWidth('accidentalNatural', glyphScale) + 2;
-  const clefWidth = Glyph.getWidth('gClef', glyphScale); // widest clef
+  const naturalWidth = getWidth(0xe261 /*accidentalNatural*/) + 2;
+  const clefWidth = getWidth(0xe050 /*gClef*/);
   return { sharpWidth, flatWidth, naturalWidth, clefWidth, ksPadding };
 };
 

--- a/tests/key_clef_tests.ts
+++ b/tests/key_clef_tests.ts
@@ -22,19 +22,19 @@ const ClefKeySignatureTests = {
   },
 };
 
-function getWidth(code: number) {
+function getWidth(code: string) {
   const el = new Element();
-  el.setText(String.fromCharCode(code));
+  el.setText(code);
   el.measureText();
   return el.getWidth();
 }
 
 const fontWidths = () => {
-  const sharpWidth = getWidth(0xe262 /*accidentalSharp*/) + 1;
-  const flatWidth = getWidth(0xe260 /*accidentalFlat*/) + 1;
+  const sharpWidth = getWidth('\ue262' /*accidentalSharp*/) + 1;
+  const flatWidth = getWidth('\ue260' /*accidentalFlat*/) + 1;
   const ksPadding = 10; // hard-coded in keysignature.ts
-  const naturalWidth = getWidth(0xe261 /*accidentalNatural*/) + 2;
-  const clefWidth = getWidth(0xe050 /*gClef*/);
+  const naturalWidth = getWidth('\ue261' /*accidentalNatural*/) + 2;
+  const clefWidth = getWidth('\ue050' /*gClef*/); // widest clef
   return { sharpWidth, flatWidth, naturalWidth, clefWidth, ksPadding };
 };
 

--- a/tests/keysignature_tests.ts
+++ b/tests/keysignature_tests.ts
@@ -6,8 +6,8 @@
 
 import { MAJOR_KEYS, MINOR_KEYS, TestOptions, VexFlowTests } from './vexflow_test_helpers';
 
+import { Element } from '../src/element';
 import { Flow } from '../src/flow';
-import { Glyph } from '../src/glyph';
 import { KeySignature } from '../src/keysignature';
 import { ContextBuilder } from '../src/renderer';
 import { Stave } from '../src/stave';
@@ -29,12 +29,18 @@ const KeySignatureTests = {
   },
 };
 
+function getWidth(code: number) {
+  const el = new Element();
+  el.setText(String.fromCharCode(code));
+  el.measureText();
+  return el.getWidth();
+}
+
 const fontWidths = () => {
-  const glyphScale = 39; // default font scale
-  const sharpWidth = Glyph.getWidth('accidentalSharp', glyphScale) + 1;
-  const flatWidth = Glyph.getWidth('accidentalFlat', glyphScale) + 1;
-  const naturalWidth = Glyph.getWidth('accidentalNatural', glyphScale) + 2;
-  const clefWidth = Glyph.getWidth('gClef', glyphScale) * 2; // widest clef
+  const sharpWidth = getWidth(0xe262 /*accidentalSharp*/) + 1;
+  const flatWidth = getWidth(0xe260 /*accidentalFlat*/) + 1;
+  const naturalWidth = getWidth(0xe261 /*accidentalNatural*/) + 2;
+  const clefWidth = getWidth(0xe050 /*gClef*/) * 2;
   return { sharpWidth, flatWidth, naturalWidth, clefWidth };
 };
 

--- a/tests/keysignature_tests.ts
+++ b/tests/keysignature_tests.ts
@@ -29,18 +29,18 @@ const KeySignatureTests = {
   },
 };
 
-function getWidth(code: number) {
+function getWidth(code: string) {
   const el = new Element();
-  el.setText(String.fromCharCode(code));
+  el.setText(code);
   el.measureText();
   return el.getWidth();
 }
 
 const fontWidths = () => {
-  const sharpWidth = getWidth(0xe262 /*accidentalSharp*/) + 1;
-  const flatWidth = getWidth(0xe260 /*accidentalFlat*/) + 1;
-  const naturalWidth = getWidth(0xe261 /*accidentalNatural*/) + 2;
-  const clefWidth = getWidth(0xe050 /*gClef*/) * 2;
+  const sharpWidth = getWidth('\ue262' /*accidentalSharp*/) + 1;
+  const flatWidth = getWidth('\ue260' /*accidentalFlat*/) + 1;
+  const naturalWidth = getWidth('\ue261' /*accidentalNatural*/) + 2;
+  const clefWidth = getWidth('\ue050' /*gClef*/) * 2; // widest clef
   return { sharpWidth, flatWidth, naturalWidth, clefWidth };
 };
 

--- a/tests/ornament_tests.ts
+++ b/tests/ornament_tests.ts
@@ -238,9 +238,9 @@ function drawOrnamentsWithAccidentals(options: TestOptions): void {
 
 function jazzOrnaments(options: TestOptions): void {
   const el = new Element();
-  el.setText(String.fromCharCode(0xe050));
+  el.setText('\ue050' /* gClef */); // widest clef
   el.measureText();
-  const clefWidth = el.getWidth(); // widest clef
+  const clefWidth = el.getWidth();
 
   // Helper function.
   function draw(modifiers: Ornament[], keys: string[], x: number, width: number, y: number, stemDirection?: number) {

--- a/tests/ornament_tests.ts
+++ b/tests/ornament_tests.ts
@@ -11,9 +11,9 @@ import { TestOptions, VexFlowTests } from './vexflow_test_helpers';
 import { Accidental } from '../src/accidental';
 import { Beam } from '../src/beam';
 import { Dot } from '../src/dot';
+import { Element } from '../src/element';
 import { Factory } from '../src/factory';
 import { Formatter } from '../src/formatter';
-import { Glyph } from '../src/glyph';
 import { Ornament } from '../src/ornament';
 import { ContextBuilder } from '../src/renderer';
 import { Stave } from '../src/stave';
@@ -237,7 +237,10 @@ function drawOrnamentsWithAccidentals(options: TestOptions): void {
 }
 
 function jazzOrnaments(options: TestOptions): void {
-  const clefWidth = Glyph.getWidth('gClef', 38); // widest clef
+  const el = new Element();
+  el.setText(String.fromCharCode(0xe050));
+  el.measureText();
+  const clefWidth = el.getWidth(); // widest clef
 
   // Helper function.
   function draw(modifiers: Ornament[], keys: string[], x: number, width: number, y: number, stemDirection?: number) {

--- a/tests/stringnumber_tests.ts
+++ b/tests/stringnumber_tests.ts
@@ -5,7 +5,7 @@
 
 import { TestOptions, VexFlowTests } from './vexflow_test_helpers';
 
-import { Glyph } from '../src/glyph';
+import { Element } from '../src/element';
 import { Renderer } from '../src/renderer';
 import { Stave } from '../src/stave';
 import { BarlineType } from '../src/stavebarline';
@@ -275,8 +275,10 @@ function multi(options: TestOptions): void {
 
 function drawAccidentals(options: TestOptions): void {
   const f = VexFlowTests.makeFactory(options, 750);
-  const glyphScale = 39; // default font scale
-  const clefWidth = Glyph.getWidth('gClef', glyphScale); // widest clef
+  const el = new Element();
+  el.setText(String.fromCharCode(0xe050));
+  el.measureText();
+  const clefWidth = el.getWidth(); // widest clef
 
   const notes = [
     f.StaveNote({ keys: ['c/4', 'e/4', 'g/4', 'c/5', 'e/5', 'g/5'], stemDirection: 1, duration: '4' }),


### PR DESCRIPTION
Visual changes due to the different measure.

current
![KeySignature Cancelled_key__for_each_clef__test Bravura svg_current](https://github.com/vexflow/vexflow/assets/22865285/ce22103a-d988-4080-91c4-9547b798dd72)
reference
![KeySignature Cancelled_key__for_each_clef__test Bravura svg_reference](https://github.com/vexflow/vexflow/assets/22865285/b238eb6c-aeba-418c-a5e0-13858c3b14db)
current
![Ornament Jazz_Ornaments Bravura svg_current](https://github.com/vexflow/vexflow/assets/22865285/805c2704-8c2e-4e84-8c3d-c3fa578f1824)
reference
![Ornament Jazz_Ornaments Bravura svg_reference](https://github.com/vexflow/vexflow/assets/22865285/f4989a24-7b20-4d2f-a1f6-412c7fe8ab74)

