### PR TITLE
Fix Annotation and ChordSymbol justification padding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ ruby_sess.*
 # Jetbrains
 .idea/.gitignore
 .idea/VexFlow.iml
+.idea/vexflow5.iml
+.idea/copilot
 .idea/encodings.xml
 .idea/misc.xml
 .idea/modules.xml

--- a/src/annotation.ts
+++ b/src/annotation.ts
@@ -88,10 +88,10 @@ export class Annotation extends Modifier {
       const glyphWidth = note.getGlyphWidth();
       // Get the text width from the font metrics.
       const textWidth = annotation.getWidth();
-      if (annotation.horizontalJustification === AnnotationHorizontalJustify.LEFT) {
+      if (annotation.horizontalJustification === AnnotationHorizontalJustify.RIGHT) {
         maxLeftGlyphWidth = Math.max(glyphWidth, maxLeftGlyphWidth);
         leftWidth = Math.max(leftWidth, textWidth) + Annotation.minAnnotationPadding;
-      } else if (annotation.horizontalJustification === AnnotationHorizontalJustify.RIGHT) {
+      } else if (annotation.horizontalJustification === AnnotationHorizontalJustify.LEFT) {
         maxRightGlyphWidth = Math.max(glyphWidth, maxRightGlyphWidth);
         rightWidth = Math.max(rightWidth, textWidth);
       } else {

--- a/src/chordsymbol.ts
+++ b/src/chordsymbol.ts
@@ -200,10 +200,10 @@ export class ChordSymbol extends Modifier {
       if (symbol.getReportWidth()) {
         if (isStemmableNote(note)) {
           const glyphWidth = note.getGlyphWidth();
-          if (symbol.getHorizontal() === ChordSymbolHorizontalJustify.LEFT) {
+          if (symbol.getHorizontal() === ChordSymbolHorizontalJustify.RIGHT) {
             maxLeftGlyphWidth = Math.max(glyphWidth, maxLeftGlyphWidth);
             leftWidth = Math.max(leftWidth, width) + ChordSymbol.minPadding;
-          } else if (symbol.getHorizontal() === ChordSymbolHorizontalJustify.RIGHT) {
+          } else if (symbol.getHorizontal() === ChordSymbolHorizontalJustify.LEFT) {
             maxRightGlyphWidth = Math.max(glyphWidth, maxRightGlyphWidth);
             rightWidth = Math.max(rightWidth, width);
           } else {

--- a/tests/annotation_tests.ts
+++ b/tests/annotation_tests.ts
@@ -7,27 +7,31 @@
 //       Did a previous version of the API accept a number as the fourth argument?
 //       We removed the fourth argument from all of our test cases.
 
-import { VexFlow } from '../src/vexflow';
-import { TestOptions, VexFlowTests } from './vexflow_test_helpers';
+import {VexFlow} from '../src/vexflow';
+import {TestOptions, VexFlowTests} from './vexflow_test_helpers';
 
-import { Annotation, AnnotationVerticalJustify } from '../src/annotation';
-import { Articulation } from '../src/articulation';
-import { Beam } from '../src/beam';
-import { Bend } from '../src/bend';
-import { ElementStyle } from '../src/element';
-import { Formatter } from '../src/formatter';
-import { Metrics } from '../src/metrics';
-import { ModifierPosition } from '../src/modifier';
-import { Registry } from '../src/registry';
-import { ContextBuilder } from '../src/renderer';
-import { Stave } from '../src/stave';
-import { StaveNote, StaveNoteStruct } from '../src/stavenote';
-import { Stem } from '../src/stem';
-import { TabNote, TabNoteStruct } from '../src/tabnote';
-import { TabStave } from '../src/tabstave';
-import { Tickable } from '../src/tickable';
-import { Vibrato } from '../src/vibrato';
-import { Voice } from '../src/voice';
+import {
+  Annotation,
+  AnnotationHorizontalJustify,
+  AnnotationVerticalJustify
+} from '../src/annotation';
+import {Articulation} from '../src/articulation';
+import {Beam} from '../src/beam';
+import {Bend} from '../src/bend';
+import {ElementStyle} from '../src/element';
+import {Formatter} from '../src/formatter';
+import {Metrics} from '../src/metrics';
+import {ModifierPosition} from '../src/modifier';
+import {Registry} from '../src/registry';
+import {ContextBuilder} from '../src/renderer';
+import {Stave} from '../src/stave';
+import {StaveNote, StaveNoteStruct} from '../src/stavenote';
+import {Stem} from '../src/stem';
+import {TabNote, TabNoteStruct} from '../src/tabnote';
+import {TabStave} from '../src/tabstave';
+import {Tickable} from '../src/tickable';
+import {Vibrato} from '../src/vibrato';
+import {Voice} from '../src/voice';
 
 const AnnotationTests = {
   Start(): void {
@@ -81,12 +85,13 @@ function lyrics(options: TestOptions): void {
     });
 
     // Add lyrics under the first row.
-    ['hand,', 'and', 'me', 'pears', 'lead', 'the'].forEach((text, ix) => {
+    ['Handily', 'and', 'me', 'Pears', 'lead', 'the'].forEach((text, ix) => {
       const verse = Math.floor(ix / 3);
       const noteGroupID = 'n' + (ix % 3);
       const noteGroup = registry.getElementById(noteGroupID) as Tickable;
       const lyricsAnnotation = f.Annotation({ text }).setFontSize(fontSize);
       lyricsAnnotation.setPosition(ModifierPosition.BELOW);
+      if (ix % 3 === 0) lyricsAnnotation.setJustification(AnnotationHorizontalJustify.LEFT);
       noteGroup.addModifier(lyricsAnnotation, verse);
     });
 

--- a/tests/chordsymbol_tests.ts
+++ b/tests/chordsymbol_tests.ts
@@ -27,6 +27,7 @@ const ChordSymbolTests = {
     run('Bottom Chord Symbols', bottom);
     run('Bottom Stem Down Chord Symbols', bottomStemDown);
     run('Double Bottom Chord Symbols', doubleBottom);
+    run('Wide Chord Symbols', wide);
   },
 };
 
@@ -485,6 +486,39 @@ function doubleBottom(options: TestOptions): void {
   draw(chords1, chords2, 10);
   options.assert.ok(true, '2 Bottom Chord Symbol');
 }
+
+function wide(options: TestOptions): void {
+  const f = VexFlowTests.makeFactory(options, 300 * 1.5, 680);
+  const ctx = f.getContext();
+  ctx.scale(1.5, 1.5);
+
+  function draw(chord1: ChordSymbol, chord2: ChordSymbol, y: number) {
+    const stave = new Stave(10, y, 250).addClef('treble').setContext(ctx).draw();
+
+    const notes = [
+      note(f, ['e/4', 'a/4', 'd/5'], 'h', chord1).addModifier(new Accidental('b'), 0),
+      note(f, ['c/4', 'e/4', 'B/4'], 'h', chord2),
+    ];
+    Formatter.FormatAndDraw(ctx, stave, notes);
+  }
+
+  let chord1 = f.ChordSymbol().addText('FrogToad7').setHorizontal('left').addGlyphOrText('(#11b9)', superscript);
+  let chord2 = f.ChordSymbol({ hJustify: 'left' }).addText('CToShiningC').addGlyphSuperscript('majorSeventh');
+  draw(chord1, chord2, 40);
+
+  chord1 = f
+    .ChordSymbol({ hJustify: 'right' })
+    .addText('FrogToad7')
+    .setHorizontal('left')
+    .addGlyphOrText('#11', superscript)
+    .addGlyphOrText('b9', subscript);
+  chord2 = f.ChordSymbol({ hJustify: 'left' }).addText('CToShiningC').addTextSuperscript('Maj.');
+  draw(chord1, chord2, 240);
+
+  options.assert.ok(true, 'Wide Chord Symbols');
+}
+
+
 
 VexFlowTests.register(ChordSymbolTests);
 export { ChordSymbolTests };


### PR DESCRIPTION
Fixes #178 

All the visual differences are things like this, where the first note was left justified, so it previously got extra space to the left, now it gets it to the right.

Reference:
![canvas_Annotation TabNote_Annotations Bravura_reference](https://github.com/vexflow/vexflow/assets/3521479/274d870b-b4f3-4ec9-b49d-1a14d51f6279)

Current:
![canvas_Annotation TabNote_Annotations Bravura_current](https://github.com/vexflow/vexflow/assets/3521479/5123f356-e9b9-4a16-95e0-c19a655d6665)


Reference:
![canvas_ChordSymbol Top_Chord_Symbols Bravura_reference](https://github.com/vexflow/vexflow/assets/3521479/9c88ff1d-4c67-4896-bed8-85baaa8d73bc)

Current:
![canvas_ChordSymbol Top_Chord_Symbols Bravura_current](https://github.com/vexflow/vexflow/assets/3521479/641340b9-2af5-4280-a748-c1fffb9e62fb)


Added a new test with very long chord symbols and changed the lyrics test to start with a long lyric, left justified.

Reference:
![svg_Annotation Lyrics Bravura svg_reference](https://github.com/vexflow/vexflow/assets/3521479/c9aad7ed-ab00-42ac-92d1-298315526d22)

Current:
![svg_Annotation Lyrics Bravura svg_current](https://github.com/vexflow/vexflow/assets/3521479/165e12da-cd6a-454f-827f-f00fd1ed914f)
