### PR TITLE
Fix JSFiddle examples (doctype and meta charset declarations).

### DIFF
--- a/demos/jsfiddle/gracenotes.html
+++ b/demos/jsfiddle/gracenotes.html
@@ -1,14 +1,19 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-  <style>
-    canvas {
-      border: 1px solid gray;
-    }
-  </style>
+  <head>
+    <!-- IMPORTANT: Set the character set to UTF-8. Otherwise you may get weird symbols on the score. -->
+    <meta charset="utf-8" />
+    <style>
+      canvas {
+        border: 1px solid gray;
+      }
+    </style>
+  </head>
   <!-- This example is available at: https://jsfiddle.net/smyht3q5/ -->
   <body>
-    <canvas id="output"></canvas>
-    <script src="https://cdn.jsdelivr.net/npm/vexflow/build/cjs/vexflow.js"></script>
+    <canvas id="output" width="520" height="210"></canvas>
+    <!-- <script src="https://cdn.jsdelivr.net/npm/vexflow/build/cjs/vexflow.js"></script> -->
+    <script src="../../build/cjs/vexflow.js"></script>
     <script>
       const canvas = document.getElementById('output');
 
@@ -19,159 +24,163 @@
       const context = renderer.getContext();
       renderer.resize(520, 210);
 
-      const TIME4_4 = {
-        numBeats: 4,
-        beatValue: 4,
-        resolution: Vex.Flow.RESOLUTION,
-      };
+      Vex.Flow.loadFonts('Bravura', 'Academico').then(drawStave);
 
