### PR TITLE
Run eslint.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -321,13 +321,7 @@ function webpackConfigs() {
   const WATCH = true;
 
   function prodConfig(watch = false) {
-    return getConfig(
-      [VEX],
-      PRODUCTION_MODE,
-      BANNER,
-      'Vex',
-      watch
-    );
+    return getConfig([VEX], PRODUCTION_MODE, BANNER, 'Vex', watch);
   }
 
   function debugConfig(watch = false) {
@@ -354,6 +348,11 @@ module.exports = (grunt) => {
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),
     webpack: webpackConfigs(),
+
+    eslint: {
+      target: ['src/**/*.ts', 'tests/**/*.ts', 'src/**/*.js', 'tests/**/*.js', 'entry/**/*.ts'],
+      options: {},
+    },
 
     // grunt qunit
     // Run unit tests on the command line by loading tests/flow-headless-browser.html.
@@ -427,6 +426,7 @@ module.exports = (grunt) => {
     },
   });
 
+  grunt.loadNpmTasks('grunt-eslint');
   grunt.loadNpmTasks('grunt-contrib-clean');
   grunt.loadNpmTasks('grunt-contrib-copy');
   grunt.loadNpmTasks('grunt-contrib-qunit');
@@ -441,6 +441,8 @@ module.exports = (grunt) => {
     'build:types',
     // 'build:docs',
   ]);
+
+  grunt.registerTask('lint', 'eslint', ['eslint']);
 
   // grunt test
   // Run command line qunit tests.

