### PR TITLE
Move package.json project name to `vexflow`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "vxflw-early-access",
-  "version": "5.0.0-alpha.11",
+  "name": "vexflow",
+  "version": "5.0.0-alpha.0",
   "description": "A JavaScript library for rendering music notation and guitar tablature.",
   "exports": {
     ".": {


### PR DESCRIPTION
We can start publishing alpha / beta versions under `vexflow` from now on.