-      // Create and draw the tablature stave
-      const stave = new Stave(10, 40, 500);
-      stave.setContext(context).draw();
+      function drawStave() {
+        const TIME4_4 = {
+          numBeats: 4,
+          beatValue: 4,
+          resolution: Vex.Flow.RESOLUTION,
+        };
 
-      function note(params) {
-        return new StaveNote(params);
+        // Create and draw the tablature stave
+        const stave = new Stave(10, 40, 500);
+        stave.setContext(context).draw();
+
+        function note(params) {
+          return new StaveNote(params);
+        }
+
+        const notesA = [
+          note({
+            keys: ['f/5'],
+            stemDirection: Stem.UP,
+            duration: '16',
+          }),
+          note({
+            keys: ['f/5'],
+            stemDirection: Stem.UP,
+            duration: '16',
+          }),
+          note({
+            keys: ['d/5'],
+            stemDirection: Stem.UP,
+            duration: '16',
+          }),
+          note({
+            keys: ['c/5'],
+            stemDirection: Stem.UP,
+            duration: '16',
+          }),
+          note({
+            keys: ['c/5'],
+            stemDirection: Stem.UP,
+            duration: '16',
+          }),
+          note({
+            keys: ['d/5'],
+            stemDirection: Stem.UP,
+            duration: '16',
+          }),
+          note({
+            keys: ['f/5'],
+            stemDirection: Stem.UP,
+            duration: '16',
+          }),
+          note({
+            keys: ['e/5'],
+            stemDirection: Stem.UP,
+            duration: '16',
+          }),
+        ];
+
+        const notesB = [
+          note({
+            keys: ['f/4'],
+            stemDirection: Stem.DOWN,
+            duration: '16',
+          }),
+          note({
+            keys: ['e/4'],
+            stemDirection: Stem.DOWN,
+            duration: '16',
+          }),
+          note({
+            keys: ['d/4'],
+            stemDirection: Stem.DOWN,
+            duration: '16',
+          }),
+          note({
+            keys: ['c/4'],
+            stemDirection: Stem.DOWN,
+            duration: '16',
+          }),
+          note({
+            keys: ['c/4'],
+            stemDirection: Stem.DOWN,
+            duration: '16',
+          }),
+          note({
+            keys: ['d/4'],
+            stemDirection: Stem.DOWN,
+            duration: '16',
+          }),
+          note({
+            keys: ['f/4'],
+            stemDirection: Stem.DOWN,
+            duration: '16',
+          }),
+          note({
+            keys: ['e/4'],
+            stemDirection: Stem.DOWN,
+            duration: '16',
+          }),
+        ];
+
+        const graceNotes1 = [
+          new GraceNote({
+            keys: ['b/4'],
+            duration: '8',
+            slash: true,
+          }),
+        ];
+        const graceNotes2 = [
+          new GraceNote({
+            keys: ['f/4'],
+            duration: '8',
+            slash: true,
+          }),
+        ];
+        const graceNotes3 = [
+          new GraceNote({
+            keys: ['f/4'],
+            duration: '32',
+            stemDirection: Stem.DOWN,
+          }),
+          new GraceNote({
+            keys: ['e/4'],
+            duration: '32',
+            stemDirection: Stem.DOWN,
+          }),
+        ];
+
+        graceNotes2[0].setStemDirection(-1);
+        graceNotes2[0].addModifier(new Accidental('#'));
+
+        notesA[3].addModifier(new GraceNoteGroup(graceNotes1));
+        notesB[1].addModifier(new GraceNoteGroup(graceNotes2).beamNotes());
+        notesB[5].addModifier(new GraceNoteGroup(graceNotes3).beamNotes());
+
+        const voiceA = new Voice(TIME4_4).setStrict(false);
+        const voiceB = new Voice(TIME4_4).setStrict(false);
+        voiceA.addTickables(notesA);
+        voiceB.addTickables(notesB);
+
+        const formatter = new Formatter().joinVoices([voiceA, voiceB]).formatToStave([voiceA, voiceB], stave);
+        const beam1_1 = new Beam(notesA.slice(0, 4));
+        const beam1_2 = new Beam(notesA.slice(4, 8));
+
+        const beam2_1 = new Beam(notesB.slice(0, 4));
+        const beam2_2 = new Beam(notesB.slice(4, 8));
+
+        voiceA.draw(context, stave);
+        voiceB.draw(context, stave);
+        beam1_1.setContext(context).draw();
+        beam1_2.setContext(context).draw();
+
+        beam2_1.setContext(context).draw();
+        beam2_2.setContext(context).draw();
       }
-
-      const notesA = [
-        note({
-          keys: ['f/5'],
-          stemDirection: Stem.UP,
-          duration: '16',
-        }),
-        note({
-          keys: ['f/5'],
-          stemDirection: Stem.UP,
-          duration: '16',
-        }),
-        note({
-          keys: ['d/5'],
-          stemDirection: Stem.UP,
-          duration: '16',
-        }),
-        note({
-          keys: ['c/5'],
-          stemDirection: Stem.UP,
-          duration: '16',
-        }),
-        note({
-          keys: ['c/5'],
-          stemDirection: Stem.UP,
-          duration: '16',
-        }),
-        note({
-          keys: ['d/5'],
-          stemDirection: Stem.UP,
-          duration: '16',
-        }),
-        note({
-          keys: ['f/5'],
-          stemDirection: Stem.UP,
-          duration: '16',
-        }),
-        note({
-          keys: ['e/5'],
-          stemDirection: Stem.UP,
-          duration: '16',
-        }),
-      ];
-
-      const notesB = [
-        note({
-          keys: ['f/4'],
-          stemDirection: Stem.DOWN,
-          duration: '16',
-        }),
-        note({
-          keys: ['e/4'],
-          stemDirection: Stem.DOWN,
-          duration: '16',
-        }),
-        note({
-          keys: ['d/4'],
-          stemDirection: Stem.DOWN,
-          duration: '16',
-        }),
-        note({
-          keys: ['c/4'],
-          stemDirection: Stem.DOWN,
-          duration: '16',
-        }),
-        note({
-          keys: ['c/4'],
-          stemDirection: Stem.DOWN,
-          duration: '16',
-        }),
-        note({
-          keys: ['d/4'],
-          stemDirection: Stem.DOWN,
-          duration: '16',
-        }),
-        note({
-          keys: ['f/4'],
-          stemDirection: Stem.DOWN,
-          duration: '16',
-        }),
-        note({
-          keys: ['e/4'],
-          stemDirection: Stem.DOWN,
-          duration: '16',
-        }),
-      ];
-
-      const graceNotes1 = [
-        new GraceNote({
-          keys: ['b/4'],
-          duration: '8',
-          slash: true,
-        }),
-      ];
-      const graceNotes2 = [
-        new GraceNote({
-          keys: ['f/4'],
-          duration: '8',
-          slash: true,
-        }),
-      ];
-      const graceNotes3 = [
-        new GraceNote({
-          keys: ['f/4'],
-          duration: '32',
-          stemDirection: Stem.DOWN,
-        }),
-        new GraceNote({
-          keys: ['e/4'],
-          duration: '32',
-          stemDirection: Stem.DOWN,
-        }),
-      ];
-
-      graceNotes2[0].setStemDirection(-1);
-      graceNotes2[0].addModifier(new Accidental('#'));
-
-      notesA[3].addModifier(new GraceNoteGroup(graceNotes1));
-      notesB[1].addModifier(new GraceNoteGroup(graceNotes2).beamNotes());
-      notesB[5].addModifier(new GraceNoteGroup(graceNotes3).beamNotes());
-
-      const voiceA = new Voice(TIME4_4).setStrict(false);
-      const voiceB = new Voice(TIME4_4).setStrict(false);
-      voiceA.addTickables(notesA);
-      voiceB.addTickables(notesB);
-
-      const formatter = new Formatter().joinVoices([voiceA, voiceB]).formatToStave([voiceA, voiceB], stave);
-      const beam1_1 = new Beam(notesA.slice(0, 4));
-      const beam1_2 = new Beam(notesA.slice(4, 8));
-
-      const beam2_1 = new Beam(notesB.slice(0, 4));
-      const beam2_2 = new Beam(notesB.slice(4, 8));
-
-      voiceA.draw(context, stave);
-      voiceB.draw(context, stave);
-      beam1_1.setContext(context).draw();
-      beam1_2.setContext(context).draw();
-
-      beam2_1.setContext(context).draw();
-      beam2_2.setContext(context).draw();
     </script>
   </body>
 </html>

--- a/demos/jsfiddle/sandbox.html
+++ b/demos/jsfiddle/sandbox.html
@@ -1,39 +1,46 @@
-<!DOCTYPE >
+<!doctype html>
 <!-- 
   This example is available at:
   https://jsfiddle.net/wjm3t5su/ -->
 <html>
-  <style>
-    body {
-      font-family: Arial, 'sans-serif';
-    }
-  </style>
+  <head>
+    <!-- IMPORTANT: Set the character set to UTF-8. Otherwise you may get weird symbols on the score. -->
+    <meta charset="utf-8" />
+    <style>
+      body {
+        font-family: sans-serif;
+      }
+    </style>
+  </head>
   <body>
     <div id="output"></div>
-    <script src="https://cdn.jsdelivr.net/npm/vexflow/build/cjs/vexflow.js"></script>
+    <!-- <script src="https://cdn.jsdelivr.net/npm/vexflow/build/cjs/vexflow.js"></script> -->
+    <script src="../../build/cjs/vexflow.js"></script>
     <script>
       const { Renderer, Stave } = Vex.Flow;
 
-      // Vex.Flow.setFonts('Bravura');
-      // Vex.Flow.setFonts('Gonville');
-      Vex.Flow.setFonts('Petaluma');
+      Vex.Flow.loadFonts('Bravura', 'Petaluma').then(() => {
+        // Vex.Flow.setFonts('Bravura');
+        // Vex.Flow.setFonts('Gonville');
+        Vex.Flow.setFonts('Petaluma');
 
-      // Create an SVG renderer and attach it to the DIV element with id="output".
-      const div = document.getElementById('output');
-      const renderer = new Renderer(div, Renderer.Backends.SVG);
+        // Create an SVG renderer and attach it to the DIV element with id="output".
+        const div = document.getElementById('output');
+        const renderer = new Renderer(div, Renderer.Backends.SVG);
 
-      // Configure the rendering context.
-      renderer.resize(800, 500);
-      const context = renderer.getContext();
+        // Configure the rendering context.
+        renderer.resize(800, 500);
+        const context = renderer.getContext();
 
-      // Create a stave of width 400 at position 10, 40 on the canvas.
-      const stave = new Stave(10, 40, 400);
+        // Create a stave of width 400 at position 10, 40 on the canvas.
+        const stave = new Stave(10, 40, 400);
 
-      // Add a clef and time signature.
-      stave.addClef('treble').addTimeSignature('4/4');
+        // Add a clef and time signature.
+        stave.addClef('treble').addTimeSignature('4/4');
 
-      // Connect it to the rendering context and draw!
-      stave.setContext(context).draw();
+        // Connect it to the rendering context and draw!
+        stave.setContext(context).draw();
+      });
     </script>
   </body>
 </html>

--- a/demos/jsfiddle/tutorial/step1_basics.html
+++ b/demos/jsfiddle/tutorial/step1_basics.html
@@ -1,40 +1,44 @@
-<!DOCTYPE >
+<!doctype html>
 <!-- 
 This example is available at: https://jsfiddle.net/cwnsrep9/
 It is included in the VexFlow Tutorial: https://github.com/0xfe/vexflow/wiki/Tutorial
 -->
 <html>
-  <style>
-    body {
-      font-family: Arial, 'sans-serif';
-    }
-  </style>
+  <head>
+    <!-- IMPORTANT: Set the character set to UTF-8. Otherwise you may get weird symbols on the score. -->
+    <meta charset="utf-8" />
+  </head>
   <body>
     <div id="output"></div>
     <!--
     On JSFiddle.net, we pin the dependency to an exact version number,
     to prevent a future release from accidentally breaking the example. 
     -->
-    <script src="https://cdn.jsdelivr.net/npm/vexflow/build/cjs/vexflow.js"></script>
+    <!-- <script src="https://cdn.jsdelivr.net/npm/vexflow/build/cjs/vexflow.js"></script> -->
+    <script src="../../../build/cjs/vexflow.js"></script>
     <script>
-      const { Renderer, Stave } = Vex.Flow;
+      Vex.Flow.loadFonts('Bravura', 'Academico').then(drawStave);
 
-      // Create an SVG renderer and attach it to the DIV element named "boo".
-      const div = document.getElementById('output');
-      const renderer = new Renderer(div, Renderer.Backends.SVG);
+      function drawStave() {
+        const { Renderer, Stave } = Vex.Flow;
 
-      // Configure the rendering context.
-      renderer.resize(500, 500);
-      const context = renderer.getContext();
+        // Create an SVG renderer and attach it to the DIV element named "boo".
+        const div = document.getElementById('output');
+        const renderer = new Renderer(div, Renderer.Backends.SVG);
 
-      // Create a stave of width 400 at position 10, 40 on the canvas.
-      const stave = new Stave(10, 40, 400);
+        // Configure the rendering context.
+        renderer.resize(500, 500);
+        const context = renderer.getContext();
 
-      // Add a clef and time signature.
-      stave.addClef('treble').addTimeSignature('4/4');
+        // Create a stave of width 400 at position 10, 40 on the canvas.
+        const stave = new Stave(10, 40, 400);
 
-      // Connect it to the rendering context and draw!
-      stave.setContext(context).draw();
+        // Add a clef and time signature.
+        stave.addClef('treble').addTimeSignature('4/4');
+
+        // Connect it to the rendering context and draw!
+        stave.setContext(context).draw();
+      }
     </script>
   </body>
 </html>

--- a/demos/jsfiddle/tutorial/step2_addnotes.html
+++ b/demos/jsfiddle/tutorial/step2_addnotes.html
@@ -1,81 +1,89 @@
-<!DOCTYPE >
+<!doctype html>
 <!-- 
 This example is available at: https://jsfiddle.net/c36p8eo2/
 It is included in the VexFlow Tutorial: https://github.com/0xfe/vexflow/wiki/Tutorial
 -->
 <html>
-  <style>
-    body {
-      font-family: Arial, 'sans-serif';
-    }
-  </style>
+  <head>
+    <!-- IMPORTANT: Set the character set to UTF-8. Otherwise you may get weird symbols on the score. -->
+    <meta charset="utf-8" />
+    <style>
+      body {
+        font-family: sans-serif;
+      }
+    </style>
+  </head>
   <body>
     <div id="output"></div>
     <!--
     On JSFiddle.net, we pin the dependency to an exact version number,
     to prevent a future release from accidentally breaking the example. 
     -->
-    <script src="https://cdn.jsdelivr.net/npm/vexflow/build/cjs/vexflow.js"></script>
+    <!-- <script src="https://cdn.jsdelivr.net/npm/vexflow/build/cjs/vexflow.js"></script> -->
+    <script src="../../../build/cjs/vexflow.js"></script>
     <script>
-      const { Renderer, Stave, StaveNote, Voice, Formatter } = Vex.Flow;
+      Vex.Flow.loadFonts('Bravura', 'Academico').then(drawStave);
+      function drawStave() {
+        const { Renderer, Stave, StaveNote, Voice, Formatter } = Vex.Flow;
 
-      // Create an SVG renderer and attach it to the DIV element named "boo".
-      const div = document.getElementById('output');
-      const renderer = new Renderer(div, Renderer.Backends.SVG);
+        // Create an SVG renderer and attach it to the DIV element named "boo".
+        const div = document.getElementById('output');
+        const renderer = new Renderer(div, Renderer.Backends.SVG);
 
-      // Configure the rendering context.
-      renderer.resize(500, 500);
-      const context = renderer.getContext();
+        // Configure the rendering context.
+        renderer.resize(500, 500);
+        const context = renderer.getContext();
 
-      // Create a stave of width 400 at position 10, 40 on the canvas.
-      const stave = new Stave(10, 40, 400);
+        // Create a stave of width 400 at position 10, 40 on the canvas.
+        const stave = new Stave(10, 40, 400);
 
-      // Add a clef and time signature.
-      stave.addClef('treble').addTimeSignature('4/4');
+        // Add a clef and time signature.
+        stave.addClef('treble').addTimeSignature('4/4');
 
-      // Connect it to the rendering context and draw!
-      stave.setContext(context).draw();
+        // Connect it to the rendering context and draw!
+        stave.setContext(context).draw();
 
-      // Create the notes
-      const notes = [
-        // A quarter-note C.
-        new StaveNote({
-          keys: ['c/4'],
-          duration: 'q',
-        }),
+        // Create the notes
+        const notes = [
+          // A quarter-note C.
+          new StaveNote({
+            keys: ['c/4'],
+            duration: 'q',
+          }),
 
-        // A quarter-note D.
-        new StaveNote({
-          keys: ['d/4'],
-          duration: 'q',
-        }),
+          // A quarter-note D.
+          new StaveNote({
+            keys: ['d/4'],
+            duration: 'q',
+          }),
 
-        // A quarter-note rest. Note that the key (b/4) specifies the vertical
-        // position of the rest.
-        new StaveNote({
-          keys: ['b/4'],
-          duration: 'qr',
-        }),
+          // A quarter-note rest. Note that the key (b/4) specifies the vertical
+          // position of the rest.
+          new StaveNote({
+            keys: ['b/4'],
+            duration: 'qr',
+          }),
 
-        // A C-Major chord.
-        new StaveNote({
-          keys: ['c/4', 'e/4', 'g/4'],
-          duration: 'q',
-        }),
-      ];
+          // A C-Major chord.
+          new StaveNote({
+            keys: ['c/4', 'e/4', 'g/4'],
+            duration: 'q',
+          }),
+        ];
 
-      // Create a voice in 4/4 and add above notes
-      const voice = new Voice({
-        numBeats: 4,
-        beatValue: 4,
-      });
-      voice.addTickables(notes);
+        // Create a voice in 4/4 and add above notes
+        const voice = new Voice({
+          numBeats: 4,
+          beatValue: 4,
+        });
+        voice.addTickables(notes);
 
-      // Format and justify the notes to 400 pixels.
-      new Formatter().joinVoices([voice]).format([voice], 350);
+        // Format and justify the notes to 400 pixels.
+        new Formatter().joinVoices([voice]).format([voice], 350);
 
-      // Render voice
-      voice.draw(context, stave);
+        // Render voice
+        voice.draw(context, stave);
+      }
     </script>
   </body>
 </html>

--- a/demos/jsfiddle/tutorial/step2_secondvoice.html
+++ b/demos/jsfiddle/tutorial/step2_secondvoice.html
@@ -1,87 +1,96 @@
-<!DOCTYPE >
 <!-- 
 This example is available at: https://jsfiddle.net/awe4vdms/
 It is included in the VexFlow Tutorial: https://github.com/0xfe/vexflow/wiki/Tutorial
 -->
+<!doctype html>
 <html>
-  <style>
-    body {
-      font-family: Arial, 'sans-serif';
-    }
-  </style>
+  <head>
+    <!-- IMPORTANT: Set the character set to UTF-8. Otherwise you may get weird symbols on the score. -->
+    <meta charset="utf-8" />
+    <style>
+      body {
+        font-family: sans-serif;
+      }
+    </style>
+  </head>
   <body>
     <div id="output"></div>
     <!--
     On JSFiddle.net, we pin the dependency to an exact version number,
     to prevent a future release from accidentally breaking the example. 
     -->
-    <script src="https://cdn.jsdelivr.net/npm/vexflow/build/cjs/vexflow.js"></script>
+    <!-- <script src="https://cdn.jsdelivr.net/npm/vexflow/build/cjs/vexflow.js"></script> -->
+    <script src="../../../build/cjs/vexflow.js"></script>
     <script>
-      const { Renderer, Stave, StaveNote, Voice, Formatter } = Vex.Flow;
+      Vex.Flow.loadFonts('Bravura', 'Academico').then(drawStave);
 
-      // Create an SVG renderer and attach it to the DIV element named "boo".
-      const div = document.getElementById('output');
-      const renderer = new Renderer(div, Renderer.Backends.SVG);
+      function drawStave() {
+        const { Renderer, Stave, StaveNote, Voice, Formatter } = Vex.Flow;
 
-      // Configure the rendering context.
-      renderer.resize(500, 500);
-      const context = renderer.getContext();
+        // Create an SVG renderer and attach it to the DIV element named "boo".
+        const div = document.getElementById('output');
+        const renderer = new Renderer(div, Renderer.Backends.SVG);
 
-      // Create a stave of width 400 at position 10, 40 on the canvas.
-      const stave = new Stave(10, 40, 400);
+        // Configure the rendering context.
+        renderer.resize(500, 500);
+        const context = renderer.getContext();
 
-      // Add a clef and time signature.
-      stave.addClef('treble').addTimeSignature('4/4');
+        // Create a stave of width 400 at position 10, 40 on the canvas.
+        const stave = new Stave(10, 40, 400);
 
-      // Connect it to the rendering context and draw!
-      stave.setContext(context).draw();
+        // Add a clef and time signature.
+        stave.addClef('treble').addTimeSignature('4/4');
 
-      // Create the notes
-      const notes = [
-        new StaveNote({
-          keys: ['c/5'],
-          duration: 'q',
-        }),
-        new StaveNote({
-          keys: ['d/4'],
-          duration: 'q',
-        }),
-        new StaveNote({
-          keys: ['b/4'],
-          duration: 'qr',
-        }),
-        new StaveNote({
-          keys: ['c/4', 'e/4', 'g/4'],
-          duration: 'q',
-        }),
-      ];
+        // Connect it to the rendering context and draw!
+        stave.setContext(context).draw();
 
-      const notes2 = [
-        new StaveNote({
-          keys: ['c/4'],
-          duration: 'w',
-        }),
-      ];
+        // Create the notes
+        const notes = [
+          new StaveNote({
+            keys: ['c/5'],
+            duration: 'q',
+          }),
+          new StaveNote({
+            keys: ['d/4'],
+            duration: 'q',
+          }),
+          new StaveNote({
+            keys: ['b/4'],
+            duration: 'qr',
+          }),
+          new StaveNote({
+            keys: ['c/4', 'e/4', 'g/4'],
+            duration: 'q',
+          }),
+        ];
 
-      // Create a voice in 4/4 and add above notes
-      const voices = [
-        new Voice({
-          numBeats: 4,
-          beatValue: 4,
-        }).addTickables(notes),
-        new Voice({
-          numBeats: 4,
-          beatValue: 4,
-        }).addTickables(notes2),
-      ];
+        const notes2 = [
+          new StaveNote({
+            keys: ['c/4'],
+            duration: 'w',
+          }),
+        ];
 
-      // Format and justify the notes to 400 pixels.
-      new Formatter().joinVoices(voices).format(voices, 350);
+        // Create a voice in 4/4 and add above notes
+        const voices = [
+          new Voice({
+            numBeats: 4,
+            beatValue: 4,
+          }).addTickables(notes),
+          new Voice({
+            numBeats: 4,
+            beatValue: 4,
+          }).addTickables(notes2),
+        ];
 
-      // Render voices.
-      voices.forEach(function (v) {
-        v.draw(context, stave);
-      });
+        // Format and justify the notes to 400 pixels.
+        new Formatter().joinVoices(voices).format(voices, 350);
+
+        // Render voices.
+        voices.forEach(function (v) {
+          v.draw(context, stave);
+        });
+      }
     </script>
   </body>
 </html>


### PR DESCRIPTION
Addresses #140 by making sure we don't have an empty doctype declaration on example pages.

Also add this block:

```html
  <head>
    <!-- IMPORTANT: Set the character set to UTF-8. Otherwise you may get weird symbols on the score. -->
    <meta charset="utf-8" />
  </head>
```

The charset declaration is important, because when the file is loaded from the file system or from a web server that does not default to UTF-8, the browser may show weird characters on the staff.