### PR TITLE
metronome musicxml features

### DIFF
--- a/src/stavetempo.ts
+++ b/src/stavetempo.ts
@@ -6,16 +6,40 @@ import { Glyphs } from './glyphs';
 import { Metrics } from './metrics';
 import { Stave } from './stave';
 import { StaveModifier, StaveModifierPosition } from './stavemodifier';
-import { Tables } from './tables';
 import { Category } from './typeguard';
 
 export interface StaveTempoOptions {
+  /** free text i.e.: 'Adagio', 'Andate grazioso', ... */
   name?: string;
+  /**
+   * Indicates whether or not to put the metronome mark in parentheses.
+   * It is no if not specified.
+   * */
   parenthesis?: boolean;
+  /**
+   * Indicates the graphical note type to use in a metronome mark.
+   * see: `StaveTempo.#durationToCode`.
+   */
   duration?: string;
+  /**
+   * Specifies the number of augmentation dots for a metronome mark note.
+   */
   dots?: number;
-  bpm?: number;
+  /**
+   * Specifies the beats per minute associated with the metronome mark.
+   * i.e.: 120, "c. 108", "132-144"
+   */
+  bpm?: number | string;
+  /**
+   * Indicates the graphical note type to use at the right of the equation
+   *  in a metronome mark.
+   * see: `StaveTempo.#durationToCode`.
+   */
   duration2?: string;
+  /**
+   * Specifies the number of augmentation dots for a metronome mark note 
+   * at the right of the equation.
+   */
   dots2?: number;
 }
 

--- a/tests/stave_tests.ts
+++ b/tests/stave_tests.ts
@@ -675,7 +675,7 @@ function drawTempo(options: TestOptions, contextBuilder: ContextBuilder): void {
   drawTempoStaveBar(100, { duration: '8', dots: 2, bpm: 90 }, 0);
   drawTempoStaveBar(100, { duration: '16', dots: 1, bpm: 96 }, 0);
   drawTempoStaveBar(100, { duration: '32', bpm: 70 }, 0);
-  drawTempoStaveBar(250, { name: 'Andante', bpm: 120 }, -20, [
+  drawTempoStaveBar(250, { name: 'Andante', duration: 'q', bpm: 120 }, -20, [
     new StaveNote({ keys: ['c/4'], duration: '8' }),
     new StaveNote({ keys: ['d/4'], duration: '8' }),
     new StaveNote({ keys: ['g/4'], duration: '8' }),
@@ -690,8 +690,8 @@ function drawTempo(options: TestOptions, contextBuilder: ContextBuilder): void {
   y += 150;
 
   drawTempoStaveBar(120, { duration: 'w', bpm: 80 }, 0);
-  drawTempoStaveBar(100, { duration: 'h', bpm: 90 }, 0);
-  drawTempoStaveBar(100, { duration: 'q', bpm: 96 }, 0);
+  drawTempoStaveBar(100, { duration: 'h', dots2: 1, duration2: 'q' }, 0);
+  drawTempoStaveBar(100, { duration: 'q', dots: 1, duration2: 'h', parenthesis: true }, 0);
   drawTempoStaveBar(100, { duration: '8', bpm: 70 }, 0);
   drawTempoStaveBar(250, { name: 'Andante grazioso' }, 0, [
     new StaveNote({ keys: ['c/4'], duration: '8' }),

--- a/tests/stave_tests.ts
+++ b/tests/stave_tests.ts
@@ -671,7 +671,7 @@ function drawTempo(options: TestOptions, contextBuilder: ContextBuilder): void {
     x += width;
   }
 
-  drawTempoStaveBar(120, { duration: 'q', dots: 1, bpm: 80 }, 0);
+  drawTempoStaveBar(120, { duration: 'q', dots: 1, bpm: '80-90' }, 0);
   drawTempoStaveBar(100, { duration: '8', dots: 2, bpm: 90 }, 0);
   drawTempoStaveBar(100, { duration: '16', dots: 1, bpm: 96 }, 0);
   drawTempoStaveBar(100, { duration: '32', bpm: 70 }, 0);
@@ -690,7 +690,7 @@ function drawTempo(options: TestOptions, contextBuilder: ContextBuilder): void {
   y += 150;
 
   drawTempoStaveBar(120, { duration: 'w', bpm: 80 }, 0);
-  drawTempoStaveBar(100, { duration: 'h', dots2: 1, duration2: 'q' }, 0);
+  drawTempoStaveBar(100, { duration: 'h', duration2: 'q', dots2: 1 }, 0);
   drawTempoStaveBar(100, { duration: 'q', dots: 1, duration2: 'h', parenthesis: true }, 0);
   drawTempoStaveBar(100, { duration: '8', bpm: 70 }, 0);
   drawTempoStaveBar(250, { name: 'Andante grazioso' }, 0, [


### PR DESCRIPTION
Features missing detected by @jaredjj3 in https://github.com/stringsync/vexml/pull/157

Tests modified to show the new features:

reference
![svg_Stave Tempo_Test Bravura svg_reference](https://github.com/vexflow/vexflow/assets/22865285/7e64cd18-a5aa-44b5-9a8b-2f8e94e807a4)
current
![svg_Stave Tempo_Test Bravura svg_current](https://github.com/vexflow/vexflow/assets/22865285/fe0d33fe-39fb-48f4-89d8-a07f244da651)
