### PR TITLE
fix tabstave measure numbers

### DIFF
--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -196,6 +196,10 @@ export const MetricsDefaults: Record<string, any> = {
     fontWeight: 'bold',
   },
 
+  TabStave: {
+    fontSize: 8,
+  },
+
   TabTie: {
     fontSize: 10,
   },

--- a/tests/tabstave_tests.ts
+++ b/tests/tabstave_tests.ts
@@ -19,6 +19,7 @@ const TabStaveTests = {
 function draw(options: TestOptions, contextBuilder: ContextBuilder): void {
   const ctx = contextBuilder(options.elementId, 400, 160);
   const stave = new TabStave(10, 10, 300);
+  stave.setMeasure(1);
   stave.setNumLines(6);
   stave.setContext(ctx);
   stave.draw();


### PR DESCRIPTION
fixes #207 

Metric defined and TabStave test modified to include measure number.

![image](https://github.com/vexflow/vexflow/assets/22865285/e56792ca-dcc7-4374-b1ba-994e1490e201)