--- a/src/canvascontext.ts
+++ b/src/canvascontext.ts
@@ -115,7 +115,7 @@ export class CanvasContext extends RenderContext {
 
   openRotation(angleDegrees: number, x: number, y: number) {
     this.curTransfrom = this.context2D.getTransform();
-    this.context2D.translate(x,y);
+    this.context2D.translate(x, y);
     this.context2D.rotate((angleDegrees * Math.PI) / 180);
     this.context2D.translate(-x, -y);
   }

--- a/src/font.ts
+++ b/src/font.ts
@@ -1,4 +1,4 @@
-import { Tables } from "./tables";
+import { Tables } from './tables';
 
 export interface FontInfo {
   /** CSS font-family, e.g., 'Arial', 'Helvetica Neue, Arial, sans-serif', 'Times, serif' */
@@ -119,8 +119,8 @@ export class Font {
       family = f;
     }
 
-    family = family ?? Tables.lookupMetric('fontFamily') as string;
-    size = size ?? Tables.lookupMetric('fontSize')+'pt';
+    family = family ?? (Tables.lookupMetric('fontFamily') as string);
+    size = size ?? Tables.lookupMetric('fontSize') + 'pt';
     weight = weight ?? FontWeight.NORMAL;
     style = style ?? FontStyle.NORMAL;
 
@@ -189,7 +189,7 @@ export class Font {
     let size: string;
     const sz = fontInfo.size;
     if (sz === undefined) {
-      size = Tables.lookupMetric('fontSize')+'pt';
+      size = Tables.lookupMetric('fontSize') + 'pt';
     } else if (typeof sz === 'number') {
       size = sz + 'pt ';
     } else {

--- a/src/glyphs.ts
+++ b/src/glyphs.ts
@@ -75,7 +75,7 @@ export enum Glyphs {
   accSagittal23SmallDiesisUp = '\ue39e',
   // U+E307  25 small diesis down, 2° down [53 EDO]
   accSagittal25SmallDiesisDown = '\ue307',
-  // U+E306  25 small diesis up, (25S, ~5:13S, ~37S, 5C plus 5C), 2° up [53 EDO]
+  // U+E306  25 small diesis up, (25S, ~5:13S, ~37S, 5C plus 5C), 2° up [53 EDO]
   accSagittal25SmallDiesisUp = '\ue306',
   // U+E3F7  2 minas down, 65/77-schismina down, 0.83 cents down
   accSagittal2MinasDown = '\ue3f7',
@@ -91,7 +91,7 @@ export enum Glyphs {
   accSagittal35LargeDiesisUp = '\ue30e',
   // U+E309  35 medium diesis down, 1°[50] 2°[27] down, 2/9-tone down
   accSagittal35MediumDiesisDown = '\ue309',
-  // U+E308  35 medium diesis up, (35M, ~13M, ~125M, 5C plus 7C), 2/9-tone up
+  // U+E308  35 medium diesis up, (35M, ~13M, ~125M, 5C plus 7C), 2/9-tone up
   accSagittal35MediumDiesisUp = '\ue308',
   // U+E3FD  3 tinas down, 1 mina down, 1/(5⋅7⋅13)-schismina down, 0.42 cents down
   accSagittal3TinasDown = '\ue3fd',
@@ -151,7 +151,7 @@ export enum Glyphs {
   accSagittal5v49MediumDiesisUp = '\ue3a6',
   // U+E301  5:7 kleisma down
   accSagittal5v7KleismaDown = '\ue301',
-  // U+E300  5:7 kleisma up, (5:7k, ~11:13k, 7C less 5C)
+  // U+E300  5:7 kleisma up, (5:7k, ~11:13k, 7C less 5C)
   accSagittal5v7KleismaUp = '\ue300',
   // U+E403  6 tinas down, 2 minas down, 65/77-schismina down, 0.83 cents down
   accSagittal6TinasDown = '\ue403',

--- a/src/multimeasurerest.ts
+++ b/src/multimeasurerest.ts
@@ -125,7 +125,7 @@ export class MultiMeasureRest extends Element {
     return defined(this.stave, 'NoStave', 'No stave attached to instance.');
   }
 
-  drawLine(stave: Stave, ctx: RenderContext, left: number, right: number, spacingBetweenLines: number): void {
+  drawLine(stave: Stave, ctx: RenderContext, left: number, right: number): void {
     const options = this.renderOptions;
 
     const y = stave.getYForLine(options.line);
@@ -145,7 +145,7 @@ export class MultiMeasureRest extends Element {
     el.renderText(ctx, left + (right - left) * 0.5 - el.getWidth() * 0.5, y);
   }
 
-  drawSymbols(stave: Stave, ctx: RenderContext, left: number, right: number, spacingBetweenLines: number): void {
+  drawSymbols(stave: Stave, ctx: RenderContext, left: number, right: number): void {
     const n4 = Math.floor(this.numberOfMeasures / 4);
     const n = this.numberOfMeasures % 4;
     const n2 = Math.floor(n / 2);
@@ -210,11 +210,10 @@ export class MultiMeasureRest extends Element {
     this.xs.left = left;
     this.xs.right = right;
 
-    const spacingBetweenLines = options.spacingBetweenLinesPx;
     if (options.useSymbols) {
-      this.drawSymbols(stave, ctx, left, right, spacingBetweenLines);
+      this.drawSymbols(stave, ctx, left, right);
     } else {
-      this.drawLine(stave, ctx, left, right, spacingBetweenLines);
+      this.drawLine(stave, ctx, left, right);
     }
 
     if (options.showNumber) {

--- a/src/parenthesis.ts
+++ b/src/parenthesis.ts
@@ -5,7 +5,7 @@
 import { Modifier, ModifierPosition } from './modifier';
 import { ModifierContextState } from './modifiercontext';
 import { Note } from './note';
-import { Category, isGraceNote } from './typeguard';
+import { Category } from './typeguard';
 
 /** Parenthesis implements parenthesis modifiers for notes. */
 export class Parenthesis extends Modifier {

--- a/src/pedalmarking.ts
+++ b/src/pedalmarking.ts
@@ -53,7 +53,7 @@ export class PedalMarking extends Element {
   protected notes: StaveNote[];
 
   /** Glyph data */
-  static readonly GLYPHS: Record<string, string > = {
+  static readonly GLYPHS: Record<string, string> = {
     pedalDepress: '\uE650' /*keyboardPedalPed*/,
     pedalRelease: '\uE655' /*keyboardPedalUp*/,
   };

--- a/src/rendercontext.ts
+++ b/src/rendercontext.ts
@@ -79,7 +79,6 @@ export abstract class RenderContext {
   get font(): string {
     return this.getFont();
   }
-
 }
 
 /**

--- a/src/tables.ts
+++ b/src/tables.ts
@@ -251,7 +251,6 @@ const notesInfo: Record<
   {
     index: number;
     intVal?: number;
-
   }
 > = {
   C: { index: 0, intVal: 0 },

--- a/src/tabnote.ts
+++ b/src/tabnote.ts
@@ -220,7 +220,7 @@ export class TabNote extends StemmableNote {
     return this.flag.getHeight() > Stem.HEIGHT ? this.flag.getHeight() - Stem.HEIGHT : 0;
   }
 
-  static tabToElement(fret: string, scale: number = 1.0): Element {
+  static tabToElement(fret: string): Element {
     let el: Element;
 
     if (fret.toUpperCase() === 'X') {
@@ -242,7 +242,7 @@ export class TabNote extends StemmableNote {
     for (let i = 0; i < this.positions.length; ++i) {
       let fret = this.positions[i].fret;
       if (this.ghost) fret = '(' + fret + ')';
-      const el = TabNote.tabToElement(fret.toString(), this.renderOptions.scale);
+      const el = TabNote.tabToElement(fret.toString());
       this.fretElement.push(el);
       this.width = Math.max(el.getWidth(), this.width);
     }

--- a/src/tremolo.ts
+++ b/src/tremolo.ts
@@ -37,7 +37,8 @@ export class Tremolo extends Modifier {
     const scale = isGraceNote(note) ? GraceNote.SCALE : 1;
     const ySpacing = Tables.lookupMetric(`Tremolo.spacing`) * stemDirection * scale;
 
-    const x = note.getAbsoluteX() + (stemDirection === Stem.UP ? note.getGlyphWidth() - Stem.WIDTH / 2 : Stem.WIDTH / 2);
+    const x =
+      note.getAbsoluteX() + (stemDirection === Stem.UP ? note.getGlyphWidth() - Stem.WIDTH / 2 : Stem.WIDTH / 2);
     let y = note.getStemExtents().topY + (this.num <= 3 ? ySpacing : 0);
 
     this.fontInfo.size = Tables.lookupMetric(`Tremolo.fontSize`) * scale;

--- a/tests/beam_tests.ts
+++ b/tests/beam_tests.ts
@@ -11,7 +11,6 @@ import {
   AnnotationVerticalJustify,
   Beam,
   Dot,
-  Font,
   FontStyle,
   FontWeight,
   StaveNoteStruct,
@@ -20,6 +19,7 @@ import {
   TabNoteStruct,
   Voice,
 } from '../src/index';
+
 import { Tables } from '../src/tables';
 
 const BeamTests = {

--- a/tests/tabnote_tests.ts
+++ b/tests/tabnote_tests.ts
@@ -82,7 +82,6 @@ function width(assert: Assert): void {
   assert.throws(() => note.getWidth(), /UnformattedNote/, 'Unformatted note should have no width');
 }
 
-
 function draw(options: TestOptions, contextBuilder: ContextBuilder): void {
   const ctx = contextBuilder(options.elementId, 600, 140);
   ctx.font = '10pt Arial';


### PR DESCRIPTION
I ran eslint and fixed a bunch of issues it highlighted:

```
vexflow/src/canvascontext.ts
  118:32  warning  Insert `·`  prettier/prettier

vexflow/src/font.ts
  1:10  error  'TupletMetrics' is defined but never used  @typescript-eslint/no-unused-vars
  2:10  error  'defined' is defined but never used        @typescript-eslint/no-unused-vars

vexflow/src/glyphs.ts
    78:56  error  Irregular whitespace not allowed  no-irregular-whitespace
    78:61  error  Irregular whitespace not allowed  no-irregular-whitespace
    94:56  error  Irregular whitespace not allowed  no-irregular-whitespace
    94:61  error  Irregular whitespace not allowed  no-irregular-whitespace
   154:48  error  Irregular whitespace not allowed  no-irregular-whitespace
   154:53  error  Irregular whitespace not allowed  no-irregular-whitespace
  3591:3   error  Duplicate enum member value 𝆹    @typescript-eslint/no-duplicate-enum-values

vexflow/src/multimeasurerest.ts
  129:75  error  'spacingBetweenLines' is defined but never used  @typescript-eslint/no-unused-vars
  151:78  error  'spacingBetweenLines' is defined but never used  @typescript-eslint/no-unused-vars

vexflow/src/parenthesis.ts
  8:20  error  'isGraceNote' is defined but never used  @typescript-eslint/no-unused-vars

vexflow/src/pedalmarking.ts
  57:48  warning  Delete `·`  prettier/prettier

vexflow/src/rendercontext.ts
  82:1  warning  Delete `⏎`  prettier/prettier

vexflow/src/tables.ts
  262:1  warning  Delete `⏎`  prettier/prettier

vexflow/src/tabnote.ts
  223:37  error  'scale' is assigned a value but never used  @typescript-eslint/no-unused-vars

vexflow/src/tremolo.ts
  41:14  warning  Insert `⏎·····`  prettier/prettier

vexflow/tests/beam_tests.ts
   8:1  warning  Run autofix to sort these imports!  simple-import-sort/imports
  14:3  error    'Font' is defined but never used    @typescript-eslint/no-unused-vars

vexflow/tests/tabnote_tests.ts
  85:1  warning  Delete `⏎`  prettier/prettier

✖ 21 problems (14 errors, 7 warnings)
  0 errors and 7 warnings potentially fixable with the `--fix` option.
```