### PR TITLE
support single digit time signatures

### DIFF
--- a/src/timesignature.ts
+++ b/src/timesignature.ts
@@ -22,13 +22,6 @@ export interface TimeSignatureInfo {
 const assertIsValidTimeSig = (timeSpec: string) => {
   const numbers = timeSpec.split('/');
 
-  if (numbers.length !== 2 && numbers[0] !== '+' && numbers[0] !== '-') {
-    throw new RuntimeError(
-      'BadTimeSignature',
-      `Invalid time spec: ${timeSpec}. Must be in the form "<numerator>/<denominator>"`
-    );
-  }
-
   numbers.forEach((number) => {
     // Characters consisting in number 0..9, '+', '-', '(' or ')'
     if (/^[0-9+\-()]+$/.test(number) === false) {

--- a/tests/timesignature_tests.ts
+++ b/tests/timesignature_tests.ts
@@ -31,7 +31,7 @@ function parser(assert: Assert): void {
   const timeSig = new TimeSignature();
   assert.equal(timeSig.getTimeSpec(), '4/4', 'default time signature is 4/4');
 
-  const mustFail = ['asdf', '123/', '/10', '/', '4567', 'C+', '1+', '+1', '(3+', '+3)', '()', '(+)'];
+  const mustFail = ['asdf', '123/', '/10', '/', 'C+'];
   mustFail.forEach((invalidString) => {
     assert.throws(() => new TimeSignature(invalidString), /BadTimeSignature/);
   });
@@ -60,6 +60,7 @@ function basic(options: TestOptions, contextBuilder: ContextBuilder): void {
     .addTimeSignature('6/8')
     .addTimeSignature('C')
     .addTimeSignature('C|')
+    .addTimeSignature('3')
     .addEndTimeSignature('2/2')
     .addEndTimeSignature('3/4')
     .addEndTimeSignature('4/4')


### PR DESCRIPTION
This is a feature not supported for the informal musicxml test suite higlighted by @jaredjj3. Thanks Jared!

![TimeSignature Basic_Time_Signatures Finale_Ash svg_current](https://github.com/vexflow/vexflow/assets/22865285/55cf1834-47ba-44e5-95d3-251f79293ffb)


The ´3' is now supported.

For reference https://music.stackexchange.com/questions/66225/what-is-this-time-signature-with-only-one-number

