### PR TITLE
Hotfix ornament delayed draw

### DIFF
--- a/src/ornament.ts
+++ b/src/ornament.ts
@@ -10,7 +10,6 @@ import { ModifierContextState } from './modifiercontext';
 import { Note } from './note';
 import { StemmableNote } from './stemmablenote';
 import { Tables } from './tables';
-import { TickContext } from './tickcontext';
 import { Category } from './typeguard';
 import { log } from './util';
 
@@ -243,11 +242,13 @@ export class Ornament extends Modifier {
       if (this.delayXShift !== undefined) {
         delayXShift = this.delayXShift;
       } else {
-        const nextContext = TickContext.getNextContext(note.getTickContext());
+        const tickables = note.getVoice().getTickables();
+        const index = tickables.indexOf(note);
+        const nextContext = index + 1 < tickables.length ? tickables[index + 1].checkTickContext() : undefined;
         if (nextContext) {
           delayXShift += (nextContext.getX() - startX) * 0.5;
         } else {
-          delayXShift += (stave.getX() + stave.getWidth() - startX) * 0.5;
+          delayXShift += (stave.getX() + stave.getWidth() - glyphX) * 0.5;
         }
         this.delayXShift = delayXShift;
       }

--- a/tests/ornament_tests.ts
+++ b/tests/ornament_tests.ts
@@ -28,6 +28,7 @@ const OrnamentTests = {
     run('Ornaments Vertically Shifted', drawOrnamentsDisplaced);
     run('Ornaments - Delayed turns', drawOrnamentsDelayed);
     run('Ornaments - Delayed turns, Multiple Draws', drawOrnamentsDelayedMultipleDraws);
+    run('Ornaments - Delayed turns, Multiple Voices', drawOrnamentsDelayedMultipleVoices);
     run('Stacked', drawOrnamentsStacked);
     run('With Upper/Lower Accidentals', drawOrnamentsWithAccidentals);
     run('Jazz Ornaments', jazzOrnaments);
@@ -165,6 +166,46 @@ function drawOrnamentsDelayedMultipleDraws(options: TestOptions): void {
   // However, if you inspect the SVG element, you will see duplicate paths.
   Formatter.FormatAndDraw(context, stave, notes);
   Formatter.FormatAndDraw(context, stave, notes);
+}
+
+function drawOrnamentsDelayedMultipleVoices(options: TestOptions, contextBuilder: ContextBuilder): void {
+  options.assert.expect(0);
+
+  // Get the rendering context
+  const ctx = contextBuilder(options.elementId, 550, 195);
+
+  const stave = new Stave(10, 30, 500);
+  stave.addClef('treble');
+  stave.addKeySignature('C#');
+  stave.addTimeSignature('4/4');
+
+  const notes1 = [
+    new StaveNote({ keys: ['f/5'], duration: '2r'}),
+    new StaveNote({ keys: ['c/5'], duration: '2', stem_direction: 1 }),
+  ];
+  const notes2 = [
+    new StaveNote({ keys: ['a/4'], duration: '4', stem_direction: -1 }),
+    new StaveNote({ keys: ['e/4'], duration: '4r'}),
+    new StaveNote({ keys: ['e/4'], duration: '2r'}),
+  ];
+
+  notes1[1].addModifier(new Ornament('turn_inverted').setDelayed(true), 0);
+  notes2[0].addModifier(new Ornament('turn').setDelayed(true), 0);
+
+  const voice1 = new Voice({ num_beats: 4, beat_value: 4, });
+  voice1.addTickables(notes1);
+  const voice2 = new Voice({ num_beats: 4, beat_value: 4, });
+  voice2.addTickables(notes2);
+
+  const formatWidth = stave.getNoteEndX() - stave.getNoteStartX();
+  const formatter = new Formatter();
+  formatter.joinVoices([voice1]);
+  formatter.joinVoices([voice2]);
+  formatter.format([voice1, voice2], formatWidth);
+
+  stave.setContext(ctx).draw();
+  voice1.draw(ctx, stave);
+  voice2.draw(ctx, stave);
 }
 
 function drawOrnamentsStacked(options: TestOptions): void {

--- a/tests/ornament_tests.ts
+++ b/tests/ornament_tests.ts
@@ -180,21 +180,21 @@ function drawOrnamentsDelayedMultipleVoices(options: TestOptions, contextBuilder
   stave.addTimeSignature('4/4');
 
   const notes1 = [
-    new StaveNote({ keys: ['f/5'], duration: '2r'}),
-    new StaveNote({ keys: ['c/5'], duration: '2', stem_direction: 1 }),
+    new StaveNote({ keys: ['f/5'], duration: '2r' }),
+    new StaveNote({ keys: ['c/5'], duration: '2', stemDirection: 1 }),
   ];
   const notes2 = [
-    new StaveNote({ keys: ['a/4'], duration: '4', stem_direction: -1 }),
-    new StaveNote({ keys: ['e/4'], duration: '4r'}),
-    new StaveNote({ keys: ['e/4'], duration: '2r'}),
+    new StaveNote({ keys: ['a/4'], duration: '4', stemDirection: -1 }),
+    new StaveNote({ keys: ['e/4'], duration: '4r' }),
+    new StaveNote({ keys: ['e/4'], duration: '2r' }),
   ];
 
-  notes1[1].addModifier(new Ornament('turn_inverted').setDelayed(true), 0);
+  notes1[1].addModifier(new Ornament('turnInverted').setDelayed(true), 0);
   notes2[0].addModifier(new Ornament('turn').setDelayed(true), 0);
 
-  const voice1 = new Voice({ num_beats: 4, beat_value: 4, });
+  const voice1 = new Voice({ numBeats: 4, beatValue: 4 });
   voice1.addTickables(notes1);
-  const voice2 = new Voice({ num_beats: 4, beat_value: 4, });
+  const voice2 = new Voice({ numBeats: 4, beatValue: 4 });
   voice2.addTickables(notes2);
 
   const formatWidth = stave.getNoteEndX() - stave.getNoteStartX();


### PR DESCRIPTION
Port from https://github.com/0xfe/vexflow/pull/1598
Issue this repository https://github.com/vexflow/vexflow/issues/118

I tried porting it, but the Y coordinate of the turn of the lower voice went down. Can I assume this is an intended change in VexFlow 5?
This change only affects the X coordinate.

**VexFlow 4**
![image](https://github.com/vexflow/vexflow/assets/36094352/93c9976a-2ffc-44ad-b168-6731eff3511b)

**VexFlow5**
![image](https://github.com/vexflow/vexflow/assets/36094352/a3cb3027-a38d-47ad-9efc-9ad9be87c0fe)
