### PR TITLE
Redesign pointer events

### DIFF
--- a/src/canvascontext.ts
+++ b/src/canvascontext.ts
@@ -2,7 +2,7 @@
 // MIT License
 
 import { Font, FontInfo } from './font';
-import { GroupAttributes, RenderContext, TextMeasure } from './rendercontext';
+import { RenderContext, TextMeasure } from './rendercontext';
 import { globalObject, warn } from './util';
 import { isHTMLCanvas } from './web';
 
@@ -105,7 +105,7 @@ export class CanvasContext extends RenderContext {
   }
 
   // eslint-disable-next-line
-  openGroup(cls?: string, id?: string, attrs?: GroupAttributes): any {
+  openGroup(cls?: string, id?: string): any {
     // Containers not implemented.
   }
 
@@ -213,6 +213,11 @@ export class CanvasContext extends RenderContext {
 
   fillRect(x: number, y: number, width: number, height: number): this {
     this.context2D.fillRect(x, y, width, height);
+    return this;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  pointerRect(x: number, y: number, width: number, height: number): this {
     return this;
   }
 

--- a/src/rendercontext.ts
+++ b/src/rendercontext.ts
@@ -11,10 +11,6 @@ export interface TextMeasure {
   height: number;
 }
 
-export interface GroupAttributes {
-  pointerBBox: boolean;
-}
-
 export abstract class RenderContext {
   static get CATEGORY(): string {
     return Category.RenderContext;
@@ -34,6 +30,7 @@ export abstract class RenderContext {
   abstract resize(width: number, height: number): this;
   abstract fillRect(x: number, y: number, width: number, height: number): this;
   abstract clearRect(x: number, y: number, width: number, height: number): this;
+  abstract pointerRect(x: number, y: number, width: number, height: number): this;
   abstract beginPath(): this;
   abstract moveTo(x: number, y: number): this;
   abstract lineTo(x: number, y: number): this;
@@ -55,7 +52,7 @@ export abstract class RenderContext {
   abstract save(): this;
   abstract restore(): this;
   // eslint-disable-next-line
-  abstract openGroup(cls?: string, id?: string, attrs?: GroupAttributes): any;
+  abstract openGroup(cls?: string, id?: string): any;
   abstract closeGroup(): void;
   abstract openRotation(angleDegrees: number, x: number, y: number): void;
   abstract closeRotation(): void;

--- a/src/stavenote.ts
+++ b/src/stavenote.ts
@@ -1118,7 +1118,7 @@ export class StaveNote extends StemmableNote {
     const ctx = this.checkContext();
     this.#noteHeads.forEach((notehead) => {
       notehead.applyStyle(ctx);
-      ctx.openGroup('notehead', notehead.getAttribute('id'), { pointerBBox: true });
+      ctx.openGroup('notehead', notehead.getAttribute('id'));
       notehead.setContext(ctx).draw();
       this.drawModifiers(notehead);
       ctx.closeGroup();
@@ -1218,6 +1218,8 @@ export class StaveNote extends StemmableNote {
     if (shouldRenderStem) this.drawStem();
     this.drawNoteHeads();
     this.drawFlag();
+    const bb = this.getBoundingBox();
+    ctx.pointerRect(bb.getX(), bb.getY(), bb.getW(), bb.getH());
     ctx.closeGroup();
     this.restoreStyle();
     this.setRendered();

--- a/src/stem.ts
+++ b/src/stem.ts
@@ -212,7 +212,7 @@ export class Stem extends Element {
     // Draw the stem
     ctx.save();
     this.applyStyle();
-    ctx.openGroup('stem', this.getAttribute('id'), { pointerBBox: true });
+    ctx.openGroup('stem', this.getAttribute('id'));
     ctx.beginPath();
     ctx.setLineWidth(Stem.WIDTH);
     ctx.moveTo(stemX, stemY - stemletYOffset + yBaseOffset);

--- a/src/svgcontext.ts
+++ b/src/svgcontext.ts
@@ -5,7 +5,7 @@
 import { Element } from './element';
 import { Font, FontInfo, FontStyle, FontWeight } from './font';
 import { Metrics } from './metrics';
-import { GroupAttributes, RenderContext, TextMeasure } from './rendercontext';
+import { RenderContext, TextMeasure } from './rendercontext';
 import { Tables } from './tables';
 import { normalizeAngle, prefix, RuntimeError } from './util';
 
@@ -96,6 +96,7 @@ export class SVGContext extends RenderContext {
 
     // Create a SVG element and add it to the container element.
     const svg = this.create('svg');
+    svg.setAttribute('pointer-events', 'none');
     this.element.appendChild(svg);
     this.svg = svg;
 
@@ -160,7 +161,7 @@ export class SVGContext extends RenderContext {
   }
 
   // Allow grouping elements in containers for interactivity.
-  openGroup(cls?: string, id?: string, attrs?: GroupAttributes): SVGGElement {
+  openGroup(cls?: string, id?: string): SVGGElement {
     const group = this.create('g');
     this.groups.push(group);
     this.parent.appendChild(group);
@@ -168,9 +169,6 @@ export class SVGContext extends RenderContext {
     if (cls) group.setAttribute('class', prefix(cls));
     if (id) group.setAttribute('id', prefix(id));
 
-    if (attrs && attrs.pointerBBox) {
-      group.setAttribute('pointer-events', 'bounding-box');
-    }
     this.applyAttributes(group, this.attributes);
     this.groupAttributes.push({ ...this.groupAttributes[this.groupAttributes.length - 1], ...this.attributes });
     return group;
@@ -382,6 +380,12 @@ export class SVGContext extends RenderContext {
 
   fillRect(x: number, y: number, width: number, height: number): this {
     const attributes = { fill: this.attributes.fill, stroke: 'none' };
+    this.rect(x, y, width, height, attributes);
+    return this;
+  }
+
+  pointerRect(x: number, y: number, width: number, height: number): this {
+    const attributes = { opacity: '0', 'pointer-events': 'auto' };
     this.rect(x, y, width, height, attributes);
     return this;
   }

--- a/src/tabnote.ts
+++ b/src/tabnote.ts
@@ -431,7 +431,7 @@ export class TabNote extends StemmableNote {
     const renderStem = this.beam === undefined && this.renderOptions.drawStem;
 
     this.applyStyle();
-    ctx.openGroup('tabnote', this.getAttribute('id'), { pointerBBox: true });
+    ctx.openGroup('tabnote', this.getAttribute('id'));
     this.drawPositions();
     this.drawStemThrough();
 


### PR DESCRIPTION
The solution is to set a transparent pointer rect to capture the events.

No visual differences but right behaviour on the interactive mouseover tests.