### PR TITLE
Adjust pedalmarkins end

### DIFF
--- a/src/pedalmarking.ts
+++ b/src/pedalmarking.ts
@@ -4,27 +4,13 @@
 import { Element } from './element';
 import { Glyphs } from './glyphs';
 import { Metrics } from './metrics';
-import { RenderContext } from './rendercontext';
 import { StaveNote } from './stavenote';
-import { Tables } from './tables';
 import { Category } from './typeguard';
 import { log, RuntimeError } from './util';
 
 // eslint-disable-next-line
 function L(...args: any[]) {
   if (PedalMarking.DEBUG) log('VexFlow.PedalMarking', args);
-}
-
-/**
- * Draws a pedal glyph with the provided `name` on a rendering `context`
- * at the coordinates `x` and `y. Takes into account the glyph data
- * coordinate shifts. Returns the width of the glyph.
- */
-function drawPedalGlyph(name: string, ctx: RenderContext, x: number, y: number): number {
-  const glyph = new Element(PedalMarking.CATEGORY);
-  glyph.setText(PedalMarking.GLYPHS[name] ?? name);
-  glyph.renderText(ctx, x - (glyph.getWidth() - Tables.STAVE_LINE_DISTANCE) / 2, y);
-  return glyph.getWidth();
 }
 
 /**
@@ -44,8 +30,8 @@ export class PedalMarking extends Element {
 
   protected line: number;
   protected type: number;
-  protected customDepressText: string;
-  protected customReleaseText: string;
+  protected depressText: string;
+  protected releaseText: string;
 
   public renderOptions: {
     color: string;
@@ -107,9 +93,9 @@ export class PedalMarking extends Element {
     this.type = PedalMarking.type.TEXT;
     this.line = 0;
 
-    // Custom text for the release/depress markings
-    this.customDepressText = '';
-    this.customReleaseText = '';
+    // Text for the release/depress markings
+    this.depressText = PedalMarking.GLYPHS.pedalDepress;
+    this.releaseText = PedalMarking.GLYPHS.pedalRelease;
 
     this.renderOptions = {
       bracketHeight: 10,
@@ -134,8 +120,9 @@ export class PedalMarking extends Element {
    * set if the parameter is falsy.
    */
   setCustomText(depress: string, release?: string): this {
-    this.customDepressText = depress || '';
-    this.customReleaseText = release || '';
+    this.depressText = depress || '';
+    this.releaseText = release || '';
+    this.setFont(Metrics.getFontInfo('PedalMarking.text'));
     return this;
   }
 
