### PR TITLE
Remove hash from private properties

### DIFF
--- a/src/accidental.ts
+++ b/src/accidental.ts
@@ -72,8 +72,8 @@ export class Accidental extends Modifier {
       y?: number;
       line: number;
       /**
-       * The amount by which the accidental requests notes be shifted to the right
-       * to accomodate its presence.
+       * The amount by which the accidental requests that notes be shifted to the right
+       * to accommodate its presence.
        */
       extraXSpaceNeeded: number;
       accidental: Accidental;
@@ -196,7 +196,7 @@ export class Accidental extends Modifier {
     // in 'Tables.accidentalColumnsTable'
     //
     // Beyond 6 vertical accidentals, default to the parallel ascending lines approach,
-    // using as few columns as possible for the verticle structure.
+    // using as few columns as possible for the vertical structure.
     //
     // TODO (?): Allow column to be specified for an accidental at run-time?
 
@@ -211,7 +211,7 @@ export class Accidental extends Modifier {
       while (groupEnd + 1 < staveLineAccidentalLayoutMetrics.length && !noFurtherConflicts) {
         // if this note conflicts with the next:
         if (
-          this.#checkCollision(
+          this.checkCollision(
             staveLineAccidentalLayoutMetrics[groupEnd],
             staveLineAccidentalLayoutMetrics[groupEnd + 1]
           )
@@ -223,7 +223,7 @@ export class Accidental extends Modifier {
         }
       }
 
-      // Gets an a line from the `lineList`, relative to the current group
+      // Gets a line from the `lineList`, relative to the current group
       const getGroupLine = (index: number) => staveLineAccidentalLayoutMetrics[groupStart + index];
       const getGroupLines = (indexes: number[]) => indexes.map(getGroupLine);
       const lineDifference = (indexA: number, indexB: number) => {
@@ -232,13 +232,13 @@ export class Accidental extends Modifier {
       };
 
       const notColliding = (...indexPairs: number[][]) =>
-        indexPairs.map(getGroupLines).every(([line1, line2]) => !this.#checkCollision(line1, line2));
+        indexPairs.map(getGroupLines).every(([line1, line2]) => !this.checkCollision(line1, line2));
 
       // Set columns for the lines in this group:
       const groupLength = groupEnd - groupStart + 1;
 
       // Set the accidental column for each line of the group
-      let endCase = this.#checkCollision(
+      let endCase = this.checkCollision(
         staveLineAccidentalLayoutMetrics[groupStart],
         staveLineAccidentalLayoutMetrics[groupEnd]
       )
@@ -288,7 +288,7 @@ export class Accidental extends Modifier {
           collisionDetected = false;
           for (let line = 0; line + patternLength < staveLineAccidentalLayoutMetrics.length; line++) {
             if (
-              this.#checkCollision(
+              this.checkCollision(
                 staveLineAccidentalLayoutMetrics[line],
                 staveLineAccidentalLayoutMetrics[line + patternLength]
               )
@@ -343,7 +343,7 @@ export class Accidental extends Modifier {
     columnWidths[0] = leftShift + maxExtraXSpaceNeeded;
     columnXOffsets[0] = leftShift;
 
-    // Fill columnWidths with widest needed x-space;
+    // Fill columnWidths with the widest needed x-space;
     // this is what keeps the columns parallel.
     staveLineAccidentalLayoutMetrics.forEach((line) => {
       if (line.width > columnWidths[line.column]) columnWidths[line.column] = line.width;
@@ -360,7 +360,7 @@ export class Accidental extends Modifier {
     staveLineAccidentalLayoutMetrics.forEach((line) => {
       let lineWidth = 0;
       const lastAccOnLine = accCount + line.numAcc;
-      // handle all of the accidentals on a given line:
+      // handle all accidentals on a given line:
       for (accCount; accCount < lastAccOnLine; accCount++) {
         const xShift = columnXOffsets[line.column - 1] + lineWidth + maxExtraXSpaceNeeded;
         accidentalLinePositionsAndSpaceNeeds[accCount].accidental.setXShift(xShift);
@@ -375,7 +375,10 @@ export class Accidental extends Modifier {
   }
 
   /** Helper function to determine whether two lines of accidentals collide vertically */
-  static #checkCollision(line1: StaveLineAccidentalLayoutMetrics, line2: StaveLineAccidentalLayoutMetrics): boolean {
+  protected static checkCollision(
+    line1: StaveLineAccidentalLayoutMetrics,
+    line2: StaveLineAccidentalLayoutMetrics
+  ): boolean {
     let clearance = line2.line - line1.line;
     let clearanceRequired = 3;
     // But less clearance is required for certain accidentals: b, bb and ##.

--- a/src/beam.ts
+++ b/src/beam.ts
@@ -68,26 +68,27 @@ export class Beam extends Element {
   postFormatted: boolean;
   slope: number = 0;
 
-  readonly #stemDirection: number;
-  readonly #ticks: number;
+  private readonly _stemDirection: number;
+  private readonly _ticks: number;
 
-  #yShift: number = 0;
-  #breakOnIndexes: number[];
-  #beamCount: number;
-  #unbeamable?: boolean;
+  protected yShift: number = 0;
+  private breakOnIndexes: number[];
+  private _beamCount: number;
+  // note that this is never set and is a private property.  Remove?
+  private unbeamable?: boolean;
 
   /**
    * Overrides to default beam directions for secondary-level beams that do not
    * connect to any other note. See further explanation at
    * `setPartialBeamSideAt`
    */
-  #forcedPartialDirections: {
+  private forcedPartialDirections: {
     [noteIndex: number]: PartialBeamDirection;
   } = {};
 
   /** Get the direction of the beam */
   getStemDirection(): number {
-    return this.#stemDirection;
+    return this._stemDirection;
   }
 
   /**
@@ -459,18 +460,19 @@ export class Beam extends Element {
     }
 
     // Validate beam line, direction and ticks.
-    this.#ticks = notes[0].getIntrinsicTicks();
+    this._ticks = notes[0].getIntrinsicTicks();
 
-    if (this.#ticks >= Tables.durationToTicks('4')) {
+    if (this._ticks >= Tables.durationToTicks('4')) {
+      // Q(MSAC) -- what about beamed half-note measured tremolos?
       throw new RuntimeError('BadArguments', 'Beams can only be applied to notes shorter than a quarter note.');
     }
 
     let i; // shared iterator
     let note;
 
-    this.#stemDirection = notes[0].getStemDirection();
+    this._stemDirection = notes[0].getStemDirection();
 
-    let stemDirection = this.#stemDirection;
+    let stemDirection = this._stemDirection;
     // Figure out optimal stem direction based on given notes
 
     if (autoStem && isStaveNote(notes[0])) {
@@ -486,15 +488,15 @@ export class Beam extends Element {
       note = notes[i];
       if (autoStem) {
         note.setStemDirection(stemDirection);
-        this.#stemDirection = stemDirection;
+        this._stemDirection = stemDirection;
       }
       note.setBeam(this);
     }
 
     this.postFormatted = false;
     this.notes = notes;
-    this.#beamCount = this.getBeamCount();
-    this.#breakOnIndexes = [];
+    this._beamCount = this.getBeamCount();
+    this.breakOnIndexes = [];
     this.renderOptions = {
       beamWidth: 5,
       maxSlope: 0.25,
@@ -525,7 +527,7 @@ export class Beam extends Element {
 
   /** Set which note `indexes` to break the secondary beam at. */
   breakSecondaryAt(indexes: number[]): this {
-    this.#breakOnIndexes = indexes;
+    this.breakOnIndexes = indexes;
     return this;
   }
 
@@ -543,7 +545,7 @@ export class Beam extends Element {
    * ```
    */
   setPartialBeamSideAt(noteIndex: number, side: PartialBeamDirection) {
-    this.#forcedPartialDirections[noteIndex] = side;
+    this.forcedPartialDirections[noteIndex] = side;
     return this;
   }
 
@@ -552,7 +554,7 @@ export class Beam extends Element {
    * that does not connect to any other notes).
    */
   unsetPartialBeamSideAt(noteIndex: number) {
-    delete this.#forcedPartialDirections[noteIndex];
+    delete this.forcedPartialDirections[noteIndex];
     return this;
   }
 
@@ -573,7 +575,7 @@ export class Beam extends Element {
       renderOptions: { maxSlope, minSlope, slopeIterations, slopeCost },
     } = this;
 
-    const stemDirection = this.#stemDirection;
+    const stemDirection = this._stemDirection;
 
     const firstNote = notes[0];
     const initialSlope = getStemSlope(firstNote, notes[notes.length - 1]);
@@ -625,7 +627,7 @@ export class Beam extends Element {
     }
 
     this.slope = bestSlope;
-    this.#yShift = yShift;
+    this.yShift = yShift;
   }
 
   /** Calculate a slope and y-shift for flat beams. */
@@ -635,7 +637,7 @@ export class Beam extends Element {
       renderOptions: { beamWidth, minFlatBeamOffset, flatBeamOffset },
     } = this;
 
-    const stemDirection = this.#stemDirection;
+    const stemDirection = this._stemDirection;
 
     // If a flat beam offset has not yet been supplied or calculated,
     // generate one based on the notes in this particular note group
@@ -689,7 +691,7 @@ export class Beam extends Element {
 
     // For flat beams, the slope and yShift are 0.
     this.slope = 0;
-    this.#yShift = 0;
+    this.yShift = 0;
   }
 
   /** Return the Beam y offset. */
@@ -717,8 +719,8 @@ export class Beam extends Element {
       renderOptions: { showStemlets, stemletExtension, beamWidth },
     } = this;
 
-    const yShift = this.#yShift;
-    const beamCount = this.#beamCount;
+    const yShift = this.yShift;
+    const beamCount = this._beamCount;
 
     const firstNote = notes[0];
     const firstStemTipY = this.getBeamYToDraw();
@@ -736,7 +738,7 @@ export class Beam extends Element {
           note.getStemDirection() === Stem.UP ? stemTipY - beamedStemTipY : beamedStemTipY - stemTipY;
         // Determine necessary extension for cross-stave notes in the beam group
         let crossStemExtension = 0;
-        if (note.getStemDirection() !== this.#stemDirection) {
+        if (note.getStemDirection() !== this._stemDirection) {
           const beamCount = note.getGlyphProps().beamCount;
           crossStemExtension = (1 + (beamCount - 1) * 1.5) * this.renderOptions.beamWidth;
 
@@ -772,7 +774,7 @@ export class Beam extends Element {
       return BEAM_LEFT;
     }
 
-    const forcedBeamDirection = this.#forcedPartialDirections[noteIndex];
+    const forcedBeamDirection = this.forcedPartialDirections[noteIndex];
     if (forcedBeamDirection) return forcedBeamDirection;
 
     const lookupDuration = `${Tables.durationToNumber(duration) / 2}`;
@@ -813,7 +815,7 @@ export class Beam extends Element {
       // 8th note beams are always drawn.
       if (parseInt(duration, 10) >= 8) {
         // First, check to see if any indexes were set up through breakSecondaryAt()
-        shouldBreak = this.#breakOnIndexes.indexOf(i) !== -1;
+        shouldBreak = this.breakOnIndexes.indexOf(i) !== -1;
 
         // If the secondary breaks were auto-configured in the render options,
         //  handle that as well.
@@ -923,7 +925,7 @@ export class Beam extends Element {
     const firstNote = this.notes[0];
     let beamY = this.getBeamYToDraw();
     const firstStemX = firstNote.getStemX();
-    const beamThickness = this.renderOptions.beamWidth * this.#stemDirection;
+    const beamThickness = this.renderOptions.beamWidth * this._stemDirection;
 
     // Draw the beams.
     for (let i = 0; i < validBeamDurations.length; ++i) {
@@ -983,7 +985,7 @@ export class Beam extends Element {
   draw(): void {
     const ctx = this.checkContext();
     this.setRendered();
-    if (this.#unbeamable) return;
+    if (this.unbeamable) return;
 
     if (!this.postFormatted) {
       this.postFormat();

--- a/src/fraction.ts
+++ b/src/fraction.ts
@@ -14,8 +14,8 @@ export class Fraction {
   }
 
   // Cached objects for comparisons.
-  static #fractionA = new Fraction();
-  static #fractionB = new Fraction();
+  private static fractionA = new Fraction();
+  private static fractionB = new Fraction();
 
   /**
    * GCD: Greatest common divisor using the Euclidean algorithm.
@@ -127,22 +127,22 @@ export class Fraction {
 
   /** Simplify both sides and check if they are equal. */
   equals(compare: Fraction | number): boolean {
-    const a = Fraction.#fractionA.copy(compare).simplify();
-    const b = Fraction.#fractionB.copy(this).simplify();
+    const a = Fraction.fractionA.copy(compare).simplify();
+    const b = Fraction.fractionB.copy(this).simplify();
 
     return a.numerator === b.numerator && a.denominator === b.denominator;
   }
 
   /** Greater than operator. */
   greaterThan(compare: Fraction | number): boolean {
-    const a = Fraction.#fractionA.copy(this);
+    const a = Fraction.fractionA.copy(this);
     a.subtract(compare);
     return a.numerator > 0;
   }
 
   /** Greater than or equals operator. */
   greaterThanEquals(compare: Fraction | number): boolean {
-    const a = Fraction.#fractionA.copy(this);
+    const a = Fraction.fractionA.copy(this);
     a.subtract(compare);
     return a.numerator >= 0;
   }
@@ -171,12 +171,12 @@ export class Fraction {
     }
   }
 
-  /** Return the integer component (eg. 5/2 => 2). */
+  /** Return the integer component (e.g. 5/2 => 2). */
   quotient(): number {
     return Math.floor(this.numerator / this.denominator);
   }
 
-  /** Return the remainder component (eg. 5/2 => 1). */
+  /** Return the remainder component (e.g. 5/2 => 1). */
   remainder(): number {
     return this.numerator % this.denominator;
   }
@@ -188,21 +188,21 @@ export class Fraction {
     return this;
   }
 
-  /** Return a raw string representation (eg. "5/2"). */
+  /** Return a raw string representation (e.g. "5/2"). */
   toString(): string {
     return `${this.numerator}/${this.denominator}`;
   }
 
-  /** Return a simplified string respresentation. */
+  /** Return a simplified string representation. */
   toSimplifiedString(): string {
-    return Fraction.#fractionA.copy(this).simplify().toString();
+    return Fraction.fractionA.copy(this).simplify().toString();
   }
 
   /** Return string representation in mixed form. */
   toMixedString(): string {
     let s = '';
     const q = this.quotient();
-    const f = Fraction.#fractionA.copy(this);
+    const f = Fraction.fractionA.copy(this);
 
     if (q < 0) {
       f.makeAbs();

--- a/src/modifier.ts
+++ b/src/modifier.ts
@@ -61,8 +61,8 @@ export class Modifier extends Element {
   protected textLine: number;
   protected position: ModifierPosition;
 
-  #spacingFromNextModifier: number;
-  #modifierContext?: ModifierContext;
+  protected spacingFromNextModifier: number;
+  protected modifierContext?: ModifierContext;
 
   constructor() {
     super();
@@ -72,7 +72,7 @@ export class Modifier extends Element {
     // The `textLine` is reserved space above or below a stave.
     this.textLine = 0;
     this.position = Modifier.Position.LEFT;
-    this.#spacingFromNextModifier = 0;
+    this.spacingFromNextModifier = 0;
   }
 
   /** Called when position changes. */
@@ -122,17 +122,17 @@ export class Modifier extends Element {
 
   /** Get `ModifierContext`. */
   getModifierContext(): ModifierContext | undefined {
-    return this.#modifierContext;
+    return this.modifierContext;
   }
 
   /** Check and get `ModifierContext`. */
   checkModifierContext(): ModifierContext {
-    return defined(this.#modifierContext, 'NoModifierContext', 'Modifier Context Required');
+    return defined(this.modifierContext, 'NoModifierContext', 'Modifier Context Required');
   }
 
   /** Every modifier must be part of a `ModifierContext`. */
   setModifierContext(c: ModifierContext): this {
-    this.#modifierContext = c;
+    this.modifierContext = c;
     return this;
   }
 
@@ -165,12 +165,12 @@ export class Modifier extends Element {
 
   /** Set spacing from next modifier. */
   setSpacingFromNextModifier(x: number): void {
-    this.#spacingFromNextModifier = x;
+    this.spacingFromNextModifier = x;
   }
 
   /** Get spacing from next modifier. */
   getSpacingFromNextModifier(): number {
-    return this.#spacingFromNextModifier;
+    return this.spacingFromNextModifier;
   }
 
   /**

--- a/src/multimeasurerest.ts
+++ b/src/multimeasurerest.ts
@@ -10,7 +10,7 @@ import { Stave } from './stave';
 import { StaveModifierPosition } from './stavemodifier';
 import { Tables } from './tables';
 import { Category, isBarline } from './typeguard';
-import { defined } from './util';
+import { defined, RuntimeError } from './util';
 
 export interface MultimeasureRestRenderOptions {
   /** Extracted by Factory.MultiMeasureRest() and passed to the MultiMeasureRest constructor. */
@@ -64,10 +64,10 @@ export class MultiMeasureRest extends Element {
 
   protected stave?: Stave;
 
-  #hasPaddingLeft = false;
-  #hasPaddingRight = false;
-  #hasLineThickness = false;
-  #hasSymbolSpacing = false;
+  protected hasPaddingLeft = false;
+  protected hasPaddingRight = false;
+  protected hasLineThickness = false;
+  protected hasSymbolSpacing = false;
 
   /**
    *
@@ -88,10 +88,10 @@ export class MultiMeasureRest extends Element {
     }
 
     // Keep track of whether these four options were provided.
-    this.#hasPaddingLeft = typeof options.paddingLeft === 'number';
-    this.#hasPaddingRight = typeof options.paddingRight === 'number';
-    this.#hasLineThickness = typeof options.lineThickness === 'number';
-    this.#hasSymbolSpacing = typeof options.symbolSpacing === 'number';
+    this.hasPaddingLeft = typeof options.paddingLeft === 'number';
+    this.hasPaddingRight = typeof options.paddingRight === 'number';
+    this.hasLineThickness = typeof options.lineThickness === 'number';
+    this.hasSymbolSpacing = typeof options.symbolSpacing === 'number';
 
     this.renderOptions = {
       useSymbols: false,
@@ -138,7 +138,11 @@ export class MultiMeasureRest extends Element {
     const el = new Element();
     el.setText(txt);
     // Add middle bars until the right padding is reached
-    for (let i = 1; (i + 2) * el.getWidth() + left <= right; i++) {
+    const elWidth = el.getWidth();
+    if (!elWidth) {
+      throw new RuntimeError('Cannot drawLine if width is 0');
+    }
+    for (let i = 1; (i + 2) * elWidth + left <= right; i++) {
       txt += '\ue4f0'; /*restHBarMiddle*/
     }
     txt += '\ue4f1'; /*restHBarRight*/
@@ -202,10 +206,10 @@ export class MultiMeasureRest extends Element {
     }
 
     const options = this.renderOptions;
-    if (this.#hasPaddingLeft) {
+    if (this.hasPaddingLeft) {
       left = stave.getX() + options.paddingLeft;
     }
-    if (this.#hasPaddingRight) {
+    if (this.hasPaddingRight) {
       right = stave.getX() + stave.getWidth() - options.paddingRight;
     }
 

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -42,20 +42,20 @@ export interface RegistryUpdate {
 }
 
 export class Registry {
-  static #defaultRegistry?: Registry;
+  protected static defaultRegistry?: Registry;
 
   static getDefaultRegistry(): Registry | undefined {
-    return Registry.#defaultRegistry;
+    return Registry.defaultRegistry;
   }
 
   // If you call `enableDefaultRegistry`, any new elements will auto-register with
   // the provided registry as soon as they're constructed.
   static enableDefaultRegistry(registry: Registry): void {
-    Registry.#defaultRegistry = registry;
+    Registry.defaultRegistry = registry;
   }
 
   static disableDefaultRegistry(): void {
-    Registry.#defaultRegistry = undefined;
+    Registry.defaultRegistry = undefined;
   }
 
   protected index: Index;

--- a/src/stavetempo.ts
+++ b/src/stavetempo.ts
@@ -18,7 +18,7 @@ export interface StaveTempoOptions {
   parenthesis?: boolean;
   /**
    * Indicates the graphical note type to use in a metronome mark.
-   * see: `StaveTempo.#durationToCode`.
+   * see: `StaveTempo.durationToCode`.
    */
   duration?: string;
   /**
@@ -33,7 +33,7 @@ export interface StaveTempoOptions {
   /**
    * Indicates the graphical note type to use at the right of the equation
    *  in a metronome mark.
-   * see: `StaveTempo.#durationToCode`.
+   * see: `StaveTempo.durationToCode`.
    */
   duration2?: string;
   /**
@@ -59,7 +59,7 @@ export class StaveTempo extends StaveModifier {
     this.setYShift(shiftY);
   }
 
-  #durationToCode: Record<string, string> = {
+  protected durationToCode: Record<string, string> = {
     '1/4': Glyphs.metNoteDoubleWholeSquare,
     long: Glyphs.metNoteDoubleWholeSquare,
     '1/2': Glyphs.metNoteDoubleWhole,
@@ -120,7 +120,7 @@ export class StaveTempo extends StaveModifier {
     }
 
     if (duration) {
-      el.setText(this.#durationToCode[duration]);
+      el.setText(this.durationToCode[duration]);
       el.renderText(ctx, x + this.xShift, y + this.yShift);
       x += el.getWidth() + 3;
       if (dots) {
@@ -135,7 +135,7 @@ export class StaveTempo extends StaveModifier {
       elText.renderText(ctx, x + this.xShift, y + this.yShift);
       x += elText.getWidth() + 3;
       if (duration2) {
-        el.setText(this.#durationToCode[duration2]);
+        el.setText(this.durationToCode[duration2]);
         el.renderText(ctx, x + this.xShift, y + this.yShift);
         x += el.getWidth() + 3;
         if (dots2) {

--- a/src/svgcontext.ts
+++ b/src/svgcontext.ts
@@ -90,7 +90,7 @@ export class SVGContext extends RenderContext {
 
     this.precision = Math.pow(10, Tables.RENDER_PRECISION_PLACES);
 
-    // Create a SVG element and add it to the container element.
+    // Create an SVG element and add it to the container element.
     const svg = this.create('svg');
     svg.setAttribute('pointer-events', 'none');
     this.element.appendChild(svg);
@@ -281,7 +281,7 @@ export class SVGContext extends RenderContext {
     // style.width / style.height properties that are applied to
     // the SVG object from our internal conception of the SVG
     // width/height.  This would allow us to create automatically
-    // scaling SVG's that filled their containers, for instance.
+    // scaling SVGs that filled their containers, for instance.
     //
     // As this isn't implemented in Canvas contexts,
     // I've left as is for now, but in using the viewBox to
@@ -502,7 +502,7 @@ export class SVGContext extends RenderContext {
     return this;
   }
 
-  #getShadowStyle(): string {
+  protected getShadowStyle(): string {
     // A CSS drop-shadow filter blur looks different than a canvas shadowBlur
     // of the same radius, so we scale the drop-shadow radius here to make it
     // look close to the canvas shadow.
@@ -517,7 +517,7 @@ export class SVGContext extends RenderContext {
 
     attributes.d = this.path;
     if ((this.attributes.shadowBlur as number) > 0) {
-      attributes.style = this.#getShadowStyle();
+      attributes.style = this.getShadowStyle();
     }
 
     this.applyAttributes(path, attributes);
@@ -533,7 +533,7 @@ export class SVGContext extends RenderContext {
       d: this.path,
     };
     if ((this.attributes.shadowBlur as number) > 0) {
-      attributes.style = this.#getShadowStyle();
+      attributes.style = this.getShadowStyle();
     }
 
     this.applyAttributes(path, attributes);

--- a/src/tickable.ts
+++ b/src/tickable.ts
@@ -51,8 +51,8 @@ export abstract class Tickable extends Element {
   protected intrinsicTicks: number;
   protected alignCenter: boolean;
 
-  #preFormatted: boolean = false;
-  #postFormatted: boolean = false;
+  private _preFormatted: boolean = false;
+  private _postFormatted: boolean = false;
 
   constructor() {
     super();
@@ -121,7 +121,7 @@ export abstract class Tickable extends Element {
 
   /** Get width of note. Used by the formatter for positioning. */
   getWidth(): number {
-    if (!this.#preFormatted) {
+    if (!this._preFormatted) {
       throw new RuntimeError('UnformattedNote', "Can't call GetWidth on an unformatted note.");
     }
 
@@ -247,7 +247,7 @@ export abstract class Tickable extends Element {
       this.modifierContext.addMember(this.modifiers[i]);
     }
     this.modifierContext.addMember(this);
-    this.#preFormatted = false;
+    this._preFormatted = false;
     return this;
   }
 
@@ -258,7 +258,7 @@ export abstract class Tickable extends Element {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   addModifier(modifier: Modifier, index: number = 0): this {
     this.modifiers.push(modifier);
-    this.#preFormatted = false;
+    this._preFormatted = false;
     return this;
   }
 
@@ -270,7 +270,7 @@ export abstract class Tickable extends Element {
   /** Set the Tick Context. */
   setTickContext(tc: TickContext): void {
     this.tickContext = tc;
-    this.#preFormatted = false;
+    this._preFormatted = false;
   }
 
   checkTickContext(message = 'Tickable has no tick context.'): TickContext {
@@ -279,7 +279,7 @@ export abstract class Tickable extends Element {
 
   /** Preformat the Tickable. */
   preFormat(): void {
-    if (this.#preFormatted) return;
+    if (this._preFormatted) return;
 
     this.width = 0;
     if (this.modifierContext) {
@@ -290,27 +290,27 @@ export abstract class Tickable extends Element {
 
   /** Set preformatted status. */
   set preFormatted(value: boolean) {
-    this.#preFormatted = value;
+    this._preFormatted = value;
   }
 
   get preFormatted(): boolean {
-    return this.#preFormatted;
+    return this._preFormatted;
   }
 
   /** Postformat the Tickable. */
   postFormat(): this {
-    if (this.#postFormatted) return this;
-    this.#postFormatted = true;
+    if (this._postFormatted) return this;
+    this._postFormatted = true;
     return this;
   }
 
   /** Set postformatted status. */
   set postFormatted(value: boolean) {
-    this.#postFormatted = value;
+    this._postFormatted = value;
   }
 
   get postFormatted(): boolean {
-    return this.#postFormatted;
+    return this._postFormatted;
   }
 
   /** Return the intrinsic ticks. */

--- a/src/vibrato.ts
+++ b/src/vibrato.ts
@@ -6,6 +6,7 @@ import { Modifier } from './modifier';
 import { ModifierContext, ModifierContextState } from './modifiercontext';
 import { Tables } from './tables';
 import { Category } from './typeguard';
+import { RuntimeError } from './util';
 
 export interface VibratoRenderOptions {
   code: number;
@@ -68,8 +69,12 @@ export class Vibrato extends Modifier {
   setVibratoWidth(width: number): this {
     this.renderOptions.width = width;
     this.text = String.fromCodePoint(this.renderOptions.code);
+    const myWidth = this.getWidth();
+    if (!myWidth) {
+      throw new RuntimeError('Cannot set vibrato width if width is 0');
+    }
 
-    const items = Math.round(this.renderOptions.width / this.getWidth());
+    const items = Math.round(this.renderOptions.width / myWidth);
     for (let i = 1; i < items; i++) {
       this.text += String.fromCodePoint(this.renderOptions.code);
     }

--- a/tests/flow-headless-browser.html
+++ b/tests/flow-headless-browser.html
@@ -9,7 +9,7 @@
     <div id="font-preload">
       <!--
         Preload fonts and styles for testing.
-        The empty tags <b></b>, <i></i>, and <span style="font-weight: xxx"></span> are for loading different font weights/styles. 
+        The empty tags <b></b>, <i></i>, and <span style="font-weight: xxx"></span> are for loading different font weights/styles.
       -->
       <span style="font-family: Academico"><b></b></span>
       <span style="font-family: Bravura"></span>
@@ -48,6 +48,8 @@
     <script>
       QUnit.config.autostart = false;
       QUnit.config.noglobals = true;
+      // uncomment below to detect infinite loops in tests.
+      // QUnit.testStart(d => console.log(d.name, d.module));
       VexFlow.Test.run();
       QUnit.start();
     </script>

--- a/tests/vexflow_test_helpers.ts
+++ b/tests/vexflow_test_helpers.ts
@@ -232,11 +232,11 @@ export class VexFlowTests {
     NODE_TEST_CONFIG.fontStacks = fontStacks;
   }
 
-  static #NEXT_TEST_ID = 0;
+  private static NEXT_TEST_ID = 0;
 
   /** Return a unique ID for a test. */
   static generateTestID(prefix: string): string {
-    return prefix + '_' + VexFlowTests.#NEXT_TEST_ID++;
+    return prefix + '_' + VexFlowTests.NEXT_TEST_ID++;
   }
 
   /**


### PR DESCRIPTION
For many of them I looked up in the past whether they were protected or private (or if they were mentioned in docs) and set protected or private accordingly.  For the rest I used my best judgment about whether I would ever want to query them outside of the system or not.

Fixes #179 

Add runtime tests for two cases where zero-width element would cause infinite loops -- these came up when my code was buggy, but figured it's worth keeping the tests in.

Running visual differences now.