### PR TITLE
Remove unneeded test on StaveModifier

### DIFF
--- a/src/stave.ts
+++ b/src/stave.ts
@@ -564,7 +564,7 @@ export class Stave extends Element {
     const noPosition = position === undefined;
     const noCategory = category === undefined;
     if (noPosition && noCategory) {
-      return this.modifiers;
+      return this.modifiers; // Should this be [...this.modifiers]?
     } else if (noPosition) {
       // A category was provided.
       return this.modifiers.filter((m: StaveModifier) => category === m.getCategory());
@@ -717,13 +717,10 @@ export class Stave extends Element {
 
     // Draw the modifiers (bar lines, coda, segno, repeat brackets, etc.)
     for (let i = 0; i < this.modifiers.length; i++) {
-      const modifier = this.modifiers[i];
-      // Only draw modifier if it has a draw function
-      if (typeof modifier.draw === 'function') {
-        modifier.applyStyle(ctx);
-        modifier.draw(this, this.getModifierXShift(i));
-        modifier.restoreStyle(ctx);
-      }
+      const modifier: StaveModifier = this.modifiers[i];
+      modifier.applyStyle(ctx);
+      modifier.draw(this, this.getModifierXShift(i));
+      modifier.restoreStyle(ctx);
     }
 
     // Render measure numbers


### PR DESCRIPTION
A test that each StaveModifier has a draw() method goes back to the pre-ES6 class version of Vexflow and is unnecessary now.

First added way back in 2012 as:
https://github.com/vexflow/vexflow/commit/f5e562519dffd0e5931c136218ab36bbc2cf1cb3

Added a type to remind ourselves that these are StaveModifiers not Modifiers.

Q: Stave().getModifiers returns a different array than Stave.modifiers if position or category is specified, but returns the original array if neither is specified.  I wonder if line 567 should be changed to return [...this.modifiers] so that in all cases `.modifiers` remains immutable?