### PR TITLE
Annotation - remove outdated comment

### DIFF
--- a/src/annotation.ts
+++ b/src/annotation.ts
@@ -224,10 +224,6 @@ export class Annotation extends Modifier {
     const start = note.getModifierStartXY(ModifierPosition.ABOVE, this.index);
 
     this.setRendered();
-
-    // Apply style might not save context, if this.style is undefined, so we
-    // still need to save context state just before this, since we will be
-    // changing ctx parameters below.
     this.applyStyle();
     ctx.openGroup('annotation', this.getAttribute('id'));
 

--- a/src/annotation.ts
+++ b/src/annotation.ts
@@ -209,7 +209,7 @@ export class Annotation extends Modifier {
 
   /**
    * Set horizontal justification.
-   * @param justification value in `Annotation.Justify`.
+   * @param just value in `Annotation.Justify`.
    */
   setJustification(just: string | AnnotationHorizontalJustify): this {
     this.horizontalJustification = typeof just === 'string' ? Annotation.HorizontalJustifyString[just] : just;


### PR DESCRIPTION
Minor.

A change to v5 format in  #51 left a comment that is now outdated.  Annotation no longer changes anything in RenderContext except through applyStyle(), so there is no need for an additional ctx.save() or ctx.restore().

https://github.com/vexflow/vexflow/commit/d6c878989e3e7f9723d7fcf63fb039faef7c66df

Fix param typing in setJustification