### PR TITLE
ornaments above stave

### DIFF
--- a/src/ornament.ts
+++ b/src/ornament.ts
@@ -8,6 +8,7 @@ import { Metrics } from './metrics';
 import { Modifier, ModifierPosition } from './modifier';
 import { ModifierContextState } from './modifiercontext';
 import { Note } from './note';
+import { Stem } from './stem';
 import { StemmableNote } from './stemmablenote';
 import { Tables } from './tables';
 import { Category } from './typeguard';
@@ -70,6 +71,15 @@ export class Ornament extends Modifier {
         leftShift += ornament.width + Ornament.minPadding;
       } else if (ornament.position === ModifierPosition.ABOVE) {
         width = Math.max(ornament.getWidth(), width);
+        const note = ornament.getNote() as StemmableNote;
+        let curTop = note.getLineNumber(true) + state.topTextLine;
+        const stem = note.getStem();
+        if (stem && note.getStemDirection() === Stem.UP) {
+          curTop += Math.abs(stem.getHeight()) / Tables.STAVE_LINE_DISTANCE;
+        }
+        const numLines = note.getStave()?.getNumLines() ?? 0;
+        // make sure that the ornaments stay above the staff
+        if (curTop < numLines) state.topTextLine += numLines - curTop;
         ornament.setTextLine(state.topTextLine);
         state.topTextLine += increment;
       } else {

--- a/tests/ornament_tests.ts
+++ b/tests/ornament_tests.ts
@@ -45,19 +45,19 @@ function drawOrnaments(options: TestOptions, contextBuilder: ContextBuilder): vo
   const stave = new Stave(10, 30, 700);
   stave.setContext(ctx).draw();
   const notes = [
-    new StaveNote({ keys: ['f/4'], duration: '4', stemDirection: 1 }),
-    new StaveNote({ keys: ['f/4'], duration: '4', stemDirection: 1 }),
-    new StaveNote({ keys: ['f/4'], duration: '4', stemDirection: 1 }),
-    new StaveNote({ keys: ['f/4'], duration: '4', stemDirection: 1 }),
-    new StaveNote({ keys: ['f/4'], duration: '4', stemDirection: 1 }),
-    new StaveNote({ keys: ['f/4'], duration: '4', stemDirection: 1 }),
-    new StaveNote({ keys: ['f/4'], duration: '4', stemDirection: 1 }),
-    new StaveNote({ keys: ['f/4'], duration: '4', stemDirection: 1 }),
-    new StaveNote({ keys: ['f/4'], duration: '4', stemDirection: 1 }),
-    new StaveNote({ keys: ['f/4'], duration: '4', stemDirection: 1 }),
-    new StaveNote({ keys: ['f/4'], duration: '4', stemDirection: 1 }),
-    new StaveNote({ keys: ['f/4'], duration: '4', stemDirection: 1 }),
-    new StaveNote({ keys: ['f/4'], duration: '4', stemDirection: 1 }),
+    new StaveNote({ keys: ['c/4'], duration: '4', stemDirection: 1 }),
+    new StaveNote({ keys: ['c/4'], duration: '4', stemDirection: 1 }),
+    new StaveNote({ keys: ['c/4'], duration: '4', stemDirection: 1 }),
+    new StaveNote({ keys: ['c/4'], duration: '4', stemDirection: 1 }),
+    new StaveNote({ keys: ['c/4'], duration: '4', stemDirection: 1 }),
+    new StaveNote({ keys: ['c/4'], duration: '4', stemDirection: 1 }),
+    new StaveNote({ keys: ['c/4'], duration: '4', stemDirection: 1 }),
+    new StaveNote({ keys: ['c/4'], duration: '4', stemDirection: 1 }),
+    new StaveNote({ keys: ['c/4'], duration: '4', stemDirection: 1 }),
+    new StaveNote({ keys: ['c/4'], duration: '4', stemDirection: 1 }),
+    new StaveNote({ keys: ['c/4'], duration: '4', stemDirection: 1 }),
+    new StaveNote({ keys: ['c/4'], duration: '4', stemDirection: 1 }),
+    new StaveNote({ keys: ['c/4'], duration: '4', stemDirection: 1 }),
   ];
 
   notes[0].addModifier(new Ornament('mordent'), 0);


### PR DESCRIPTION
There was no ornament test with low notes. Jared highlighted that they should stay about the Stave. 

I modified a test to lower the notes and Ornament.format to make the ornaments stay above.

Only one difference in the modified test

current
![svg_Ornament Ornaments Bravura svg_current](https://github.com/vexflow/vexflow/assets/22865285/4050a064-c2ee-463d-bc0f-5d6195daf0ab)
reference
![svg_Ornament Ornaments Bravura svg_reference](https://github.com/vexflow/vexflow/assets/22865285/7fc7465f-17b7-4dc5-aa44-836192291e63)
without the modification in Ornament, the ornaments go between lines.