### PR TITLE
fix stavenote bounding box

### DIFF
--- a/src/accidental.ts
+++ b/src/accidental.ts
@@ -562,9 +562,9 @@ export class Accidental extends Modifier {
 
     // Figure out the start `x` and `y` coordinates for note and index.
     const start = note.getModifierStartXY(position, index);
-    const accX = start.x;
-    const accY = start.y;
-    L('Rendering: ', type, accX, accY);
-    this.renderText(ctx, accX - this.width, accY);
+    this.x = start.x - this.width;
+    this.y = start.y;
+    L('Rendering: ', type, start.x, start.y);
+    this.renderText(ctx, 0, 0);
   }
 }

--- a/src/dot.ts
+++ b/src/dot.ts
@@ -163,9 +163,9 @@ export class Dot extends Modifier {
       start.y = note.getStemExtents().baseY;
     }
 
-    const x = start.x;
-    const y = start.y + this.dotShiftY * lineSpace;
+    this.x = start.x;
+    this.y = start.y + this.dotShiftY * lineSpace;
 
-    this.renderText(ctx, x, y);
+    this.renderText(ctx, 0, 0);
   }
 }

--- a/src/element.ts
+++ b/src/element.ts
@@ -340,7 +340,7 @@ export class Element {
 
   /** Get the boundingBox. */
   getBoundingBox(): BoundingBox {
-    return new BoundingBox(0, -this.textMetrics.actualBoundingBoxAscent, this.width, this.height);
+    return new BoundingBox(this.x, this.y - this.textMetrics.actualBoundingBoxAscent, this.width, this.height);
   }
 
   /** Return the context, such as an SVGContext or CanvasContext object. */

--- a/src/ornament.ts
+++ b/src/ornament.ts
@@ -270,12 +270,12 @@ export class Ornament extends Modifier {
       this.yShift += this.getHeight();
     }
 
-    this.renderText(
-      ctx,
+    this.x =
       glyphX -
-        (this.position === ModifierPosition.ABOVE || this.position === ModifierPosition.BELOW ? this.width * 0.5 : 0),
-      glyphY
-    );
+      (this.position === ModifierPosition.ABOVE || this.position === ModifierPosition.BELOW ? this.width * 0.5 : 0);
+    this.y = glyphY;
+
+    this.renderText(ctx, 0, 0);
 
     if (this.accidentalUpper) {
       glyphY -= this.getHeight() + this.renderOptions.accidentalUpperPadding;

--- a/src/stavenote.ts
+++ b/src/stavenote.ts
@@ -614,6 +614,9 @@ export class StaveNote extends StemmableNote {
       const bbFlag = this.flag.getBoundingBox();
       boundingBox.mergeWith(bbFlag.move(flagX, flagY));
     }
+    for (let i = 0; i < this.modifiers.length; i++) {
+      boundingBox.mergeWith(this.modifiers[i].getBoundingBox());
+    }
     return boundingBox;
   }
 

--- a/tests/stavenote_tests.ts
+++ b/tests/stavenote_tests.ts
@@ -27,6 +27,7 @@ import { Stem } from '../src/stem';
 import { StringNumber } from '../src/stringnumber';
 import { Stroke } from '../src/strokes';
 import { TickContext } from '../src/tickcontext';
+import { Ornament } from '../src';
 
 const StaveNoteTests = {
   Start(): void {
@@ -467,16 +468,16 @@ function drawBoundingBoxes(options: TestOptions, contextBuilder: ContextBuilder)
   ];
   options.assert.expect(noteStructs.length * 2);
 
+  const notes: StaveNote[] = [];
   for (let i = 0; i < noteStructs.length; ++i) {
-    const note = draw(
-      staveNote(noteStructs[i]),
-      stave,
-      ctx,
-      (i + 1) * 25,
-      true /* drawBoundingBox */,
-      false /* addModifierContext */
-    );
+    notes.push(staveNote(noteStructs[i]));
+  }
+  notes[2].addModifier(new Ornament('tr'), 0);
+  notes[2].addModifier(new Accidental('b'), 0);
+  Dot.buildAndAttach([notes[2]], { all: true });
 
+  for (let i = 0; i < noteStructs.length; ++i) {
+    const note = draw(notes[i], stave, ctx, (i + 1) * 25, true /* drawBoundingBox */, false /* addModifierContext */);
     options.assert.ok(note.getX() > 0, 'Note ' + i + ' has X value');
     options.assert.ok(note.getYs().length > 0, 'Note ' + i + ' has Y values');
   }


### PR DESCRIPTION
The topic ibounding box is not complete with this PR but I would like to check with a new alpha release if this goes in the good direction to resolve the issue #155 from @AaronDavidNewman. I have modified the stavenote bounding box test to include an accidental, an ornament and dots. This test is the only visual difference.

![svg_StaveNote StaveNote_BoundingBoxes___Treble Bravura svg_current](https://github.com/vexflow/vexflow/assets/22865285/d168a139-0cb8-44d5-b5d3-682beadb3027)

