### PR TITLE
new element style infrastructure

### DIFF
--- a/src/bend.ts
+++ b/src/bend.ts
@@ -63,7 +63,7 @@ export class Bend extends Modifier {
   
   /** Set the element style used for rendering the lines. */
   setStyleLine(style: ElementStyle): this {
-    this.styleLine = {...this.styleLine, ...style};
+    this.styleLine = style;
     return this;
   }
 
@@ -71,7 +71,6 @@ export class Bend extends Modifier {
   getStyleLine(): ElementStyle {
     return this.styleLine;
   }
-
 
   public renderOptions: {
     releaseWidth: number;
@@ -110,7 +109,7 @@ export class Bend extends Modifier {
    */
   constructor(phrase: BendPhrase[]) {
     super();
-  
+
     this.xShift = 0;
     this.tap = '';
     this.renderOptions = {

--- a/src/bend.ts
+++ b/src/bend.ts
@@ -1,7 +1,8 @@
 // Copyright (c) 2023-present VexFlow contributors: https://github.com/vexflow/vexflow/graphs/contributors
 // MIT License
 
-import { Element } from './element';
+import { Element, ElementStyle } from './element';
+import { Metrics } from './metrics';
 import { Modifier } from './modifier';
 import { ModifierContextState } from './modifiercontext';
 import { Category, isTabNote } from './typeguard';
@@ -57,6 +58,20 @@ export class Bend extends Modifier {
 
   protected tap: string;
   protected phrase: BendPhrase[];
+  
+  protected styleLine: ElementStyle = Metrics.getStyle('Bend.line');;
+  
+  /** Set the element style used for rendering the lines. */
+  setStyleLine(style: ElementStyle): this {
+    this.styleLine = {...this.styleLine, ...style};
+    return this;
+  }
+
+  /** Get the element style used for rendering the lines. */
+  getStyleLine(): ElementStyle {
+    return this.styleLine;
+  }
+
 
   public renderOptions: {
     releaseWidth: number;
@@ -95,15 +110,14 @@ export class Bend extends Modifier {
    */
   constructor(phrase: BendPhrase[]) {
     super();
-
+  
     this.xShift = 0;
     this.tap = '';
     this.renderOptions = {
       bendWidth: 8,
       releaseWidth: 8,
     };
-    this.setStyle({ lineWidth: 1.0, strokeStyle: 'black', fillStyle: 'black' });
-
+  
     this.phrase = phrase;
 
     this.updateWidth();
@@ -175,18 +189,22 @@ export class Bend extends Modifier {
     const renderBend = (x: number, y: number, width: number, height: number) => {
       const cpX = x + width;
       const cpY = y;
-
+      
+      this.applyStyle(ctx, this.styleLine);
       ctx.beginPath();
       ctx.moveTo(x, y);
       ctx.quadraticCurveTo(cpX, cpY, x + width, height);
       ctx.stroke();
+      this.restoreStyle(ctx, this.styleLine);
     };
 
     const renderRelease = (x: number, y: number, width: number, height: number) => {
+      this.applyStyle(ctx, this.styleLine);
       ctx.beginPath();
       ctx.moveTo(x, height);
       ctx.quadraticCurveTo(x + width, height, x + width, y);
       ctx.stroke();
+      this.restoreStyle(ctx, this.styleLine);
     };
 
     const renderArrowHead = (x: number, y: number, direction: number) => {

--- a/src/element.ts
+++ b/src/element.ts
@@ -200,13 +200,13 @@ export class Element {
    * ```
    */
   setStyle(style: ElementStyle): this {
-    this.style = {...this.style, ...style};
+    this.style = style;
     return this;
   }
 
   /** Set the element & associated children style used for rendering. */
   setGroupStyle(style: ElementStyle): this {
-    this.style = {...this.style, ...style};
+    this.style = style;
     this.children.forEach((child) => child.setGroupStyle(style));
     return this;
   }

--- a/src/element.ts
+++ b/src/element.ts
@@ -114,7 +114,7 @@ export class Element {
   protected attrs: ElementAttributes;
 
   protected rendered: boolean;
-  protected style?: ElementStyle;
+  protected style: ElementStyle = {};
   protected registry?: Registry;
 
   protected _fontInfo: Required<FontInfo>;
@@ -152,6 +152,7 @@ export class Element {
 
     this.rendered = false;
     this._fontInfo = Metrics.getFontInfo(this.attrs.type);
+    this.style = Metrics.getStyle(this.attrs.type);
     this.fontScale = Metrics.get(`${this.attrs.type}.fontScale`);
 
     // If a default registry exist, then register with it right away.
@@ -198,29 +199,29 @@ export class Element {
    * element.drawWithStyle();
    * ```
    */
-  setStyle(style: ElementStyle | undefined): this {
-    this.style = style;
+  setStyle(style: ElementStyle): this {
+    this.style = {...this.style, ...style};
     return this;
   }
 
   /** Set the element & associated children style used for rendering. */
   setGroupStyle(style: ElementStyle): this {
-    this.style = style;
+    this.style = {...this.style, ...style};
     this.children.forEach((child) => child.setGroupStyle(style));
     return this;
   }
 
   /** Get the element style used for rendering. */
-  getStyle(): ElementStyle | undefined {
+  getStyle(): ElementStyle {
     return this.style;
   }
 
   /** Apply the element style to `context`. */
   applyStyle(
     context: RenderContext | undefined = this.context,
-    style: ElementStyle | undefined = this.getStyle()
+    style: ElementStyle = this.getStyle()
   ): this {
-    if (!style) return this;
+    if (Object.keys(style).length == 0) return this;
     if (!context) return this;
 
     context.save();
@@ -237,9 +238,9 @@ export class Element {
   /** Restore the style of `context`. */
   restoreStyle(
     context: RenderContext | undefined = this.context,
-    style: ElementStyle | undefined = this.getStyle()
+    style: ElementStyle = this.getStyle()
   ): this {
-    if (!style) return this;
+    if (Object.keys(style).length == 0) return this;
     if (!context) return this;
     context.restore();
     return this;

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,17 +1,52 @@
 // Copyright (c) 2023-present VexFlow contributors: https://github.com/vexflow/vexflow/graphs/contributors
 
+import { ElementStyle } from './element';
 import { FontInfo } from './font';
 
 export class Metrics {
+  protected static cacheStyle = new Map<string, ElementStyle>;
+  protected static cacheFont = new Map<string, Required<FontInfo>>;
   /** Use the provided key to look up a FontInfo in CommonMetrics. **/
-  static getFontInfo(key: string): Required<FontInfo> {
-    return {
-      family: Metrics.get(`${key}.fontFamily`),
-      size: Metrics.get(`${key}.fontSize`) * Metrics.get(`${key}.fontScale`),
-      weight: Metrics.get(`${key}.fontWeight`),
-      style: Metrics.get(`${key}.fontStyle`),
-    };
+  static clear(key?: string) {
+    if (key) {
+      this.cacheFont.delete(key);
+      this.cacheStyle.delete(key);
+    } else {
+      this.cacheFont.clear();
+      this.cacheStyle.clear();
+    }
   }
+
+  static getFontInfo(key: string): Required<FontInfo> {
+    let font= this.cacheFont.get(key);
+    if (!font) {
+      font = {
+        family: Metrics.get(`${key}.fontFamily`),
+        size: Metrics.get(`${key}.fontSize`) * Metrics.get(`${key}.fontScale`),
+        weight: Metrics.get(`${key}.fontWeight`),
+        style: Metrics.get(`${key}.fontStyle`),
+      };
+      this.cacheFont.set(key, font);
+    }
+    return structuredClone(font);  
+  }
+
+  static getStyle(key: string): ElementStyle {
+    let style= this.cacheStyle.get(key);
+    if (!style) {
+      style = {
+        fillStyle: Metrics.get(`${key}.fillStyle`),
+        strokeStyle: Metrics.get(`${key}.strokeStyle`),
+        lineWidth: Metrics.get(`${key}.lineWidth`),
+        lineDash: Metrics.get(`${key}.lineDash`),
+        shadowBlur: Metrics.get(`${key}.shadowBlur`),
+        shadowColor: Metrics.get(`${key}.shadowColor`),
+      };
+      this.cacheStyle.set(key, style);
+    }
+    return structuredClone(style); 
+  }
+
 
   /**
    * Use the provided key to look up a value in CommonMetrics.
@@ -76,6 +111,10 @@ export const MetricsDefaults: Record<string, any> = {
 
   Bend: {
     fontSize: 10,
+    line: {  
+      strokeStyle: '#777777',
+      lineWidth: 1,
+    },  
   },
 
   ChordSymbol: {
@@ -127,6 +166,7 @@ export const MetricsDefaults: Record<string, any> = {
   },
 
   Stave: {
+    strokeStyle: '#999999',
     fontSize: 8,
     padding: 12,
     endPaddingMax: 10,
@@ -197,6 +237,7 @@ export const MetricsDefaults: Record<string, any> = {
   },
 
   TabStave: {
+    strokeStyle: '#999999',
     fontSize: 8,
   },
 

--- a/src/notehead.ts
+++ b/src/notehead.ts
@@ -84,7 +84,7 @@ export class NoteHead extends Note {
       this.text = noteStruct.customGlyphCode;
     }
 
-    this.setStyle(noteStruct.style);
+    this.setStyle(noteStruct.style??{});
     this.slashed = noteStruct.slashed || false;
 
     this.renderOptions = {

--- a/src/stave.ts
+++ b/src/stave.ts
@@ -28,7 +28,6 @@ export interface StaveOptions {
   spaceBelowStaffLn?: number;
   spaceAboveStaffLn?: number;
   verticalBarWidth?: number;
-  fillStyle?: string;
   leftBar?: boolean;
   rightBar?: boolean;
   spacingBetweenLinesPx?: number;
@@ -100,7 +99,6 @@ export class Stave extends Element {
     this.options = {
       verticalBarWidth: 10, // Width around vertical bar end-marker
       numLines: 5,
-      fillStyle: '#999999',
       leftBar: true, // draw vertical bar on left
       rightBar: true, // draw vertical bar on right
       spacingBetweenLinesPx: Tables.STAVE_LINE_DISTANCE, // in pixels
@@ -183,11 +181,11 @@ export class Stave extends Element {
   }
 
   getTopLineTopY(): number {
-    return this.getYForLine(0) - Tables.STAVE_LINE_THICKNESS / 2;
+    return this.getYForLine(0) - (this.getStyle().lineWidth ?? 1) / 2;
   }
 
   getBottomLineBottomY(): number {
-    return this.getYForLine(this.getNumLines() - 1) + Tables.STAVE_LINE_THICKNESS / 2;
+    return this.getYForLine(this.getNumLines() - 1) + (this.getStyle().lineWidth ?? 1) / 2;
   }
 
   setX(x: number): this {
@@ -211,15 +209,6 @@ export class Stave extends Element {
     // reset the x position of the end barline (TODO(0xfe): This makes no sense)
     // this.modifiers[1].setX(this.endX);
     return this;
-  }
-
-  getStyle(): ElementStyle {
-    return {
-      fillStyle: this.options.fillStyle,
-      strokeStyle: this.options.fillStyle, // yes, this is correct for legacy compatibility
-      lineWidth: Tables.STAVE_LINE_THICKNESS,
-      ...super.getStyle(),
-    };
   }
 
   /**

--- a/src/vexflow.ts
+++ b/src/vexflow.ts
@@ -249,6 +249,7 @@ export class VexFlow {
   static setFonts(...fontNames: string[]): void {
     // Convert the array of font names into an array of Font objects.
     MetricsDefaults.fontFamily = fontNames.join(',');
+    Metrics.clear();
   }
 
   static getFonts(): string[] {
@@ -320,11 +321,14 @@ export class VexFlow {
   }
 
   static get STAVE_LINE_THICKNESS(): number {
-    return Tables.STAVE_LINE_THICKNESS;
+    return MetricsDefaults.Stave.lineWidth;
   }
 
   static set STAVE_LINE_THICKNESS(value: number) {
-    Tables.STAVE_LINE_THICKNESS = value;
+    MetricsDefaults.Stave.lineWidth = value;
+    MetricsDefaults.TabStave.lineWidth = value;
+    Metrics.clear('Stave');
+    Metrics.clear('TabStave');
   }
 
   static get STEM_HEIGHT(): number {


### PR DESCRIPTION
This PR is a proposal to resolve #161, it also returns the grey lines to the bends.

My proposal to make the ElementStyle Infrastructure consistent is:
- Include the defaults in `metrics.ts`
- Use `this.style` together with `setStyle()` and `getStyle()` defined on `Element` for derivate classes that require only one style and avoid `render_options` related to style (see `stave.ts`)
- For classes deriving from `Element` that require more than one style, define the additional `styleXXX` (with `getStyleXXX()` and `setStyleXXX()`) in the derived class. (see `bend.ts`) 
