### PR TITLE
notehead: fix bounding box

### DIFF
--- a/src/notehead.ts
+++ b/src/notehead.ts
@@ -127,16 +127,6 @@ export class NoteHead extends Note {
     return x + (this.displaced ? (this.width - displacementStemAdjustment) * this.stemDirection : 0);
   }
 
-  /** Get the `BoundingBox` for the `NoteHead`. */
-  getBoundingBox(): BoundingBox {
-    return new BoundingBox(
-      this.getAbsoluteX() - this.textMetrics.actualBoundingBoxLeft,
-      this.y - this.textMetrics.actualBoundingBoxAscent,
-      this.width,
-      this.height
-    );
-  }
-
   /** Set notehead to a provided `stave`. */
   setStave(stave: Stave): this {
     const line = this.getLine();
@@ -163,7 +153,7 @@ export class NoteHead extends Note {
     this.setRendered();
 
     L("Drawing note head '", this.noteType, this.duration, "' at", this.x, this.y);
-
-    this.renderText(ctx, this.getAbsoluteX() - this.x, 0);
+    this.x = this.getAbsoluteX();
+    this.renderText(ctx, 0, 0);
   }
 }


### PR DESCRIPTION
The bounding box of notehead had a bug.

current
![svg_NoteHead Bounding_Boxes Bravura svg_current](https://github.com/vexflow/vexflow/assets/22865285/d658482e-9254-4b06-b28a-830a84970ec2)
reference
![svg_NoteHead Bounding_Boxes Bravura svg_reference](https://github.com/vexflow/vexflow/assets/22865285/80bf8133-c92d-4ec9-bf69-9af006cab449)
