### PR TITLE
measure text reworked

### DIFF
--- a/src/accidental.ts
+++ b/src/accidental.ts
@@ -522,18 +522,17 @@ export class Accidental extends Modifier {
 
     if (!this.cautionary) {
       this.text += Tables.accidentalCodes(this.type);
-      this.textFont.size = Tables.lookupMetric('Accidental.fontSize');
+      this.fontInfo.size = Tables.lookupMetric('Accidental.fontSize');
     } else {
       this.text += Tables.accidentalCodes('{');
       this.text += Tables.accidentalCodes(this.type);
       this.text += Tables.accidentalCodes('}');
-      this.textFont.size = Tables.lookupMetric('Accidental.cautionary.fontSize');
+      this.fontInfo.size = Tables.lookupMetric('Accidental.cautionary.fontSize');
     }
     // Accidentals attached to grace notes are rendered smaller.
     if (isGraceNote(this.note)) {
-      this.textFont.size = Tables.lookupMetric('Accidental.grace.fontSize');
+      this.fontInfo.size = Tables.lookupMetric('Accidental.grace.fontSize');
     }
-    this.measureText();
   }
 
   /** Attach this accidental to `note`, which must be a `StaveNote`. */

--- a/src/annotation.ts
+++ b/src/annotation.ts
@@ -80,7 +80,7 @@ export class Annotation extends Modifier {
     for (let i = 0; i < annotations.length; ++i) {
       const annotation = annotations[i];
       // Text height is expressed in fractional stave spaces.
-      const textLines = (2 + Font.convertSizeToPixelValue(annotation.textFont.size)) / Tables.STAVE_LINE_DISTANCE;
+      const textLines = (2 + Font.convertSizeToPixelValue(annotation.fontInfo.size)) / Tables.STAVE_LINE_DISTANCE;
       let verticalSpaceNeeded = textLines;
 
       const note = annotation.checkAttachedNote();
@@ -188,8 +188,6 @@ export class Annotation extends Modifier {
     // warning: the default in the constructor is TOP, but in the factory the default is BOTTOM.
     // this is to support legacy application that may expect this.
     this.verticalJustification = AnnotationVerticalJustify.TOP;
-
-    this.measureText();
   }
 
   /**
@@ -233,7 +231,7 @@ export class Annotation extends Modifier {
     ctx.openGroup('annotation', this.getAttribute('id'));
 
     const textWidth = this.getWidth();
-    const textHeight = Font.convertSizeToPixelValue(this.textFont.size);
+    const textHeight = Font.convertSizeToPixelValue(this.fontInfo.size);
     let x;
     let y;
 

--- a/src/articulation.ts
+++ b/src/articulation.ts
@@ -180,7 +180,6 @@ export class Articulation extends Modifier {
   protected articulation: ArticulationStruct;
 
   protected heightShift = 0;
-  protected height = 0;
   /**
    * FIXME:
    * Most of the complex formatting logic (ie: snapping to space) is
@@ -321,7 +320,6 @@ export class Articulation extends Modifier {
       this.articulation.code ||
       Glyphs.null;
     this.text = code;
-    this.measureText();
   }
 
   /** Set if articulation should be rendered between lines. */

--- a/src/bend.ts
+++ b/src/bend.ts
@@ -217,7 +217,7 @@ export class Bend extends Modifier {
 
     const renderText = (x: number, text: string) => {
       ctx.save();
-      ctx.setFont(this.textFont);
+      ctx.setFont(this.fontInfo);
       const renderX = x - ctx.measureText(text).width / 2;
       ctx.fillText(text, renderX, annotationY);
       ctx.restore();

--- a/src/chordsymbol.ts
+++ b/src/chordsymbol.ts
@@ -238,11 +238,11 @@ export class ChordSymbol extends Modifier {
    * The offset is specified in `em`. Scale this value by the font size in pixels.
    */
   get superscriptOffset(): number {
-    return ChordSymbol.superscriptOffset * Font.convertSizeToPixelValue(this.textFont.size);
+    return ChordSymbol.superscriptOffset * Font.convertSizeToPixelValue(this.fontInfo.size);
   }
 
   get subscriptOffset(): number {
-    return ChordSymbol.subscriptOffset * Font.convertSizeToPixelValue(this.textFont.size);
+    return ChordSymbol.subscriptOffset * Font.convertSizeToPixelValue(this.fontInfo.size);
   }
   setReportWidth(value: boolean): this {
     this.reportWidth = value;
@@ -277,7 +277,7 @@ export class ChordSymbol extends Modifier {
       symbolBlock.setYShift(this.superscriptOffset);
     }
     if (symbolBlock.isSubscript() || symbolBlock.isSuperscript()) {
-      const { family, size, weight, style } = this.textFont;
+      const { family, size, weight, style } = this.fontInfo;
       const smallerFontSize = Font.scaleSize(size, ChordSymbol.superSubRatio);
       symbolBlock.setFont(family, smallerFontSize, weight, style);
     } else {
@@ -407,7 +407,7 @@ export class ChordSymbol extends Modifier {
     ctx.openGroup('chordsymbol', this.getAttribute('id'));
 
     const start = note.getModifierStartXY(Modifier.Position.ABOVE, this.index);
-    ctx.setFont(this.textFont);
+    ctx.setFont(this.fontInfo);
 
     let y: number;
 

--- a/src/clef.ts
+++ b/src/clef.ts
@@ -130,8 +130,7 @@ export class Clef extends StaveModifier {
       }
     }
     this.text = this.code;
-    this.textFont.size = Math.floor(Clef.getPoint(this.size));
-    this.measureText();
+    this.fontInfo.size = Math.floor(Clef.getPoint(this.size));
 
     return this;
   }

--- a/src/crescendo.ts
+++ b/src/crescendo.ts
@@ -58,7 +58,6 @@ export class Crescendo extends Note {
   }
 
   protected decrescendo: boolean;
-  protected height: number;
   protected line: number;
   protected options = {
     // Extensions to the length of the crescendo on either side

--- a/src/element.ts
+++ b/src/element.ts
@@ -90,7 +90,7 @@ export class Element {
   protected style?: ElementStyle;
   protected registry?: Registry;
 
-  #textFont: Required<FontInfo>;
+  #fontInfo: Required<FontInfo>;
   #text = '';
   #metricsValid = false;
   #textMetrics: TextMetrics = {
@@ -118,7 +118,7 @@ export class Element {
     };
 
     this.rendered = false;
-    this.#textFont = Tables.lookupMetricFontInfo(this.#attrs.type);
+    this.#fontInfo = Tables.lookupMetricFontInfo(this.#attrs.type);
 
     // If a default registry exist, then register with it right away.
     Registry.getDefaultRegistry()?.register(this);
@@ -341,7 +341,7 @@ export class Element {
 
   /** Returns the CSS compatible font string for the text font. */
   get font(): string {
-    return Font.toCSSString(this.#textFont);
+    return Font.toCSSString(this.#fontInfo);
   }
 
   /**
@@ -369,16 +369,16 @@ export class Element {
     this.#metricsValid = false;
     if (fontIsObject) {
       // `font` is case 1) a FontInfo object
-      this.#textFont = { ...defaultTextFont, ...font };
+      this.#fontInfo = { ...defaultTextFont, ...font };
     } else if (fontIsString && sizeWeightStyleAreUndefined) {
       // `font` is case 2) CSS font shorthand.
-      this.#textFont = Font.fromCSSString(font);
+      this.#fontInfo = Font.fromCSSString(font);
     } else {
       // `font` is case 3) a font family string (e.g., 'Times New Roman').
       // The other parameters represent the size, weight, and style.
       // It is okay for `font` to be undefined while one or more of the other arguments is provided.
       // Following CSS conventions, unspecified params are reset to the default.
-      this.#textFont = Font.validate(
+      this.#fontInfo = Font.validate(
         font ?? defaultTextFont.family,
         size ?? defaultTextFont.size,
         weight ?? defaultTextFont.weight,
@@ -393,14 +393,14 @@ export class Element {
    * 'bold 10pt Arial'.
    */
   getFont(): string {
-    return Font.toCSSString(this.#textFont);
+    return Font.toCSSString(this.#fontInfo);
   }
 
   /** Return a copy of the current FontInfo object. */
   get fontInfo(): Required<FontInfo> {
     // We can cast to Required<FontInfo> here, because
     // we just called resetFont() above to ensure this.fontInfo is set.
-    return this.#textFont;
+    return this.#fontInfo;
   }
 
   /** Set the current FontInfo object. */
@@ -562,10 +562,10 @@ export class Element {
   /** Render the element text. */
   renderText(ctx: RenderContext, xPos: number, yPos: number): void {
     ctx.save();
-    ctx.setFont(this.#textFont);
+    ctx.setFont(this.#fontInfo);
     ctx.fillText(this.#text, xPos + this.x + this.xShift, yPos + this.y + this.yShift);
     this.children.forEach((child) => {
-      ctx.setFont(child.#textFont);
+      ctx.setFont(child.#fontInfo);
       ctx.fillText(child.#text, xPos + child.x + child.xShift, yPos + child.y + child.yShift);
     });
     ctx.restore();
@@ -585,7 +585,7 @@ export class Element {
     }
     const context = txtCanvas.getContext('2d');
     if (!context) throw new RuntimeError('Font', 'No txt context');
-    context.font = Font.toCSSString(Font.validate(this.#textFont));
+    context.font = Font.toCSSString(Font.validate(this.#fontInfo));
     this.#textMetrics = context.measureText(this.#text);
     this.#height = this.#textMetrics.actualBoundingBoxAscent + this.#textMetrics.actualBoundingBoxDescent;
     this.#width = this.#textMetrics.width;

--- a/src/frethandfinger.ts
+++ b/src/frethandfinger.ts
@@ -129,7 +129,6 @@ export class FretHandFinger extends Modifier {
 
   setFretHandFinger(finger: string): this {
     this.text = finger;
-    this.measureText();
     return this;
   }
 

--- a/src/glyphnote.ts
+++ b/src/glyphnote.ts
@@ -32,7 +32,6 @@ export class GlyphNote extends Note {
 
   setGlyph(glyph: string): this {
     this.text = glyph;
-    this.measureText();
     return this;
   }
 

--- a/src/multimeasurerest.ts
+++ b/src/multimeasurerest.ts
@@ -75,7 +75,7 @@ export class MultiMeasureRest extends Element {
   constructor(numberOfMeasures: number, options: MultimeasureRestRenderOptions) {
     super();
     const fontSize = options.numberGlyphPoint ?? Tables.lookupMetric('MultiMeasureRest.fontSize'); // same as TimeSignature.
-    this.textFont.size = fontSize;
+    this.fontInfo.size = fontSize;
 
     this.numberOfMeasures = numberOfMeasures;
     this.text = '';
@@ -84,7 +84,6 @@ export class MultiMeasureRest extends Element {
       // 0xe080 is timeSig0. We calculate the code point for timeSigN to assemble the digits via SMuFL glyphs.
       this.text += String.fromCodePoint(0xe080 + Number(digit));
     }
-    this.measureText();
 
     // Keep track of whether these four options were provided.
     this.#hasPaddingLeft = typeof options.paddingLeft === 'number';

--- a/src/notehead.ts
+++ b/src/notehead.ts
@@ -96,8 +96,7 @@ export class NoteHead extends Note {
       glyphFontScale: noteStruct.glyphFontScale || Tables.lookupMetric('fontSize'),
     };
 
-    this.textFont.size = this.renderOptions.glyphFontScale;
-    this.measureText();
+    this.fontInfo.size = this.renderOptions.glyphFontScale;
   }
   /** Get the width of the notehead. */
   getWidth(): number {
@@ -160,7 +159,6 @@ export class NoteHead extends Note {
   preFormat(): this {
     if (this.preFormatted) return this;
 
-    this.measureText();
     this.preFormatted = true;
     return this;
   }

--- a/src/ornament.ts
+++ b/src/ornament.ts
@@ -169,7 +169,6 @@ export class Ornament extends Modifier {
     }
 
     this.text = Tables.ornamentCodes(this.type);
-    this.measureText();
   }
 
   /** Set note attached to ornament. */

--- a/src/stave.ts
+++ b/src/stave.ts
@@ -283,6 +283,8 @@ export class Stave extends Element {
   setSection(section: string, y: number, xOffset = 0, fontSize?: number, drawRect = true) {
     const staveSection = new StaveSection(section, this.x + xOffset, y, drawRect);
     if (fontSize) staveSection.setFontSize(fontSize);
+    staveSection.measureText();
+
     this.modifiers.push(staveSection);
     return this;
   }
@@ -305,10 +307,6 @@ export class Stave extends Element {
   ): this {
     this.modifiers.push(new StaveText(text, position, options));
     return this;
-  }
-
-  getHeight(): number {
-    return this.height;
   }
 
   getSpacingBetweenLines(): number {
@@ -730,7 +728,7 @@ export class Stave extends Element {
     // Render measure numbers
     if (this.measure > 0) {
       ctx.save();
-      ctx.setFont(this.textFont);
+      ctx.setFont(this.fontInfo);
       const textWidth = ctx.measureText('' + this.measure).width;
       y = this.getYForTopText(0) + 3;
       ctx.fillText('' + this.measure, this.x - textWidth / 2, y);

--- a/src/staveline.ts
+++ b/src/staveline.ts
@@ -76,8 +76,6 @@ export class StaveLine extends Element {
     textJustification: number;
   };
 
-  protected text: string;
-
   // These five instance variables are all initialized by the constructor via this.setNotes(notes).
   protected notes!: StaveLineNotes;
   protected firstNote!: StaveNote;
@@ -183,7 +181,7 @@ export class StaveLine extends Element {
   // Apply the text styling to the context
   applyFontStyle(): void {
     const ctx = this.checkContext();
-    ctx.setFont(this.textFont);
+    ctx.setFont(this.fontInfo);
 
     const renderOptions = this.renderOptions;
     const color = renderOptions.color;

--- a/src/stavenote.ts
+++ b/src/stavenote.ts
@@ -593,9 +593,9 @@ export class StaveNote extends StemmableNote {
 
   // Get the `BoundingBox` for the entire note
   getBoundingBox(): BoundingBox {
-    this.boundingBox = new BoundingBox(this.getAbsoluteX(), this.ys[0], 0, 0);
+    const boundingBox = new BoundingBox(this.getAbsoluteX(), this.ys[0], 0, 0);
     this.#noteHeads.forEach((notehead) => {
-      this.boundingBox?.mergeWith(notehead.getBoundingBox());
+      boundingBox.mergeWith(notehead.getBoundingBox());
     });
     const { yTop, yBottom } = this.getNoteHeadBounds();
     // eslint-disable-next-line
@@ -607,13 +607,13 @@ export class StaveNote extends StemmableNote {
         : yBottom - noteStemHeight + this.flag.getTextMetrics().actualBoundingBoxAscent;
 
     if (!this.isRest() && this.hasStem()) {
-      this.boundingBox?.mergeWith(new BoundingBox(this.getAbsoluteX(), flagY, 0, 0));
+      boundingBox.mergeWith(new BoundingBox(this.getAbsoluteX(), flagY, 0, 0));
     }
-    const bbFlag = this.flag.getBoundingBox();
-    if (!this.isRest() && bbFlag) {
-      this.boundingBox?.mergeWith(bbFlag.move(flagX, flagY));
+    if (this.hasFlag()) {
+      const bbFlag = this.flag.getBoundingBox();
+      boundingBox.mergeWith(bbFlag.move(flagX, flagY));
     }
-    return this.boundingBox;
+    return boundingBox;
   }
 
   // Gets the line number of the bottom note in the chord.

--- a/src/stavesection.ts
+++ b/src/stavesection.ts
@@ -23,7 +23,6 @@ export class StaveSection extends StaveModifier {
 
   setStaveSection(section: string): this {
     this.text = section;
-    this.measureText();
     return this;
   }
 

--- a/src/stavetempo.ts
+++ b/src/stavetempo.ts
@@ -65,8 +65,7 @@ export class StaveTempo extends StaveModifier {
 
     if (name) {
       this.text = name;
-      this.textFont = Tables.lookupMetricFontInfo('StaveTempo.name');
-      this.measureText();
+      this.fontInfo = Tables.lookupMetricFontInfo('StaveTempo.name');
       this.renderText(ctx, shiftX, y);
       x += this.getWidth();
     }

--- a/src/stavetext.ts
+++ b/src/stavetext.ts
@@ -26,7 +26,6 @@ export class StaveText extends StaveModifier {
     this.setYShift(options.shiftY ?? 0);
     this.position = position;
     this.justification = options.justification ?? TextNote.Justification.CENTER;
-    this.measureText();
   }
 
   draw(stave: Stave): this {

--- a/src/stavetie.ts
+++ b/src/stavetie.ts
@@ -167,7 +167,7 @@ export class StaveTie extends Element {
     const stave = this.notes.firstNote?.checkStave() ?? this.notes.lastNote?.checkStave();
     if (stave) {
       ctx.save();
-      ctx.setFont(this.textFont);
+      ctx.setFont(this.fontInfo);
       ctx.fillText(this.text, centerX + this.renderOptions.textShiftX, stave.getYForTopText() - 1);
       ctx.restore();
     }

--- a/src/stringnumber.ts
+++ b/src/stringnumber.ts
@@ -249,7 +249,7 @@ export class StringNumber extends Modifier {
       ctx.setLineWidth(1.5);
       ctx.stroke();
     }
-    ctx.setFont(this.textFont);
+    ctx.setFont(this.fontInfo);
     const x = dotX - ctx.measureText(this.stringNumber).width / 2;
     ctx.fillText('' + this.stringNumber, x, dotY + 4.5);
 

--- a/src/system.ts
+++ b/src/system.ts
@@ -300,7 +300,7 @@ export class System extends Element {
 
   /** Get the boundingBox. */
   getBoundingBox(): BoundingBox {
-    return new BoundingBox(this.options.x, this.options.y, this.options.width, this.lastY ?? 0 - this.options.y);
+    return new BoundingBox(this.options.x, this.options.y, this.options.width, (this.lastY ?? 0) - this.options.y);
   }
 
   /** Render the system. */

--- a/src/system.ts
+++ b/src/system.ts
@@ -295,8 +295,12 @@ export class System extends Element {
     this.startX = startX;
     this.debugNoteMetricsYs = debugNoteMetricsYs;
     this.lastY = y;
-    this.boundingBox = new BoundingBox(this.options.x, this.options.y, this.options.width, this.lastY - this.options.y);
     Stave.formatBegModifiers(this.partStaves);
+  }
+
+  /** Get the boundingBox. */
+  getBoundingBox(): BoundingBox {
+    return new BoundingBox(this.options.x, this.options.y, this.options.width, this.lastY ?? 0 - this.options.y);
   }
 
   /** Render the system. */

--- a/src/textbracket.ts
+++ b/src/textbracket.ts
@@ -81,7 +81,7 @@ export class TextBracket extends Element {
     this.textElement.measureText();
     this.superscriptElement = new Element('TextBracket');
     this.superscriptElement.setText(superscript);
-    const smallerFontSize = Font.scaleSize(this.textFont.size, 0.714286);
+    const smallerFontSize = Font.scaleSize(this.fontInfo.size, 0.714286);
     this.superscriptElement.setFontSize(smallerFontSize);
 
     this.position = typeof position === 'string' ? TextBracket.PositionString[position] : position;
@@ -108,9 +108,9 @@ export class TextBracket extends Element {
    * @returns this
    */
   applyStyle(ctx: RenderContext): this {
-    this.textElement.setFont(this.textFont);
+    this.textElement.setFont(this.fontInfo);
     // We called this.resetFont() in the constructor, so we know this.textFont is available.
-    const { family, size, weight, style } = this.textFont;
+    const { family, size, weight, style } = this.fontInfo;
     // To draw the superscript, we scale the font size by 1/1.4.
     const smallerFontSize = Font.scaleSize(size, 0.714286);
     this.superscriptElement.setFont(family, smallerFontSize, weight, style);

--- a/src/textdynamics.ts
+++ b/src/textdynamics.ts
@@ -60,7 +60,7 @@ export class TextDynamics extends Note {
     this.text = '';
 
     this.renderOptions = { glyphFontSize: Tables.lookupMetric('fontSize'), ...this.renderOptions };
-    this.textFont.size = defined(this.renderOptions.glyphFontSize) * this.renderOptions.glyphFontScale;
+    this.fontInfo.size = defined(this.renderOptions.glyphFontSize) * this.renderOptions.glyphFontScale;
     L('New Dynamics Text: ', this.sequence);
   }
 
@@ -86,8 +86,6 @@ export class TextDynamics extends Note {
       this.text += glyph;
     });
 
-    // Store the width of the text
-    this.measureText();
     this.preFormatted = true;
     return this;
   }

--- a/src/textnote.ts
+++ b/src/textnote.ts
@@ -78,20 +78,21 @@ export class TextNote extends Note {
       this.setFont(noteStruct.font);
     } else if (noteStruct.glyph === undefined) {
       this.setFont(Tables.lookupMetricFontInfo('TextNote.text.fontSize'));
-    } else {
-      this.measureText();
     }
+
     // Scale the font size by 1/1.3.
-    const smallerFontSize = Font.convertSizeToPointValue(this.textFont.size) * 0.769231;
+    const smallerFontSize = Font.convertSizeToPointValue(this.fontInfo.size) * 0.769231;
     if (noteStruct.superscript) {
       this.superscript = new Element('TexNote.subSuper');
       this.superscript.setText(noteStruct.superscript);
       this.superscript.setFontSize(smallerFontSize);
+      this.superscript.measureText();
     }
     if (noteStruct.subscript) {
       this.subscript = new Element('TexNote.subSuper');
       this.subscript.setText(noteStruct.subscript);
       this.subscript.setFontSize(smallerFontSize);
+      this.subscript.measureText();
     }
 
     this.line = noteStruct.line ?? 0;

--- a/src/timesignature.ts
+++ b/src/timesignature.ts
@@ -152,7 +152,6 @@ export class TimeSignature extends StaveModifier {
       const code = TimeSignature.getTimeSigCode(timeSpec);
       this.line = 2;
       this.text = code;
-      this.measureText();
       this.isNumeric = false;
     } else {
       if (this.validateArgs) {

--- a/src/tremolo.ts
+++ b/src/tremolo.ts
@@ -25,7 +25,6 @@ export class Tremolo extends Modifier {
     this.num = num;
     this.position = Modifier.Position.CENTER;
     this.text = '\uE220' /*tremolo1*/;
-    this.measureText();
   }
 
   /** Draw the tremolo on the rendering context. */
@@ -41,7 +40,7 @@ export class Tremolo extends Modifier {
     const x = note.getAbsoluteX() + (stemDirection === Stem.UP ? note.getGlyphWidth() - Stem.WIDTH / 2 : Stem.WIDTH / 2);
     let y = note.getStemExtents().topY + (this.num <= 3 ? ySpacing : 0);
 
-    this.textFont.size = Tables.lookupMetric(`Tremolo.fontSize`) * scale;
+    this.fontInfo.size = Tables.lookupMetric(`Tremolo.fontSize`) * scale;
 
     for (let i = 0; i < this.num; ++i) {
       this.renderText(ctx, x, y);

--- a/src/vibrato.ts
+++ b/src/vibrato.ts
@@ -68,13 +68,11 @@ export class Vibrato extends Modifier {
   setVibratoWidth(width: number): this {
     this.renderOptions.width = width;
     this.text = String.fromCodePoint(this.renderOptions.code);
-    this.measureText();
 
     const items = Math.round(this.renderOptions.width / this.getWidth());
     for (let i = 1; i < items; i++) {
       this.text += String.fromCodePoint(this.renderOptions.code);
     }
-    this.measureText();
 
     return this;
   }

--- a/src/voice.ts
+++ b/src/voice.ts
@@ -144,8 +144,6 @@ export class Voice extends Element {
   /** Set the voice's stave. */
   setStave(stave: Stave): this {
     this.stave = stave;
-    // Reset the bounding box so we can reformat.
-    this.boundingBox = undefined;
     return this;
   }
 
@@ -154,18 +152,15 @@ export class Voice extends Element {
   }
 
   /** Get the bounding box for the voice. */
-  getBoundingBox(): BoundingBox | undefined {
-    let boundingBox = undefined;
-    for (let i = 0; i < this.tickables.length; ++i) {
+  getBoundingBox(): BoundingBox {
+    const boundingBox = this.tickables[0].getBoundingBox();
+    for (let i = 1; i < this.tickables.length; ++i) {
       const tickable = this.tickables[i];
       if (!tickable.getStave() && this.stave) tickable.setStave(this.stave);
       const bb = tickable.getBoundingBox();
-      if (bb) {
-        boundingBox = boundingBox ? boundingBox.mergeWith(bb) : bb;
-      }
+      boundingBox.mergeWith(bb);
     }
-    this.boundingBox = boundingBox;
-    return this.boundingBox;
+    return boundingBox;
   }
 
   /** Set the voice mode to strict or soft. */
@@ -292,7 +287,6 @@ export class Voice extends Element {
   draw(context: RenderContext = this.checkContext(), stave?: Stave): void {
     stave = stave ?? this.stave;
     this.setRendered();
-    let boundingBox = undefined;
     for (let i = 0; i < this.tickables.length; ++i) {
       const tickable = this.tickables[i];
       // Set the stave if provided.
@@ -300,15 +294,9 @@ export class Voice extends Element {
         tickable.setStave(stave);
       }
       defined(tickable.getStave(), 'MissingStave', 'The voice cannot draw tickables without staves.');
-      const bb = tickable.getBoundingBox();
-      if (bb) {
-        boundingBox = boundingBox ? boundingBox.mergeWith(bb) : bb;
-      }
 
       tickable.setContext(context);
       tickable.drawWithStyle();
     }
-
-    this.boundingBox = boundingBox;
   }
 }

--- a/tests/mocks.ts
+++ b/tests/mocks.ts
@@ -15,7 +15,6 @@ class MockTickable extends Tickable {
   ticks: Fraction = new Fraction(1, 1);
   voice?: Voice;
   stave?: Stave;
-  width: number = 0;
   ignoreTicks: boolean = false;
 
   init(): void {


### PR DESCRIPTION
Reworlk to reduce the number of calls to measureText. Now only called when a recalculation is required based on #metricValid. No visual differences

current
![image](https://github.com/vexflow/vexflow/assets/22865285/26f17a53-7838-404a-abdb-fd341552bf81)
reference
![image](https://github.com/vexflow/vexflow/assets/22865285/29a87242-3d93-42e5-aa4d-0e17ca69902d)
