### PR TITLE
calculate width without stave

### DIFF
--- a/src/keysignature.ts
+++ b/src/keysignature.ts
@@ -165,7 +165,7 @@ export class KeySignature extends StaveModifier {
   }
 
   getWidth(): number {
-    if (!this.formatted) this.format();
+    if (!this.formatted) this.calculateWidth();
 
     return this.width;
   }
@@ -227,6 +227,30 @@ export class KeySignature extends StaveModifier {
     }
 
     this.formatted = true;
+  }
+
+  protected calculateWidth(): void {
+    this.width = 0;
+    this.accList = Tables.keySignature(defined(this.keySpec));
+    if (this.cancelKeySpec) {
+      this.convertToCancelAccList(this.cancelKeySpec);
+    }
+    if (this.alterKeySpec) {
+      this.convertToAlterAccList(this.alterKeySpec);
+    }
+
+    if (this.accList.length > 0) {
+      for (let i = 0; i < this.accList.length; ++i) {
+        const code = Tables.accidentalCodes(this.accList[i].type);
+        const glyph = new Element(Category.KeySignature);
+        glyph.setText(code);
+        // Determine spacing between current accidental and the next accidental
+        const extraWidth = 1;
+
+        // Expand size of key signature
+        this.width += glyph.getWidth() + extraWidth;
+      }
+    }
   }
 
   draw(): void {


### PR DESCRIPTION
Allows to get the width without having an assigned stave.

@ronyeh Request from @jaredjj3 to your question in https://github.com/stringsync/vexml/issues/113