### PR TITLE
cleanup - refactor currentMusicFont

### DIFF
--- a/src/font.ts
+++ b/src/font.ts
@@ -1,4 +1,3 @@
-import { StringNumberMetrics } from './stringnumber';
 import { TupletMetrics } from './tuplet';
 import { defined } from './util';
 
@@ -38,7 +37,6 @@ export interface FontMetrics extends Record<string, any> {
   digits?: Record<string, number>;
   articulation?: Record<string, Record<string, number>>;
   tremolo?: Record<string, Record<string, number>>;
-  stringNumber?: StringNumberMetrics;
   tuplet?: TupletMetrics;
   glyphs: Record<
     string,

--- a/src/fonts/common_metrics.ts
+++ b/src/fonts/common_metrics.ts
@@ -19,13 +19,6 @@ export const CommonMetrics = {
     },
   },
 
-  stringNumber: {
-    verticalPadding: 8,
-    stemPadding: 2,
-    leftPadding: 5,
-    rightPadding: 6,
-  },
-
   tuplet: {
     noteHeadOffset: 20,
     stemOffset: 10,

--- a/src/stem.ts
+++ b/src/stem.ts
@@ -171,7 +171,7 @@ export class Stem extends Element {
   }
 
   adjustHeightForFlag(): void {
-    this.renderHeightAdjustment = Tables.currentMusicFont().lookupMetric('stem.heightAdjustmentForFlag', -3);
+    this.renderHeightAdjustment = Tables.lookupMetric('Stem.heightAdjustmentForFlag', -3);
   }
 
   adjustHeightForBeam(): void {

--- a/src/stringnumber.ts
+++ b/src/stringnumber.ts
@@ -14,25 +14,9 @@ import { Tables } from './tables';
 import { Category, isStaveNote, isStemmableNote } from './typeguard';
 import { RuntimeError } from './util';
 
-export interface StringNumberMetrics {
-  verticalPadding: number;
-  stemPadding: number;
-  leftPadding: number;
-  rightPadding: number;
-}
-
 export class StringNumber extends Modifier {
   static get CATEGORY(): string {
     return Category.StringNumber;
-  }
-
-  static get metrics(): StringNumberMetrics {
-    return Tables.lookupMetric('StringNumber', {
-      verticalPadding: 0,
-      stemPadding: 0,
-      leftPadding: 0,
-      rightPadding: 0,
-    });
   }
 
   // ## Static Methods
@@ -227,9 +211,12 @@ export class StringNumber extends Modifier {
           const ys = note.getYs();
           dotY = ys.reduce((a, b) => (a < b ? a : b));
           if (note.hasStem() && stemDirection === Stem.UP) {
-            dotY = stemExt.topY + StringNumber.metrics.stemPadding;
+            dotY = stemExt.topY + Tables.lookupMetric('StringNumber.stemPadding');
           }
-          dotY -= this.radius + StringNumber.metrics.verticalPadding + this.textLine * Tables.STAVE_LINE_DISTANCE;
+          dotY -=
+            this.radius +
+            Tables.lookupMetric('StringNumber.verticalPadding') +
+            this.textLine * Tables.STAVE_LINE_DISTANCE;
         }
         break;
       case Modifier.Position.BELOW:
@@ -237,16 +224,19 @@ export class StringNumber extends Modifier {
           const ys: number[] = note.getYs();
           dotY = ys.reduce((a, b) => (a > b ? a : b));
           if (note.hasStem() && stemDirection === Stem.DOWN) {
-            dotY = stemExt.topY - StringNumber.metrics.stemPadding;
+            dotY = stemExt.topY - Tables.lookupMetric('StringNumber.stemPadding');
           }
-          dotY += this.radius + StringNumber.metrics.verticalPadding + this.textLine * Tables.STAVE_LINE_DISTANCE;
+          dotY +=
+            this.radius +
+            Tables.lookupMetric('StringNumber.verticalPadding') +
+            this.textLine * Tables.STAVE_LINE_DISTANCE;
         }
         break;
       case Modifier.Position.LEFT:
-        dotX -= this.radius / 2 + StringNumber.metrics.leftPadding;
+        dotX -= this.radius / 2 + Tables.lookupMetric('StringNumber.leftPadding');
         break;
       case Modifier.Position.RIGHT:
-        dotX += this.radius / 2 + StringNumber.metrics.rightPadding;
+        dotX += this.radius / 2 + Tables.lookupMetric('StringNumber.rightPadding');
         break;
       default:
         throw new RuntimeError('InvalidPosition', `The position ${this.position} is invalid`);

--- a/src/stringnumber.ts
+++ b/src/stringnumber.ts
@@ -27,14 +27,12 @@ export class StringNumber extends Modifier {
   }
 
   static get metrics(): StringNumberMetrics {
-    return (
-      Tables.currentMusicFont().getMetrics().stringNumber ?? {
-        verticalPadding: 0,
-        stemPadding: 0,
-        leftPadding: 0,
-        rightPadding: 0,
-      }
-    );
+    return Tables.lookupMetric('StringNumber', {
+      verticalPadding: 0,
+      stemPadding: 0,
+      leftPadding: 0,
+      rightPadding: 0,
+    });
   }
 
   // ## Static Methods

--- a/src/tables.ts
+++ b/src/tables.ts
@@ -125,6 +125,10 @@ export const CommonMetrics: Record<string, any> = {
     fontFamily: 'Arial, sans-serif',
     fontSize: 10,
     fontWeight: 'bold',
+    verticalPadding: 8,
+    stemPadding: 2,
+    leftPadding: 5,
+    rightPadding: 6,
   },
 
   Stroke: {

--- a/tests/formatter_tests.ts
+++ b/tests/formatter_tests.ts
@@ -11,8 +11,9 @@ import { Articulation } from '../src/articulation';
 import { Beam } from '../src/beam';
 import { Bend } from '../src/bend';
 import { Dot } from '../src/dot';
+import { Element } from '../src/element';
 import { Flow } from '../src/flow';
-import { Font, FontGlyph, FontWeight } from '../src/font';
+import { Font, FontWeight } from '../src/font';
 import { Formatter } from '../src/formatter';
 import { FretHandFinger } from '../src/frethandfinger';
 import { ModifierPosition } from '../src/modifier';
@@ -25,7 +26,6 @@ import { Stem } from '../src/stem';
 import { StemmableNote } from '../src/stemmablenote';
 import { StringNumber } from '../src/stringnumber';
 import { System } from '../src/system';
-import { Tables } from '../src/tables';
 import { Tuplet } from '../src/tuplet';
 import { Voice, VoiceTime } from '../src/voice';
 import { MockTickable } from './mocks';
@@ -62,16 +62,10 @@ const FormatterTests = {
 /** Calculate the glyph's width in the current music font. */
 // How is this different from Glyph.getWidth()? The numbers don't match up.
 function getGlyphWidth(glyphName: string): number {
-  // `38` seems to be the `fontScale` specified in many classes, such as
-  // Accidental, Articulation, Ornament, Strokes. Does this mean `38pt`???
-  //
-  // However, tables.ts specifies:
-  //   NOTATION_FONT_SCALE: 39,
-  //   TABLATURE_FONT_SCALE: 39,
-  const musicFont = Tables.currentMusicFont();
-  const glyph: FontGlyph = musicFont.getGlyphs()[glyphName];
-  const widthInEm = (glyph.xMax - glyph.xMin) / musicFont.getResolution();
-  return widthInEm * 38 * Font.scaleToPxFrom.pt;
+  const el = new Element();
+  el.setText(String.fromCharCode(parseInt(glyphName, 16)));
+  el.measureText()
+  return el.getWidth();
 }
 
 function buildTickContexts(assert: Assert): void {
@@ -460,7 +454,7 @@ function justifyStaveNotes(options: TestOptions): void {
 
     f.Formatter()
       .joinVoices(voices)
-      .format(voices, width - (Stave.defaultPadding + getGlyphWidth('gClef')));
+      .format(voices, width - (Stave.defaultPadding + getGlyphWidth('E050' /*gClef*/)));
 
     // Show the the width of notes via a horizontal line with red, green, yellow, blue, gray indicators.
     voices[0].getTickables().forEach((note) => Note.plotMetrics(ctx, note, y + 140)); // Bottom line.
@@ -556,7 +550,7 @@ function multiStaves(options: TestOptions): void {
   ];
 
   const staveYs = [20, 130, 250];
-  let staveWidth = width + getGlyphWidth('gClef') + getGlyphWidth('timeSig8') + Stave.defaultPadding;
+  let staveWidth = width + getGlyphWidth('E050' /*gClef*/) + getGlyphWidth('E088' /*timeSig8*/) + Stave.defaultPadding;
   let staves = [
     f.Stave({ y: staveYs[0], width: staveWidth }).addClef('treble').addTimeSignature('6/8'),
     f.Stave({ y: staveYs[1], width: staveWidth }).addClef('treble').addTimeSignature('6/8'),

--- a/tests/formatter_tests.ts
+++ b/tests/formatter_tests.ts
@@ -60,11 +60,10 @@ const FormatterTests = {
 };
 
 /** Calculate the glyph's width in the current music font. */
-// How is this different from Glyph.getWidth()? The numbers don't match up.
-function getGlyphWidth(glyphName: string): number {
+function getGlyphWidth(glyph: string): number {
   const el = new Element();
-  el.setText(String.fromCharCode(parseInt(glyphName, 16)));
-  el.measureText()
+  el.setText(glyph);
+  el.measureText();
   return el.getWidth();
 }
 
@@ -454,7 +453,7 @@ function justifyStaveNotes(options: TestOptions): void {
 
     f.Formatter()
       .joinVoices(voices)
-      .format(voices, width - (Stave.defaultPadding + getGlyphWidth('E050' /*gClef*/)));
+      .format(voices, width - (Stave.defaultPadding + getGlyphWidth('\uE050' /*gClef*/)));
 
     // Show the the width of notes via a horizontal line with red, green, yellow, blue, gray indicators.
     voices[0].getTickables().forEach((note) => Note.plotMetrics(ctx, note, y + 140)); // Bottom line.
@@ -550,7 +549,8 @@ function multiStaves(options: TestOptions): void {
   ];
 
   const staveYs = [20, 130, 250];
-  let staveWidth = width + getGlyphWidth('E050' /*gClef*/) + getGlyphWidth('E088' /*timeSig8*/) + Stave.defaultPadding;
+  let staveWidth =
+    width + getGlyphWidth('\uE050' /*gClef*/) + getGlyphWidth('\uE088' /*timeSig8*/) + Stave.defaultPadding;
   let staves = [
     f.Stave({ y: staveYs[0], width: staveWidth }).addClef('treble').addTimeSignature('6/8'),
     f.Stave({ y: staveYs[1], width: staveWidth }).addClef('treble').addTimeSignature('6/8'),


### PR DESCRIPTION
Starting with clean up :) 
Visual changes in formatter  text due to the change in width claculation.

current
![Formatter Multiple_Staves___Justified Bravura svg_current](https://github.com/vexflow/vexflow/assets/22865285/795edc5a-8855-4efe-8c0a-393a4c03092e)
reference
![Formatter Multiple_Staves___Justified Bravura svg_reference](https://github.com/vexflow/vexflow/assets/22865285/e861027e-a471-48bc-9816-a25501e6cdc4)
