### PR TITLE
Formatter: mean calculation + pull out algorithms

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -19,6 +19,10 @@ DEVELOP
 
 grunt watch
   - FAST: Watch for changes and produces the debug CJS libraries in build/cjs/.
+  - Deletes the reference images and anything else in build first.
+
+grunt webpack:watchDebug
+  - Same as grunt watch without deleting the build directory first.
 
 grunt watch:esm
   - FAST: Watch for changes and build the ESM libraries in build/esm/.

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -147,7 +147,7 @@ function getRestLineForNextNoteGroup(
     }
   }
 
-  // Locate the mid point between two lines.
+  // Locate the midpoint between two lines.
   if (compare && currRestLine !== nextRestLine) {
     const top = Math.max(currRestLine, nextRestLine);
     const bot = Math.min(currRestLine, nextRestLine);
@@ -1006,7 +1006,7 @@ export class Formatter {
       context.move(shift, prevContext, nextContext);
 
       // Q(msac): Should the cost by normalized by the number
-      // of tickables at this position?
+      // of tickables at this position?  If so, switch this to getAverageDeviationCost()
       const cost = -context.getDeviationCost();
       if (cost > 0) {
         shift = -Math.min(context.getFormatterMetrics().freedom.right, Math.abs(cost));

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -39,7 +39,7 @@ export interface FormatterOptions {
 }
 
 export interface FormatParams {
-  alignRests?: boolean;
+  alignRests?: boolean; // align rests vertically with neighboring notes.
   stave?: Stave;
   context?: RenderContext;
   autoBeam?: boolean;
@@ -189,7 +189,7 @@ export class Formatter {
   protected modifierContexts: AlignmentModifierContexts[];
   protected voices: Voice[];
   protected lossHistory: number[];
-  protected durationStats: Record<string, { mean: number; count: number }>;
+  protected durationStats: Record<string, { mean: number; count: number; total: number }>;
 
   /**
    * Helper function to layout "notes" one after the other without
@@ -198,11 +198,11 @@ export class Formatter {
   static SimpleFormat(notes: Tickable[], x = 0, { paddingBetween = 10 } = {}): void {
     notes.reduce((accumulator, note) => {
       note.addToModifierContext(new ModifierContext());
-      const tick = new TickContext().addTickable(note).preFormat();
-      const metrics = tick.getMetrics();
-      tick.setX(accumulator + metrics.totalLeftPx);
+      const tickContext = new TickContext().addTickable(note).preFormat();
+      const metrics = tickContext.getMetrics();
+      tickContext.setX(accumulator + metrics.totalLeftPx);
 
-      return accumulator + tick.getWidth() + metrics.totalRightPx + paddingBetween;
+      return accumulator + tickContext.getWidth() + metrics.totalRightPx + paddingBetween;
     }, x);
   }
 
@@ -442,7 +442,7 @@ export class Formatter {
   }
 
   /**
-   * Find all the rests in each of the `voices` and align them to neighboring notes.
+   * Find all the rests in each of the `voices` and align them vertically to neighboring notes.
    *
    * @param voices
    * @param alignAllNotes If `false`, only align rests within beamed groups of notes. If `true`, align all rests.
@@ -922,10 +922,11 @@ export class Formatter {
     function updateStats(duration: string, space: number) {
       const stats = durationStats[duration];
       if (stats === undefined) {
-        durationStats[duration] = { mean: space, count: 1 };
+        durationStats[duration] = { mean: space, count: 1, total: space };
       } else {
         stats.count += 1;
-        stats.mean = (stats.mean + space) / 2;
+        stats.total += space;
+        stats.mean = stats.total / stats.count;
       }
     }
 
@@ -982,8 +983,9 @@ export class Formatter {
    * the overall "loss" (or cost) of this layout, and repositions tickcontexts in an
    * attempt to reduce the cost. You can call this method multiple times until it finds
    * and oscillates around a global minimum.
+   * @param options parameters for tuning, currently just "alpha".
    * @param options[alpha] the "learning rate" for the formatter. It determines how much of a shift
-   * the formatter should make based on its cost function.
+   * the formatter should make based on its cost function.  Defaults to 0.5.
    */
   tune(options?: { alpha?: number }): number {
     const contexts = this.tickContexts;
@@ -993,17 +995,7 @@ export class Formatter {
 
     const alpha = options?.alpha ?? 0.5;
 
-    // Move `current` tickcontext by `shift` pixels, and adjust the freedom
-    // on adjacent tickcontexts.
-    function move(current: TickContext, shift: number, prev?: TickContext, next?: TickContext) {
-      current.setX(current.getX() + shift);
-      current.getFormatterMetrics().freedom.left += shift;
-      current.getFormatterMetrics().freedom.right -= shift;
-
-      if (prev) prev.getFormatterMetrics().freedom.right += shift;
-      if (next) next.getFormatterMetrics().freedom.left -= shift;
-    }
-
+    // function `move` moved to tickcontext.
     let shift = 0;
     this.totalShift = 0;
     contexts.list.forEach((tick, index, list) => {
@@ -1011,10 +1003,11 @@ export class Formatter {
       const prevContext = index > 0 ? contexts.map[list[index - 1]] : undefined;
       const nextContext = index < list.length - 1 ? contexts.map[list[index + 1]] : undefined;
 
-      move(context, shift, prevContext, nextContext);
+      context.move(shift, prevContext, nextContext);
 
-      const cost = -sumArray(context.getTickables().map((t) => t.getFormatterMetrics().space.deviation));
-
+      // Q(msac): Should the cost by normalized by the number
+      // of tickables at this position?
+      const cost = -context.getDeviationCost();
       if (cost > 0) {
         shift = -Math.min(context.getFormatterMetrics().freedom.right, Math.abs(cost));
       } else if (cost < 0) {
@@ -1067,7 +1060,7 @@ export class Formatter {
    * Voices are full justified to fit in `justifyWidth` pixels.
    *
    * Set `options.context` to the rendering context. Set `options.alignRests`
-   * to true to enable rest alignment.
+   * to true to enable rest vertical alignment.
    */
   format(voices: Voice[], justifyWidth?: number, options?: FormatParams): this {
     const opts = {

--- a/src/fraction.ts
+++ b/src/fraction.ts
@@ -42,7 +42,11 @@ export class Fraction {
     return (a * b) / Fraction.GCD(a, b);
   }
 
-  /** Lowest common multiple for more than two numbers. */
+  /** Lowest common multiple for more than two numbers.
+   *
+   * Note that the `args` array will be manipulated and shortened recursively during
+   * computation.
+   */
   static LCMM(args: number[]): number {
     if (args.length === 0) {
       return 0;
@@ -103,7 +107,7 @@ export class Fraction {
     return this.set(u, lcm);
   }
 
-  /** Substract value of another fraction. */
+  /** Subtract value of another fraction. */
   subtract(param1: Fraction | number = 0, param2: number = 1): this {
     const [otherNumerator, otherDenominator] = getNumeratorAndDenominator(param1, param2);
     const lcm = Fraction.LCM(this.denominator, otherDenominator);

--- a/src/tickcontext.ts
+++ b/src/tickcontext.ts
@@ -7,7 +7,7 @@
 import { Fraction } from './fraction';
 import { NoteMetrics } from './note';
 import { Tickable } from './tickable';
-import {RuntimeError, sumArray} from './util';
+import { RuntimeError, sumArray } from './util';
 
 export interface TickContextMetrics extends NoteMetrics {
   totalLeftPx: number;
@@ -72,7 +72,7 @@ export class TickContext {
     this.maxTicks = new Fraction(0, 1);
     this.maxTickable = undefined; // Biggest tickable
     this.minTicks = undefined; // this can remain null if all tickables have ignoreTicks
-    this.minTickable = undefined; // smallest tickable.
+    this.minTickable = undefined;
 
     this.padding = 1; // padding on each side (width += padding * 2)
     this.x = 0;

--- a/src/tickcontext.ts
+++ b/src/tickcontext.ts
@@ -314,6 +314,15 @@ export class TickContext {
    * more space than they should.
    */
   getDeviationCost(): number {
-    return sumArray(this.getTickables().map((t) => t.getFormatterMetrics().space.deviation));
+    return sumArray(this.tickables.map((t) => t.getFormatterMetrics().space.deviation));
+  }
+
+  /**
+   * Like getDeviationCost, but averages the cost of space deviations so that TickContexts
+   * with more Tickables are not weighted more heavily.
+   */
+  getAverageDeviationCost(): number {
+    if (!this.tickables.length) return 0;
+    return this.getDeviationCost() / this.tickables.length;
   }
 }


### PR DESCRIPTION
Fixes #187 and implements part of the philosophy of #183.

Fixes the calculation of means by adding a "total" to `Formatter().durationStats` so that mean deviation is calculated properly.

`Formatter().tune()` previously embedded a powerful `move(tickContext, shift)` routine inside it that did not use any scope or `this` variables.  Rewrote as `TickContext().move(shift)`

`Formatter().tune()` calculated the cost of space deviations as `-sumArray(context.getTickables().map((t) => t.getFormatterMetrics().space.deviation));` which does not use any scope or `this` variables.  Moved to `TickContext().getDeviationCost()` (without the negative sign).  Added `TickContext().getAverageDeviationCost()` which I believe would fix a bug that contexts with more tickables are weighed more heavily, but did not use this calculation yet, pending discussion.

Docs and typo fixes:

`Gruntfile.js` -- noted that the standard developer build system will wipe out reference images -- gave an alternative that preserves them.

`FormatParams.alignRests` (and other alignRests places) -- add notes that this aligns rests vertically not horizontally.

Rename some internal `tick` variables to `tickContext` -- I'd like us to move to using `tick` to mean a `Fraction` object consistently.

Added warning to `Fraction.LCMM` -- it actually seems like a bug to me, but didn't want to change w/o discussion.


Generated images -- only changes are to the values reported for space deviations in Factory classes, which abs(lower) the mean differences in most cases.