### PR TITLE
textbracket (v5)

### DIFF
--- a/src/tables.ts
+++ b/src/tables.ts
@@ -158,7 +158,6 @@ export const CommonMetrics: Record<string, any> = {
   },
 
   TextBracket: {
-    fontFamily: 'Times New Roman, serif',
     fontSize: 15,
     fontStyle: 'italic',
   },


### PR DESCRIPTION
TextBracket ported. Visual differences:

current
![TextBracket Simple_TextBracket Bravura svg_current](https://github.com/vexflow/vexflow/assets/22865285/30feb5d2-1a4f-418c-9834-36272f9461d0)
reference
![TextBracket Simple_TextBracket Bravura svg_reference](https://github.com/vexflow/vexflow/assets/22865285/98f6709b-ff07-40f9-9450-55052c0dffa0)
current
![TextBracket TextBracket_Styles Gonville svg_current](https://github.com/vexflow/vexflow/assets/22865285/388a016c-e963-4095-bb5a-bdddc0e769ea)
reference
![TextBracket TextBracket_Styles Bravura svg_reference](https://github.com/vexflow/vexflow/assets/22865285/d4296207-cf73-4780-8d41-521e98565ee8)
