### PR TITLE
Refactor calls to applyStyle

### DIFF
--- a/demos/node/canvas.js
+++ b/demos/node/canvas.js
@@ -39,7 +39,7 @@ context.scale(2, 2);
 const stave = new Stave(10, 40, 400);
 stave.addClef('treble');
 stave.addTimeSignature('4/4');
-stave.setContext(context).draw();
+stave.setContext(context).drawWithStyle();
 
 const notes = [
   new StaveNote({ keys: ['c/5'], duration: '4' }),

--- a/demos/node/customcontext.js
+++ b/demos/node/customcontext.js
@@ -195,4 +195,4 @@ context.setFont('Arial', 10).setBackgroundFillStyle('#eed');
 const stave = new VF.Stave(10, 40, 400);
 stave.addClef('treble');
 stave.addTimeSignature('4/4');
-stave.setContext(context).draw();
+stave.setContext(context).drawWithStyle();

--- a/demos/node/import2.mjs
+++ b/demos/node/import2.mjs
@@ -61,7 +61,7 @@ function svgScore(fontName) {
     new StaveNote({ keys: ['c/4', 'e/4', 'c/5'], duration: 'h' }),
   ];
 
-  stave.setContext(ctx).draw();
+  stave.setContext(ctx).drawWithStyle();
   Formatter.FormatAndDraw(ctx, stave, notes);
 
   // const svg = div.innerHTML.replace('<svg ', '<svg xmlns="http://www.w3.org/2000/svg" ');

--- a/demos/node/pdf-canvas.js
+++ b/demos/node/pdf-canvas.js
@@ -58,7 +58,7 @@ const stave = new Stave(10, 0, 190);
 stave.addClef('treble').addTimeSignature('4/4');
 
 // Connect it to the rendering context and draw!
-stave.setContext(context).draw();
+stave.setContext(context).drawWithStyle();
 
 const notes = [
   new StaveNote({ keys: ['c/4'], duration: 'q' }),

--- a/demos/node/pdf-svg.js
+++ b/demos/node/pdf-svg.js
@@ -45,7 +45,7 @@ const stave = new Stave(10, 0, 190);
 stave.addClef('treble').addTimeSignature('4/4');
 
 // Connect it to the rendering context and draw!
-stave.setContext(context).draw();
+stave.setContext(context).drawWithStyle();
 
 const notes = [
   new StaveNote({ keys: ['c/4'], duration: 'q' }),

--- a/demos/node/svg.js
+++ b/demos/node/svg.js
@@ -40,7 +40,7 @@ const stave = new VF.Stave(10, 40, 400);
 stave.addClef('treble').addTimeSignature('4/4');
 
 // Connect it to the rendering context and draw!
-stave.setContext(context).draw();
+stave.setContext(context).drawWithStyle();
 
 const svg = div.innerHTML.replace('<svg ', '<svg xmlns="http://www.w3.org/2000/svg" ');
 

--- a/demos/worker/worker-vexflow-core.js
+++ b/demos/worker/worker-vexflow-core.js
@@ -25,7 +25,7 @@ onmessage = function (e) {
     // Render to the OffscreenCavans.
     const stave = new Stave(15, 0, 300);
     stave.setEndBarType(BarlineType.END);
-    stave.addClef('treble').setContext(ctx).draw();
+    stave.addClef('treble').setContext(ctx).drawWithStyle();
 
     function makeRandomNote(duration = '4') {
       const notes = ['c/4', 'd/4', 'e/4', 'f/4', 'g/4', 'a/4', 'b/4', 'c/5', 'd/5', 'e/5'];

--- a/src/beam.ts
+++ b/src/beam.ts
@@ -913,7 +913,7 @@ export class Beam extends Element {
       if (stem) {
         const stemX = note.getStemX();
         stem.setNoteHeadXBounds(stemX, stemX);
-        stem.setContext(ctx).draw();
+        stem.setContext(ctx).drawWithStyle();
       }
     }, this);
   }
@@ -991,12 +991,9 @@ export class Beam extends Element {
       this.postFormat();
     }
 
-    this.drawStems(ctx);
-    ctx.save();
-    this.applyStyle();
     ctx.openGroup('beam', this.getAttribute('id'));
+    this.drawStems(ctx);
     this.drawBeamLines(ctx);
     ctx.closeGroup();
-    ctx.restore();
   }
 }

--- a/src/curve.ts
+++ b/src/curve.ts
@@ -90,8 +90,6 @@ export class Curve extends Element {
 
   renderCurve(params: { lastY: number; lastX: number; firstY: number; firstX: number; direction: number }): void {
     const ctx = this.checkContext();
-    ctx.save();
-    this.applyStyle();
 
     const xShift = this.renderOptions.xShift;
     const yShift = this.renderOptions.yShift * params.direction;
@@ -130,7 +128,6 @@ export class Curve extends Element {
     ctx.stroke();
     ctx.closePath();
     if (!this.style?.lineDash) ctx.fill();
-    ctx.restore();
   }
 
   draw(): boolean {

--- a/src/element.ts
+++ b/src/element.ts
@@ -170,7 +170,7 @@ export class Element {
    * Note that StaveNote calls setGroupStyle() when setStyle() is called.
    */
   addChildElement(child: Element): this {
-    if (child.parent) throw new RuntimeError('Element', 'Draw not defined');
+    if (child.parent) throw new RuntimeError('Element', 'Parent already defined');
     child.parent = this;
     this.children.push(child);
     return this;

--- a/src/element.ts
+++ b/src/element.ts
@@ -81,6 +81,7 @@ export class Element {
 
   // Element objects keep a list of children that they are responsible for.
   // Children inherit the style from their parents (see: setGroupStyle(s)).
+  protected parent?: Element;
   protected children: Element[] = [];
   protected static ID: number = 1000;
   protected static newID(): string {
@@ -169,6 +170,8 @@ export class Element {
    * Note that StaveNote calls setGroupStyle() when setStyle() is called.
    */
   addChildElement(child: Element): this {
+    if (child.parent) throw new RuntimeError('Element', 'Draw not defined');
+    child.parent = this;
     this.children.push(child);
     return this;
   }
@@ -592,7 +595,6 @@ export class Element {
 
   /** Render the element text. */
   renderText(ctx: RenderContext, xPos: number, yPos: number): void {
-    ctx.save();
     ctx.setFont(this._fontInfo);
     ctx.fillText(this._text, xPos + this.x + this.xShift, yPos + this.y + this.yShift);
     this.children.forEach((child) => {
@@ -600,7 +602,6 @@ export class Element {
       ctx.setFont(child.fontInfo);
       ctx.fillText(child.text, xPos + child.x + child.xShift, yPos + child.y + child.yShift);
     });
-    ctx.restore();
   }
 
   /** Measure the text using the textFont. */

--- a/src/element.ts
+++ b/src/element.ts
@@ -161,7 +161,7 @@ export class Element {
   }
 
   /**
-   * Adds a child Element to the Element, which lets it inherit the
+   * Adds a child to the Element, which lets it inherit the
    * same style as the parent when setGroupStyle() is called.
    *
    * Examples of children are noteheads and stems.  Modifiers such
@@ -169,7 +169,7 @@ export class Element {
    *
    * Note that StaveNote calls setGroupStyle() when setStyle() is called.
    */
-  addChildElement(child: Element): this {
+  addChild(child: Element): this {
     if (child.parent) throw new RuntimeError('Element', 'Parent already defined');
     child.parent = this;
     this.children.push(child);

--- a/src/flag.ts
+++ b/src/flag.ts
@@ -1,0 +1,35 @@
+// Copyright (c) 2023-present VexFlow contributors: https://github.com/vexflow/vexflow/graphs/contributors
+// MIT License
+
+import { Element } from './element';
+import { Category } from './typeguard';
+import { log } from './util';
+
+// eslint-disable-next-line
+function L(...args: any[]) {
+  if (Flag.DEBUG) log('VexFlow.Flag', args);
+}
+
+/**
+ * `Flags` are typically not manipulated
+ * directly, but used internally in `StaveNote`.
+ */
+export class Flag extends Element {
+  /** To enable logging for this class. Set `VexFlow.NoteHead.DEBUG` to `true`. */
+  static DEBUG: boolean = false;
+
+  static get CATEGORY(): string {
+    return Category.Flag;
+  }
+
+  /** Draw the notehead. */
+  draw(): void {
+    const ctx = this.checkContext();
+    this.setRendered();
+    ctx.openGroup('flag', this.getAttribute('id'));
+
+    L("Drawing flag '", this.text, "' at", this.x, this.y);
+    this.renderText(ctx, 0, 0);
+    ctx.closeGroup();
+  }
+}

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -295,8 +295,8 @@ export class Formatter {
       .formatToStave([voice], stave, { alignRests: options.alignRests, stave });
 
     // Render the voice and beams to the stave.
-    voice.setStave(stave).draw(ctx, stave);
-    beams.forEach((beam) => beam.setContext(ctx).draw());
+    voice.setContext(ctx).setStave(stave).drawWithStyle();
+    beams.forEach((beam) => beam.setContext(ctx).drawWithStyle());
 
     // Return the bounding box of the voice.
     return voice.getBoundingBox();
@@ -353,10 +353,10 @@ export class Formatter {
     // Render voices and beams to staves.
     notevoice.draw(ctx, stave);
     tabvoice.draw(ctx, tabstave);
-    beams.forEach((beam) => beam.setContext(ctx).draw());
+    beams.forEach((beam) => beam.setContext(ctx).drawWithStyle());
 
     // Draw a connector between tab and note staves.
-    new StaveConnector(stave, tabstave).setContext(ctx).draw();
+    new StaveConnector(stave, tabstave).setContext(ctx).drawWithStyle();
   }
 
   /**

--- a/src/glyphnote.ts
+++ b/src/glyphnote.ts
@@ -56,8 +56,6 @@ export class GlyphNote extends Note {
     const stave = this.checkStave();
     const ctx = stave.checkContext();
     this.setRendered();
-    ctx.save();
-    this.applyStyle(ctx);
     ctx.openGroup('glyphNote', this.getAttribute('id'));
 
     this.x = this.isCenterAligned() ? this.getAbsoluteX() - this.getWidth() / 2 : this.getAbsoluteX();
@@ -65,6 +63,5 @@ export class GlyphNote extends Note {
     this.renderText(ctx, 0, 0);
     this.drawModifiers();
     ctx.closeGroup();
-    ctx.restore();
   }
 }

--- a/src/gracenote.ts
+++ b/src/gracenote.ts
@@ -94,14 +94,12 @@ export class GraceNote extends StaveNote {
       // FIXME: avoid staff lines, ledger lines or others.
 
       const ctx = this.checkContext();
-      ctx.save();
       ctx.setLineWidth(1 * scale); // FIXME: use more appropriate value.
       ctx.beginPath();
       ctx.moveTo(slashBBox.x1, slashBBox.y1);
       ctx.lineTo(slashBBox.x2, slashBBox.y2);
       ctx.closePath();
       ctx.stroke();
-      ctx.restore();
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ export * from './element';
 export * from './factory';
 export * from './font';
 // Do not export './fonts/*' because they are used by the entry/* files.
+export * from './flag';
 export * from './formatter';
 export * from './fraction';
 export * from './frethandfinger';

--- a/src/keysignote.ts
+++ b/src/keysignote.ts
@@ -41,6 +41,6 @@ export class KeySigNote extends Note {
     this.setRendered();
     this.keySignature.setX(this.getAbsoluteX());
     this.keySignature.setContext(ctx);
-    this.keySignature.draw();
+    this.keySignature.drawWithStyle();
   }
 }

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -209,6 +209,10 @@ export const MetricsDefaults: Record<string, any> = {
     fontSize: 10,
   },
 
+  Stem: {
+    strokeStyle: 'black',
+  },
+
   StringNumber: {
     fontSize: 10,
     fontWeight: 'bold',

--- a/src/notehead.ts
+++ b/src/notehead.ts
@@ -4,6 +4,7 @@
 import { ElementStyle } from './element';
 import { Note, NoteStruct } from './note';
 import { Stave } from './stave';
+import { StaveNote } from './stavenote';
 import { Stem } from './stem';
 import { Category } from './typeguard';
 import { defined, log } from './util';
@@ -150,9 +151,12 @@ export class NoteHead extends Note {
   draw(): void {
     const ctx = this.checkContext();
     this.setRendered();
+    ctx.openGroup('notehead', this.getAttribute('id'));
 
     L("Drawing note head '", this.noteType, this.duration, "' at", this.x, this.y);
     this.x = this.getAbsoluteX();
     this.renderText(ctx, 0, 0);
+    (this.parent as StaveNote)?.drawModifiers(this);
+    ctx.closeGroup();
   }
 }

--- a/src/pedalmarking.ts
+++ b/src/pedalmarking.ts
@@ -248,7 +248,6 @@ export class PedalMarking extends Element {
     const ctx = this.checkContext();
     this.setRendered();
 
-    ctx.save();
     ctx.setStrokeStyle(this.renderOptions.color);
     ctx.setFillStyle(this.renderOptions.color);
     ctx.setFont(this.font);
@@ -260,7 +259,5 @@ export class PedalMarking extends Element {
     } else if (this.type === PedalMarking.type.TEXT) {
       this.drawText();
     }
-
-    ctx.restore();
   }
 }

--- a/src/stavehairpin.ts
+++ b/src/stavehairpin.ts
@@ -93,7 +93,7 @@ export class StaveHairpin extends Element {
       .setContext(ctx)
       .setRenderOptions(hairpinOptions)
       .setPosition(position)
-      .draw();
+      .drawWithStyle();
   }
 
   /**

--- a/src/staveline.ts
+++ b/src/staveline.ts
@@ -261,7 +261,7 @@ export class StaveLine extends Element {
   }
 
   // Renders the `StaveLine` on the context
-  draw(): this {
+  draw(): void {
     const ctx = this.checkContext();
     this.setRendered();
 
@@ -269,7 +269,6 @@ export class StaveLine extends Element {
     const lastNote = this.lastNote;
     const renderOptions = this.renderOptions;
 
-    ctx.save();
     this.applyLineStyle();
 
     // Cycle through each set of indexes and draw lines
@@ -307,8 +306,6 @@ export class StaveLine extends Element {
       this.drawArrowLine(ctx, startPosition, endPosition);
     });
 
-    ctx.restore();
-
     // Determine the x coordinate where to start the text
     const textWidth = this.width;
     const justification = renderOptions.textJustification;
@@ -334,11 +331,7 @@ export class StaveLine extends Element {
 
     // Draw the text
     const color = renderOptions.color;
-    ctx.save();
     this.applyStyle(ctx, { fillStyle: color, strokeStyle: color });
     this.renderText(ctx, x, y);
-    ctx.restore();
-
-    return this;
   }
 }

--- a/src/stavenote.ts
+++ b/src/stavenote.ts
@@ -518,7 +518,7 @@ export class StaveNote extends StemmableNote {
 
       notehead.fontInfo = this.fontInfo;
 
-      this.addChildElement(notehead);
+      this.addChild(notehead);
       this._noteHeads[this.sortedKeyProps[i].index] = notehead;
     }
     return this._noteHeads;
@@ -601,19 +601,17 @@ export class StaveNote extends StemmableNote {
     });
     const { yTop, yBottom } = this.getNoteHeadBounds();
 
-    const noteStemHeight = this.stem!.getHeight();
-    const flagX = this.getStemX() - Tables.STEM_WIDTH / 2;
-    const flagY =
-      this.getStemDirection() === Stem.DOWN
-        ? yTop - noteStemHeight - this.flag.getTextMetrics().actualBoundingBoxDescent
-        : yBottom - noteStemHeight + this.flag.getTextMetrics().actualBoundingBoxAscent;
-
     if (!this.isRest() && this.hasStem()) {
-      boundingBox.mergeWith(new BoundingBox(this.getAbsoluteX(), flagY, 0, 0));
+      const noteStemHeight = this.stem!.getHeight();
+      const stemY =
+        this.getStemDirection() === Stem.DOWN
+          ? yTop - noteStemHeight - this.flag.getTextMetrics().actualBoundingBoxDescent
+          : yBottom - noteStemHeight + this.flag.getTextMetrics().actualBoundingBoxAscent;
+      boundingBox.mergeWith(new BoundingBox(this.getAbsoluteX(), stemY, 0, 0));
     }
     if (this.hasFlag()) {
       const bbFlag = this.flag.getBoundingBox();
-      boundingBox.mergeWith(bbFlag.move(flagX, flagY));
+      boundingBox.mergeWith(bbFlag);
     }
     for (let i = 0; i < this.modifiers.length; i++) {
       boundingBox.mergeWith(this.modifiers[i].getBoundingBox());
@@ -1109,10 +1107,7 @@ export class StaveNote extends StemmableNote {
             yBottom - noteStemHeight + this.flag.getTextMetrics().actualBoundingBoxAscent;
 
       // Draw the Flag
-      this.flag.draw = (): void => {
-        this.flag.renderText(ctx, flagX, flagY);
-      };
-      this.flag.setContext(ctx).drawWithStyle();
+      this.flag.setContext(ctx).setX(flagX).setY(flagY).drawWithStyle();
     }
   }
 

--- a/src/stavenote.ts
+++ b/src/stavenote.ts
@@ -838,10 +838,10 @@ export class StaveNote extends StemmableNote {
   }
 
   setFlagStyle(style: ElementStyle): void {
-    this.flagStyle = style;
+    this.flag.setStyle(style);
   }
   getFlagStyle(): ElementStyle | undefined {
-    return this.flagStyle;
+    return this.flag.getStyle();
   }
 
   /** Get the glyph width. */
@@ -1076,12 +1076,8 @@ export class StaveNote extends StemmableNote {
       const index = modifier.checkIndex();
       const notehead = this._noteHeads[index];
       if (notehead === noteheadParam) {
-        const noteheadStyle = notehead.getStyle();
-        ctx.save();
-        notehead.applyStyle(ctx, noteheadStyle);
         modifier.setContext(ctx);
         modifier.drawWithStyle();
-        ctx.restore();
       }
     }
   }
@@ -1113,10 +1109,10 @@ export class StaveNote extends StemmableNote {
             yBottom - noteStemHeight + this.flag.getTextMetrics().actualBoundingBoxAscent;
 
       // Draw the Flag
-      ctx.save();
-      this.applyStyle(ctx, this.flagStyle);
-      this.flag.renderText(ctx, flagX, flagY);
-      ctx.restore();
+      this.flag.draw = (): void => {
+        this.flag.renderText(ctx, flagX, flagY);
+      };
+      this.flag.setContext(ctx).drawWithStyle();
     }
   }
 
@@ -1124,13 +1120,7 @@ export class StaveNote extends StemmableNote {
   drawNoteHeads(): void {
     const ctx = this.checkContext();
     this._noteHeads.forEach((notehead) => {
-      ctx.save();
-      notehead.applyStyle(ctx);
-      ctx.openGroup('notehead', notehead.getAttribute('id'));
-      notehead.setContext(ctx).draw();
-      this.drawModifiers(notehead);
-      ctx.closeGroup();
-      ctx.restore();
+      notehead.setContext(ctx).drawWithStyle();
     });
   }
 
@@ -1151,7 +1141,7 @@ export class StaveNote extends StemmableNote {
     }
 
     if (this.stem) {
-      this.stem.setContext(ctx).draw();
+      this.stem.setContext(ctx).drawWithStyle();
     }
   }
 
@@ -1220,8 +1210,6 @@ export class StaveNote extends StemmableNote {
     L('Rendering ', this.isChord() ? 'chord :' : 'note :', this.keys);
 
     // Apply the overall style -- may be contradicted by local settings:
-    ctx.save();
-    this.applyStyle();
     ctx.openGroup('stavenote', this.getAttribute('id'));
     this.drawLedgerLines();
     if (shouldRenderStem) this.drawStem();
@@ -1230,7 +1218,6 @@ export class StaveNote extends StemmableNote {
     const bb = this.getBoundingBox();
     ctx.pointerRect(bb.getX(), bb.getY(), bb.getW(), bb.getH());
     ctx.closeGroup();
-    ctx.restore();
     this.setRendered();
   }
 }

--- a/src/stavesection.ts
+++ b/src/stavesection.ts
@@ -27,7 +27,7 @@ export class StaveSection extends StaveModifier {
     return this;
   }
 
-  draw(): this {
+  draw(): void {
     const stave = this.checkStave();
     const ctx = stave.checkContext();
     this.setRendered();
@@ -46,6 +46,5 @@ export class StaveSection extends StaveModifier {
       ctx.stroke();
     }
     this.renderText(ctx, this.xShift + this.padding, y - this.padding);
-    return this;
   }
 }

--- a/src/stavetie.ts
+++ b/src/stavetie.ts
@@ -153,8 +153,6 @@ export class StaveTie extends Element {
     const firstIndexes = this.notes.firstIndexes!;
 
     const lastIndexes = this.notes.lastIndexes!;
-    ctx.save();
-    this.applyStyle();
     ctx.openGroup('stavetie', this.getAttribute('id'));
     for (let i = 0; i < firstIndexes.length; ++i) {
       const cpX = (params.lastX + lastXShift + (params.firstX + firstXShift)) / 2;
@@ -177,7 +175,6 @@ export class StaveTie extends Element {
       ctx.fill();
     }
     ctx.closeGroup();
-    ctx.restore();
   }
 
   /**
@@ -190,10 +187,8 @@ export class StaveTie extends Element {
     centerX -= ctx.measureText(this.text).width / 2;
     const stave = this.notes.firstNote?.checkStave() ?? this.notes.lastNote?.checkStave();
     if (stave) {
-      ctx.save();
       ctx.setFont(this.fontInfo);
       ctx.fillText(this.text, centerX + this.renderOptions.textShiftX, stave.getYForTopText() - 1);
-      ctx.restore();
     }
   }
 

--- a/src/stem.ts
+++ b/src/stem.ts
@@ -210,8 +210,6 @@ export class Stem extends Element {
     const stemletYOffset = this.isStemlet ? stemHeight - this.stemletHeight * this.stemDirection : 0;
 
     // Draw the stem
-    ctx.save();
-    this.applyStyle();
     ctx.openGroup('stem', this.getAttribute('id'));
     ctx.beginPath();
     ctx.setLineWidth(Stem.WIDTH);
@@ -219,6 +217,5 @@ export class Stem extends Element {
     ctx.lineTo(stemX, stemY - stemHeight - this.renderHeightAdjustment * stemDirection);
     ctx.stroke();
     ctx.closeGroup();
-    ctx.restore();
   }
 }

--- a/src/stemmablenote.ts
+++ b/src/stemmablenote.ts
@@ -4,7 +4,7 @@
 // `StemmableNote` is an abstract interface for notes with optional stems.
 // Examples of stemmable notes are `StaveNote` and `TabNote`
 
-import { Element } from './element';
+import { Flag } from './flag';
 import { Glyphs } from './glyphs';
 import { GlyphProps, Note, NoteStruct } from './note';
 import { Stem, StemOptions } from './stem';
@@ -20,7 +20,7 @@ export abstract class StemmableNote extends Note {
   stemDirection?: number;
   stem?: Stem;
 
-  protected flag = new Element();
+  protected flag = new Flag();
   protected stemExtensionOverride?: number;
 
   constructor(noteStruct: NoteStruct) {
@@ -41,7 +41,7 @@ export abstract class StemmableNote extends Note {
 
   setStem(stem: Stem): this {
     this.stem = stem;
-    this.addChildElement(stem);
+    this.addChild(stem);
     return this;
   }
 

--- a/src/stemmablenote.ts
+++ b/src/stemmablenote.ts
@@ -4,7 +4,7 @@
 // `StemmableNote` is an abstract interface for notes with optional stems.
 // Examples of stemmable notes are `StaveNote` and `TabNote`
 
-import { Element, ElementStyle } from './element';
+import { Element } from './element';
 import { Glyphs } from './glyphs';
 import { GlyphProps, Note, NoteStruct } from './note';
 import { Stem, StemOptions } from './stem';
@@ -21,7 +21,6 @@ export abstract class StemmableNote extends Note {
   stem?: Stem;
 
   protected flag = new Element();
-  protected flagStyle: ElementStyle = {};
   protected stemExtensionOverride?: number;
 
   constructor(noteStruct: NoteStruct) {
@@ -243,6 +242,6 @@ export abstract class StemmableNote extends Note {
     this.setRendered();
 
     this.setStem(new Stem(stemOptions));
-    this.stem?.setContext(this.getContext()).draw();
+    this.stem?.setContext(this.getContext()).drawWithStyle();
   }
 }

--- a/src/tabnote.ts
+++ b/src/tabnote.ts
@@ -351,10 +351,7 @@ export class TabNote extends StemmableNote {
             this.getStemY() - this.checkStem().getHeight() + this.getStemExtension();
 
       // Draw the Flag
-      this.flag.draw = (): void => {
-        this.flag.renderText(context, flagX, flagY);
-      };
-      this.flag.setContext(context).drawWithStyle();
+      this.flag.setContext(context).setX(flagX).setY(flagY).drawWithStyle();
     }
   }
 

--- a/src/tabnote.ts
+++ b/src/tabnote.ts
@@ -351,10 +351,10 @@ export class TabNote extends StemmableNote {
             this.getStemY() - this.checkStem().getHeight() + this.getStemExtension();
 
       // Draw the Flag
-      context.save();
-      this.applyStyle(context, this.flagStyle);
-      this.flag.renderText(context, flagX, flagY);
-      context.restore();
+      this.flag.draw = (): void => {
+        this.flag.renderText(context, flagX, flagY);
+      };
+      this.flag.setContext(context).drawWithStyle();
     }
   }
 
@@ -386,7 +386,6 @@ export class TabNote extends StemmableNote {
       const unusedStrings = getUnusedStringGroups(numLines, stringsUsed);
       const stemLines = getPartialStemLines(stemY, unusedStrings, this.checkStave(), this.getStemDirection());
 
-      ctx.save();
       ctx.setLineWidth(Stem.WIDTH);
       stemLines.forEach((bounds) => {
         if (bounds.length === 0) return;
@@ -397,7 +396,6 @@ export class TabNote extends StemmableNote {
         ctx.stroke();
         ctx.closePath();
       });
-      ctx.restore();
     }
   }
 
@@ -431,8 +429,6 @@ export class TabNote extends StemmableNote {
     this.setRendered();
     const renderStem = this.beam === undefined && this.renderOptions.drawStem;
 
-    ctx.save();
-    this.applyStyle();
     ctx.openGroup('tabnote', this.getAttribute('id'));
     this.drawPositions();
     this.drawStemThrough();
@@ -440,12 +436,11 @@ export class TabNote extends StemmableNote {
     if (this.stem && renderStem) {
       const stemX = this.getStemX();
       this.stem.setNoteHeadXBounds(stemX, stemX);
-      this.stem.setContext(ctx).draw();
+      this.stem.setContext(ctx).drawWithStyle();
     }
 
     this.drawFlag();
     this.drawModifiers();
     ctx.closeGroup();
-    ctx.restore();
   }
 }

--- a/src/textbracket.ts
+++ b/src/textbracket.ts
@@ -161,9 +161,6 @@ export class TextBracket extends Element {
 
     const bracketHeight = this.renderOptions.bracketHeight * this.position;
 
-    ctx.save();
-    this.applyStyle(ctx);
-
     // Draw text
     this.textElement.renderText(ctx, start.x, start.y);
 
@@ -225,7 +222,5 @@ export class TextBracket extends Element {
       ctx.stroke();
       ctx.closePath();
     }
-
-    ctx.restore();
   }
 }

--- a/src/textnote.ts
+++ b/src/textnote.ts
@@ -157,8 +157,6 @@ export class TextNote extends Note {
     }
 
     const y = stave.getYForLine(this.line + -3);
-    ctx.save();
-    this.applyStyle(ctx);
     this.renderText(ctx, x, y);
 
     const height = this.getHeight();
@@ -170,7 +168,5 @@ export class TextNote extends Note {
     if (this.subscript) {
       this.subscript.renderText(ctx, x + this.width + 2, y + height / 2.2 - 1);
     }
-
-    ctx.restore();
   }
 }

--- a/src/timesignote.ts
+++ b/src/timesignote.ts
@@ -40,6 +40,8 @@ export class TimeSigNote extends Note {
     const ctx = this.checkContext();
     this.setRendered();
 
+    ctx.openGroup('timesignote', this.getAttribute('id'));
     this.timeSig.drawAt(ctx, stave, this.getAbsoluteX());
+    ctx.closeGroup();
   }
 }

--- a/src/typeguard.ts
+++ b/src/typeguard.ts
@@ -81,6 +81,7 @@ export const enum Category {
   Curve = 'Curve',
   Dot = 'Dot',
   Element = 'Element',
+  Flag = 'Flag',
   Fraction = 'Fraction',
   FretHandFinger = 'FretHandFinger',
   GhostNote = 'GhostNote',


### PR DESCRIPTION
Fixes #223
This PR reduces the number of calls to context `save` and `restore`. It calls consistently to `drawWithStyle()` rather than `draw()`.

With this approach there is no longer missing calls to applyStyle on some elements (ie. Voice) and double calls are also avoided.

One visual difference see #226