@@ -181,16 +168,10 @@ export class PedalMarking extends Element {
 
         if (this.type === PedalMarking.type.MIXED && !prevNoteIsSame) {
           // For MIXED style, start with text instead of bracket
-          if (this.customDepressText) {
-            // If we have custom text, use instead of the default "Ped" glyph
-            textWidth = ctx.measureText(this.customDepressText).width;
-            ctx.fillText(this.customDepressText, x - (textWidth - Tables.STAVE_LINE_DISTANCE) / 2, y);
-          } else {
-            // Render the Ped glyph in position
-            textWidth = drawPedalGlyph('pedalDepress', ctx, x, y);
-          }
+          textWidth = ctx.measureText(this.depressText).width;
+          ctx.fillText(this.depressText, x, y);
           // Adjust the xShift for the next note
-          xShift = textWidth / 2 + Tables.STAVE_LINE_DISTANCE / 2 + this.renderOptions.textMarginRight;
+          xShift = textWidth + this.renderOptions.textMarginRight;
         } else {
           // Draw start bracket
           ctx.beginPath();
@@ -203,27 +184,20 @@ export class PedalMarking extends Element {
         // Get the current note index and the total notes in the associated voice
         const noteNdx = note.getVoice().getTickables().indexOf(note);
         const voiceNotes = note.getVoice().getTickables().length;
-        // Get the shift for the next note
-        const nextNoteShift =
+        // Get the absolute x position of the end of the current note
+        const noteEndX =
           noteNdx + 1 < voiceNotes ? 
           // If the next note is in the same voice, use the x position of the next note
-          note.getVoice().getTickables()[noteNdx+1].getAbsoluteX() - x :
+          note.getVoice().getTickables()[noteNdx+1].getAbsoluteX() :
           // If this is the last note is the voice, use the x position of the next stave
-          (note.getStave()?.getX() ?? 0) + (note.getStave()?.getWidth() ?? 0) - x;
-        // Adjustment for release+depress
-        xShift = 
-          nextNoteIsSame ?
-          // If the next note is the same, leave 5 points of space
-          -5 :
-          // Otherwise, shift to the right by half the text width
-          nextNoteShift - (notes[index + 1]?textWidth / 2:0) - 5;
+          (note.getStave()?.getX() ?? 0) + (note.getStave()?.getWidth() ?? 0);
 
         // Draw end bracket
         ctx.beginPath();
         ctx.moveTo(prevX, prevY);
-        ctx.lineTo(x + xShift, y);
+        ctx.lineTo(nextNoteIsSame ? x - 5 : noteEndX - 5, y);
         // No shift if next note is the same
-        ctx.lineTo(x + (nextNoteIsSame ? 0 : xShift), y - this.renderOptions.bracketHeight);
+        ctx.lineTo(nextNoteIsSame ? x : noteEndX - 5, y - this.renderOptions.bracketHeight);
         ctx.stroke();
         ctx.closePath();
       }
@@ -241,6 +215,7 @@ export class PedalMarking extends Element {
   drawText(): void {
     const ctx = this.checkContext();
     let isPedalDepressed = false;
+    let textWidth = 0;
 
     // Iterate through each note, placing glyphs or custom text accordingly
     this.notes.forEach((note) => {
@@ -249,21 +224,21 @@ export class PedalMarking extends Element {
       const x = note.getAbsoluteX();
       const y = stave.getYForBottomText(this.line + 3);
 
-      let textWidth = 0;
       if (isPedalDepressed) {
-        if (this.customDepressText) {
-          textWidth = ctx.measureText(this.customDepressText).width;
-          ctx.fillText(this.customDepressText, x - textWidth / 2, y);
-        } else {
-          drawPedalGlyph('pedalDepress', ctx, x, y);
-        }
+        textWidth = ctx.measureText(this.depressText).width;
+        ctx.fillText(this.depressText, x, y);
       } else {
-        if (this.customReleaseText) {
-          textWidth = ctx.measureText(this.customReleaseText).width;
-          ctx.fillText(this.customReleaseText, x - textWidth / 2, y);
-        } else {
-          drawPedalGlyph('pedalRelease', ctx, x, y);
-        }
+        const noteNdx = note.getVoice().getTickables().indexOf(note);
+        const voiceNotes = note.getVoice().getTickables().length;
+        // Get the shift for the next note
+        const noteEndX =
+          noteNdx + 1 < voiceNotes ? 
+          // If the next note is in the same voice, use the x position of the next note
+          note.getVoice().getTickables()[noteNdx+1].getAbsoluteX() :
+          // If this is the last note is the voice, use the x position of the next stave
+          (note.getStave()?.getX() ?? 0) + (note.getStave()?.getWidth() ?? 0) ;
+        textWidth = ctx.measureText(this.releaseText).width;
+        ctx.fillText(this.releaseText, noteEndX - textWidth, y);
       }
     });
   }
@@ -276,7 +251,7 @@ export class PedalMarking extends Element {
     ctx.save();
     ctx.setStrokeStyle(this.renderOptions.color);
     ctx.setFillStyle(this.renderOptions.color);
-    ctx.setFont(Metrics.getFontInfo('PedalMarking.text'));
+    ctx.setFont(this.font);
     L('Rendering Pedal Marking');
 
     if (this.type === PedalMarking.type.BRACKET || this.type === PedalMarking.type.MIXED) {

--- a/tests/pedalmarking_tests.ts
+++ b/tests/pedalmarking_tests.ts
@@ -17,9 +17,14 @@ const PedalMarkingTests = {
 
     const run = VexFlowTests.runTests;
     run('Simple Pedal 1', simple1);
+    run('Simple Pedal 1b', simple1b);
     run('Simple Pedal 2', simple2);
+    run('Simple Pedal 2b', simple2b);
     run('Simple Pedal 3', simple3);
+    run('Simple Pedal 3b', simple3b);
+    run('Release and Depress on Same Note 1b', releaseDepress1b);
     run('Release and Depress on Same Note 1', releaseDepress1);
+    run('Release and Depress on Same Note 2b', releaseDepress2b);
     run('Release and Depress on Same Note 2', releaseDepress2);
     run('Custom Text 1', customTest1);
     run('Custom Text 2', customTest2);
@@ -50,6 +55,29 @@ function createTest(makePedal: (f: Factory, v1: Tickable[], v2: Tickable[]) => v
   };
 }
 
+function createTest2(makePedal: (f: Factory, v1: Tickable[], v2: Tickable[]) => void) {
+  return (options: TestOptions) => {
+    const f = VexFlowTests.makeFactory(options, 550, 200);
+    const score = f.EasyScore();
+
+    const stave0 = f.Stave({ width: 250 }).addClef('treble');
+    const voice0 = score.voice(score.notes('b4/4, b4, b4, b4[stem="down"]', { stem: 'up' }));
+    const voice0b = score.voice(score.notes('b5/4, b5, b5, b5[stem="down"]', { stem: 'up' }));
+    f.Formatter().joinVoices([voice0, voice0b]).formatToStave([voice0, voice0b], stave0);
+
+    const stave1 = f.Stave({ width: 260, x: 250 });
+    const voice1 = score.voice(score.notes('c4/4, c4, c4, c4', { stem: 'up' }));
+    const voice1b = score.voice(score.notes('c5/4, c5, c5, c5/16, c5/16, c5/16, c5/16', { stem: 'up' }));
+    f.Formatter().joinVoices([voice1, voice1b]).formatToStave([voice1, voice1b], stave1);
+
+    makePedal(f, voice0.getTickables(), voice1.getTickables());
+
+    f.draw();
+
+    options.assert.ok(true, 'Must render');
+  };
+}
+
 function withSimplePedal(style: string) {
   return (factory: Factory, notes0: Tickable[], notes1: Tickable[]) =>
     factory.PedalMarking({
@@ -71,6 +99,11 @@ const simple2 = createTest(withSimplePedal('bracket'));
 const simple3 = createTest(withSimplePedal('mixed'));
 const releaseDepress1 = createTest(withReleaseAndDepressedPedal('bracket'));
 const releaseDepress2 = createTest(withReleaseAndDepressedPedal('mixed'));
+const simple1b = createTest2(withSimplePedal('text'));
+const simple2b = createTest2(withSimplePedal('bracket'));
+const simple3b = createTest2(withSimplePedal('mixed'));
+const releaseDepress1b = createTest2(withReleaseAndDepressedPedal('bracket'));
+const releaseDepress2b = createTest2(withReleaseAndDepressedPedal('mixed'));
 
 const customTest1 = createTest((factory, notes0, notes1) => {
   const pedal = factory.PedalMarking({

--- a/tests/pedalmarking_tests.ts
+++ b/tests/pedalmarking_tests.ts
@@ -32,7 +32,7 @@ const PedalMarkingTests = {
 };
 
 /**
- * Every test below uses this to set up the score and two staves/voices.
+ * Tests below uses this to set up the score and two staves with one voice.
  */
 function createTest(makePedal: (f: Factory, v1: Tickable[], v2: Tickable[]) => void) {
   return (options: TestOptions) => {
@@ -55,6 +55,9 @@ function createTest(makePedal: (f: Factory, v1: Tickable[], v2: Tickable[]) => v
   };
 }
 
+/**
+ * Tests below use this to set up the score and two staves with two voices.
+ */
 function createTest2(makePedal: (f: Factory, v1: Tickable[], v2: Tickable[]) => void) {
   return (options: TestOptions) => {
     const f = VexFlowTests.makeFactory(options, 550, 200);

--- a/tests/pedalmarking_tests.ts
+++ b/tests/pedalmarking_tests.ts
@@ -64,12 +64,12 @@ function createTest2(makePedal: (f: Factory, v1: Tickable[], v2: Tickable[]) => 
     const score = f.EasyScore();
 
     const stave0 = f.Stave({ width: 250 }).addClef('treble');
-    const voice0 = score.voice(score.notes('b4/4, b4, b4, b4[stem="down"]', { stem: 'up' }));
-    const voice0b = score.voice(score.notes('b5/4, b5, b5, b5[stem="down"]', { stem: 'up' }));
+    const voice0 = score.voice(score.notes('b4/4, b4, b4, b4', { stem: 'down' }));
+    const voice0b = score.voice(score.notes('b5/4, b5, b5, b5', { stem: 'up' }));
     f.Formatter().joinVoices([voice0, voice0b]).formatToStave([voice0, voice0b], stave0);
 
     const stave1 = f.Stave({ width: 260, x: 250 });
-    const voice1 = score.voice(score.notes('c4/4, c4, c4, c4', { stem: 'up' }));
+    const voice1 = score.voice(score.notes('c4/4, c4, c4, c4', { stem: 'down' }));
     const voice1b = score.voice(score.notes('c5/4, c5, c5, c5/16, c5/16, c5/16, c5/16', { stem: 'up' }));
     f.Formatter().joinVoices([voice1, voice1b]).formatToStave([voice1, voice1b], stave1);
 


### PR DESCRIPTION
fixes #204

Changes the pedal markins brackets ends to include the area behind the note. Either to the next note in its voice or the end of the stave.

@mscuthbert is this a right approach?
@jaredjj3 does this fix the vexml issue?

Differences

current
![canvas_PedalMarking Custom_Text_2 Bravura_current](https://github.com/vexflow/vexflow/assets/22865285/84a200f6-bcf5-407b-9413-ad14d5687541)
reference
![canvas_PedalMarking Custom_Text_2 Bravura_reference](https://github.com/vexflow/vexflow/assets/22865285/28836afa-f218-45c5-9bb9-b643055a06c5)
current
![canvas_PedalMarking Release_and_Depress_on_Same_Note_1 Bravura_current](https://github.com/vexflow/vexflow/assets/22865285/354617e3-303d-42cf-8f8f-0e1d1f04d90b)
reference
![canvas_PedalMarking Release_and_Depress_on_Same_Note_1 Bravura_reference](https://github.com/vexflow/vexflow/assets/22865285/d35a8b3b-b52c-4c6f-8ee5-6c39262fb429)
current
![canvas_PedalMarking Release_and_Depress_on_Same_Note_2 Bravura_current](https://github.com/vexflow/vexflow/assets/22865285/543487b4-91dd-4688-9e2a-5e7c93a87e05)
reference
![canvas_PedalMarking Release_and_Depress_on_Same_Note_2 Bravura_reference](https://github.com/vexflow/vexflow/assets/22865285/ee13b17c-8487-41de-a516-ba2ee6511026)
current
![canvas_PedalMarking Simple_Pedal_2 Bravura_current](https://github.com/vexflow/vexflow/assets/22865285/e8d5169b-1587-435c-9bf6-387f04f155a3)
reference
![canvas_PedalMarking Simple_Pedal_2 Bravura_reference](https://github.com/vexflow/vexflow/assets/22865285/5708c3fa-6611-41d3-a18d-898d4061940a)
current
![canvas_PedalMarking Simple_Pedal_3 Bravura_current](https://github.com/vexflow/vexflow/assets/22865285/e3732753-94a3-4eb5-8839-fc5eb53c8d87)
reference
![canvas_PedalMarking Simple_Pedal_3 Bravura_reference](https://github.com/vexflow/vexflow/assets/22865285/aa5a6ee3-87d7-4f05-b34f-f104a2f48922)
