### PR TITLE
Use of nullish coalescing operator with minus

### DIFF
--- a/src/stave.ts
+++ b/src/stave.ts
@@ -656,7 +656,7 @@ export class Stave extends Element {
           widths.right = layoutMetrics.xMax ?? 0;
           widths.paddingRight = layoutMetrics.paddingRight ?? 0;
         }
-        widths.left = -layoutMetrics.xMin ?? 0;
+        widths.left = -(layoutMetrics.xMin ?? 0);
         widths.paddingLeft = layoutMetrics.paddingLeft ?? 0;
 
         if (i === endModifiers.length - 1) {


### PR DESCRIPTION
I was building a new project that uses Vexflow, and saw a warning from ESBuild.

> [WARNING] The "??" operator here will always return the left operand [suspicious-nullish-coalescing]

```
vexflow/src/stave.ts:659:22:
    659 │         widths.left = -layoutMetrics.xMin ?? 0;
        ╵                       ~~~~~~~~~~~~~~~~~~~
```

>  The left operand of the "??" operator here will never be null or undefined, so it will always be returned. This usually indicates a bug in your code.


The underlined part of the code has a minus `-` that always tries to coerce `layoutMetrics.xMin` into a number; when it's undefined that results in `NaN`, so it never reaches `0`.

To correct this I changed it to:

```js
widths.left = -(layoutMetrics.xMin ?? 0);
```

The warning no longer appears. This seems to be the intended behavior, but maybe that minus is not supposed to be there at all? Later in the code, `widths.left` is used like:

```js
x -= widths.left;
```
