### PR TITLE
Use string literal union for key signature type

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -297,7 +297,7 @@ export class Factory {
     return timeSigNote;
   }
 
-  KeySigNote(params: { key: KeySpec; cancelKey?: string; alterKey?: string[] }): KeySigNote {
+  KeySigNote(params: { key: KeySpec; cancelKey?: KeySpec; alterKey?: string[] }): KeySigNote {
     const keySigNote = new KeySigNote(params.key, params.cancelKey, params.alterKey);
     if (this.stave) keySigNote.setStave(this.stave);
     keySigNote.setContext(this.context);

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -20,6 +20,7 @@ import { GhostNote } from './ghostnote';
 import { GlyphNote, GlyphNoteOptions } from './glyphnote';
 import { GraceNote, GraceNoteStruct } from './gracenote';
 import { GraceNoteGroup } from './gracenotegroup';
+import { KeySpec } from './keysignature';
 import { KeySigNote } from './keysignote';
 import { ModifierContext } from './modifiercontext';
 import { MultiMeasureRest, MultimeasureRestRenderOptions } from './multimeasurerest';
@@ -296,7 +297,7 @@ export class Factory {
     return timeSigNote;
   }
 
-  KeySigNote(params: { key: string; cancelKey?: string; alterKey?: string[] }): KeySigNote {
+  KeySigNote(params: { key: KeySpec; cancelKey?: string; alterKey?: string[] }): KeySigNote {
     const keySigNote = new KeySigNote(params.key, params.cancelKey, params.alterKey);
     if (this.stave) keySigNote.setStave(this.stave);
     keySigNote.setContext(this.context);

--- a/src/keysignature.ts
+++ b/src/keysignature.ts
@@ -58,7 +58,7 @@ export class KeySignature extends StaveModifier {
   protected keySpec?: KeySpec;
   protected alterKeySpec?: string[];
 
-  constructor(keySpec: KeySpec, cancelKeySpec?: string, alterKeySpec?: string[]) {
+  constructor(keySpec: KeySpec, cancelKeySpec?: KeySpec, alterKeySpec?: string[]) {
     super();
 
     this.setKeySig(keySpec, cancelKeySpec, alterKeySpec);

--- a/src/keysignature.ts
+++ b/src/keysignature.ts
@@ -13,6 +13,38 @@ import { Tables } from './tables';
 import { Category } from './typeguard';
 import { defined } from './util';
 
+export type KeySpec =
+  | 'C'
+  | 'Am'
+  | 'F'
+  | 'Dm'
+  | 'Bb'
+  | 'Gm'
+  | 'Eb'
+  | 'Cm'
+  | 'Ab'
+  | 'Fm'
+  | 'Db'
+  | 'Bbm'
+  | 'Gb'
+  | 'Ebm'
+  | 'Cb'
+  | 'Abm'
+  | 'G'
+  | 'Em'
+  | 'D'
+  | 'Bm'
+  | 'A'
+  | 'F#m'
+  | 'E'
+  | 'C#m'
+  | 'B'
+  | 'G#m'
+  | 'F#'
+  | 'D#m'
+  | 'C#'
+  | 'A#m';
+
 export class KeySignature extends StaveModifier {
   static get CATEGORY(): string {
     return Category.KeySignature;
@@ -23,11 +55,10 @@ export class KeySignature extends StaveModifier {
   protected formatted?: boolean;
   protected cancelKeySpec?: string;
   protected accList: { type: string; line: number }[] = [];
-  protected keySpec?: string;
+  protected keySpec?: KeySpec;
   protected alterKeySpec?: string[];
 
-  // Create a new Key Signature based on a `keySpec`
-  constructor(keySpec: string, cancelKeySpec?: string, alterKeySpec?: string[]) {
+  constructor(keySpec: KeySpec, cancelKeySpec?: string, alterKeySpec?: string[]) {
     super();
 
     this.setKeySig(keySpec, cancelKeySpec, alterKeySpec);
@@ -170,7 +201,7 @@ export class KeySignature extends StaveModifier {
     return this.width;
   }
 
-  setKeySig(keySpec: string, cancelKeySpec?: string, alterKeySpec?: string[]): this {
+  setKeySig(keySpec: KeySpec, cancelKeySpec?: string, alterKeySpec?: string[]): this {
     this.formatted = false;
     this.keySpec = keySpec;
     this.cancelKeySpec = cancelKeySpec;

--- a/src/keysignote.ts
+++ b/src/keysignote.ts
@@ -13,7 +13,7 @@ export class KeySigNote extends Note {
 
   protected keySignature: KeySignature;
 
-  constructor(keySpec: KeySpec, cancelKeySpec?: string, alterKeySpec?: string[]) {
+  constructor(keySpec: KeySpec, cancelKeySpec?: KeySpec, alterKeySpec?: string[]) {
     super({ duration: 'b' });
 
     this.keySignature = new KeySignature(keySpec, cancelKeySpec, alterKeySpec);

--- a/src/keysignote.ts
+++ b/src/keysignote.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2023-present VexFlow contributors: https://github.com/vexflow/vexflow/graphs/contributors
 // @author: Mark Meeus 2019
 
-import { KeySignature } from './keysignature';
+import { KeySignature, KeySpec } from './keysignature';
 import { ModifierContext } from './modifiercontext';
 import { Note } from './note';
 import { Category } from './typeguard';
@@ -13,7 +13,7 @@ export class KeySigNote extends Note {
 
   protected keySignature: KeySignature;
 
-  constructor(keySpec: string, cancelKeySpec?: string, alterKeySpec?: string[]) {
+  constructor(keySpec: KeySpec, cancelKeySpec?: string, alterKeySpec?: string[]) {
     super({ duration: 'b' });
 
     this.keySignature = new KeySignature(keySpec, cancelKeySpec, alterKeySpec);

--- a/src/stave.ts
+++ b/src/stave.ts
@@ -4,7 +4,7 @@
 import { BoundingBox, Bounds } from './boundingbox';
 import { Clef } from './clef';
 import { Element, ElementStyle } from './element';
-import { KeySignature } from './keysignature';
+import { KeySignature, KeySpec } from './keysignature';
 import { Metrics } from './metrics';
 import { Barline, BarlineType } from './stavebarline';
 import { StaveModifier, StaveModifierPosition } from './stavemodifier';
@@ -442,7 +442,7 @@ export class Stave extends Element {
     return this.endClef;
   }
 
-  setKeySignature(keySpec: string, cancelKeySpec?: string, position?: number): this {
+  setKeySignature(keySpec: KeySpec, cancelKeySpec?: string, position?: number): this {
     if (position === undefined) {
       position = StaveModifierPosition.BEGIN;
     }
@@ -457,7 +457,7 @@ export class Stave extends Element {
     return this;
   }
 
-  setEndKeySignature(keySpec: string, cancelKeySpec?: string): this {
+  setEndKeySignature(keySpec: KeySpec, cancelKeySpec?: string): this {
     this.setKeySignature(keySpec, cancelKeySpec, StaveModifierPosition.END);
     return this;
   }
@@ -485,14 +485,16 @@ export class Stave extends Element {
   /**
    * Add a key signature to the stave.
    *
-   * Example:
-   * `stave.addKeySignature('Db');`
-   * @param keySpec new key specification `[A-G][b|#]?`
+   * @example
+   * ```
+   * stave.addKeySignature('Db')
+   * ```
+   * @param keySpec new key specification `[A-G][b|#]?m?`
    * @param cancelKeySpec
    * @param position
    * @returns
    */
-  addKeySignature(keySpec: string, cancelKeySpec?: string, position?: number): this {
+  addKeySignature(keySpec: KeySpec, cancelKeySpec?: string, position?: number): this {
     if (position === undefined) {
       position = StaveModifierPosition.BEGIN;
     }

--- a/src/stave.ts
+++ b/src/stave.ts
@@ -442,7 +442,7 @@ export class Stave extends Element {
     return this.endClef;
   }
 
-  setKeySignature(keySpec: KeySpec, cancelKeySpec?: string, position?: number): this {
+  setKeySignature(keySpec: KeySpec, cancelKeySpec?: KeySpec, position?: number): this {
     if (position === undefined) {
       position = StaveModifierPosition.BEGIN;
     }
@@ -457,7 +457,7 @@ export class Stave extends Element {
     return this;
   }
 
-  setEndKeySignature(keySpec: KeySpec, cancelKeySpec?: string): this {
+  setEndKeySignature(keySpec: KeySpec, cancelKeySpec?: KeySpec): this {
     this.setKeySignature(keySpec, cancelKeySpec, StaveModifierPosition.END);
     return this;
   }
@@ -494,7 +494,7 @@ export class Stave extends Element {
    * @param position
    * @returns
    */
-  addKeySignature(keySpec: KeySpec, cancelKeySpec?: string, position?: number): this {
+  addKeySignature(keySpec: KeySpec, cancelKeySpec?: KeySpec, position?: number): this {
     if (position === undefined) {
       position = StaveModifierPosition.BEGIN;
     }

--- a/tests/keysignature_tests.ts
+++ b/tests/keysignature_tests.ts
@@ -171,7 +171,7 @@ function keysCanceledForEachClef(options: TestOptions, contextBuilder: ContextBu
   const scale = 0.8;
   const w = fontWidths();
   const keyPadding = 10;
-  const keys = ['C#', 'Cb'];
+  const keys = ['C#', 'Cb'] as const;
   const flatsKey = [7, 14];
   const sharpsKey = [14, 7];
   const natsKey = [7, 7];

--- a/tests/vexflow_test_helpers.ts
+++ b/tests/vexflow_test_helpers.ts
@@ -444,7 +444,7 @@ export const MAJOR_KEYS = [
   'B',
   'F#',
   'C#',
-];
+] as const;
 export const MINOR_KEYS = [
   'Am',
   'Dm',
@@ -461,4 +461,4 @@ export const MINOR_KEYS = [
   'G#m',
   'D#m',
   'A#m',
-];
+] as const;


### PR DESCRIPTION
Key signatures are a known set of string literals, so this improves the typing on them