### PR TITLE
Tests calling drawWithStyle (part of #225)

### DIFF
--- a/src/element.ts
+++ b/src/element.ts
@@ -183,7 +183,7 @@ export class Element {
    * Example:
    * ```typescript
    * element.setStyle({ fillStyle: 'red', strokeStyle: 'red' });
-   * element.draw();
+   * element.drawWithStyle();
    * ```
    * Note: If the element draws additional sub-elements (i.e.: Modifiers in a Stave),
    * the style can be applied to all of them by means of the context:
@@ -191,7 +191,7 @@ export class Element {
    * element.setStyle({ fillStyle: 'red', strokeStyle: 'red' });
    * element.getContext().setFillStyle('red');
    * element.getContext().setStrokeStyle('red');
-   * element.draw();
+   * element.drawWithStyle();
    * ```
    * or using drawWithStyle:
    * ```typescript
@@ -233,12 +233,13 @@ export class Element {
    * Draw the element and all its sub-elements (i.e.: Modifiers in a Stave)
    * with the element's style (see `getStyle()` and `setStyle()`)
    */
-  drawWithStyle(): void {
+  drawWithStyle(): this {
     const ctx = this.checkContext();
     ctx.save();
-    this.applyStyle();
+    this.applyStyle(ctx);
     this.draw();
     ctx.restore();
+    return this;
   }
 
   /** Draw an element. */

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -188,6 +188,7 @@ export const MetricsDefaults: Record<string, any> = {
     fontWeight: 'bold',
     lineWidth: 2,
     padding: 2,
+    strokeStyle: 'black',
   },
 
   StaveTempo: {

--- a/tests/accidental_tests.ts
+++ b/tests/accidental_tests.ts
@@ -223,10 +223,10 @@ function formatAccidentalSpaces(options: TestOptions): void {
   const formatter = new Formatter({ softmaxFactor }).joinVoices([voice]);
   const width = formatter.preCalculateMinTotalWidth([voice]);
   const stave = new Stave(10, 40, width + 20);
-  stave.setContext(context).draw();
+  stave.setContext(context).drawWithStyle();
   formatter.format([voice], width);
   voice.draw(context, stave);
-  beams.forEach((b) => b.setContext(context).draw());
+  beams.forEach((b) => b.setContext(context).drawWithStyle());
 
   notes.forEach((note) => Note.plotMetrics(context, note, 30));
 
@@ -338,7 +338,9 @@ function genAccidentals(): string[] {
   }
   // Spartan Sagittal multi-shaft accidentals
   for (let u = 0xe310; u <= 0xe335; u++) {
-    switch (u) {
+    switch (
+      u // exclude unused smufls
+    ) {
       case 0xe31a:
       case 0xe31b:
       case 0xe31e:
@@ -554,8 +556,8 @@ function multiVoice(options: TestOptions): void {
 
     new TickContext().addTickable(note1).addTickable(note2).preFormat().setX(x);
 
-    note1.setContext(ctx).draw();
-    note2.setContext(ctx).draw();
+    note1.setContext(ctx).drawWithStyle();
+    note2.setContext(ctx).drawWithStyle();
 
     Note.plotMetrics(ctx, note1, 180);
     Note.plotMetrics(ctx, note2, 15);
@@ -566,7 +568,7 @@ function multiVoice(options: TestOptions): void {
   const stave = f.Stave({ x: 10, y: 45, width: 420 });
   const ctx = f.getContext();
 
-  stave.draw();
+  stave.drawWithStyle();
 
   let note1 = f
     .StaveNote({ keys: ['c/4', 'e/4', 'a/4'], duration: '2', stemDirection: -1 })

--- a/tests/annotation_tests.ts
+++ b/tests/annotation_tests.ts
@@ -110,7 +110,7 @@ function simple(options: TestOptions, contextBuilder: ContextBuilder): void {
   ctx.scale(1.5, 1.5);
 
   ctx.font = '10pt Arial, sans-serif';
-  const stave = new TabStave(10, 10, 450).addTabGlyph().setContext(ctx).draw();
+  const stave = new TabStave(10, 10, 450).addTabGlyph().setContext(ctx).drawWithStyle();
 
   const notes = [
     tabNote({
@@ -134,7 +134,7 @@ function standard(options: TestOptions, contextBuilder: ContextBuilder): void {
   const ctx = contextBuilder(options.elementId, 500, 240);
   ctx.scale(1.5, 1.5);
 
-  const stave = new Stave(10, 10, 450).addClef('treble').setContext(ctx).draw();
+  const stave = new Stave(10, 10, 450).addClef('treble').setContext(ctx).drawWithStyle();
 
   const annotation = (text: string) =>
     new Annotation(text).setFont(Metrics.get('Annotation.fontFamily'), FONT_SIZE, 'normal', 'italic');
@@ -151,7 +151,7 @@ function standard(options: TestOptions, contextBuilder: ContextBuilder): void {
 function styling(options: TestOptions, contextBuilder: ContextBuilder): void {
   const ctx = contextBuilder(options.elementId, 500, 240);
   ctx.scale(1.5, 1.5);
-  const stave = new Stave(10, 10, 450).addClef('treble').setContext(ctx).draw();
+  const stave = new Stave(10, 10, 450).addClef('treble').setContext(ctx).drawWithStyle();
 
   const annotation = (text: string, style: ElementStyle) =>
     new Annotation(text).setFont(Metrics.get('Annotation.fontFamily'), FONT_SIZE, 'normal', 'italic').setStyle(style);
@@ -173,7 +173,7 @@ function harmonic(options: TestOptions, contextBuilder: ContextBuilder): void {
   ctx.scale(1.5, 1.5);
 
   ctx.font = '10pt Arial';
-  const stave = new TabStave(10, 10, 450).addClef('tab').setContext(ctx).draw();
+  const stave = new TabStave(10, 10, 450).addClef('tab').setContext(ctx).drawWithStyle();
 
   const notes = [
     tabNote({
@@ -202,7 +202,7 @@ function picking(options: TestOptions, contextBuilder: ContextBuilder): void {
   const ctx = contextBuilder(options.elementId, 500, 240);
 
   ctx.setFont(Metrics.get('fontFamily'), FONT_SIZE);
-  const stave = new TabStave(10, 10, 450).addClef('tab').setContext(ctx).draw();
+  const stave = new TabStave(10, 10, 450).addClef('tab').setContext(ctx).drawWithStyle();
 
   const annotation = (text: string) =>
     new Annotation(text).setFont(Metrics.get('Annotation.fontFamily'), FONT_SIZE, 'normal', 'italic');
@@ -242,7 +242,7 @@ function picking(options: TestOptions, contextBuilder: ContextBuilder): void {
 function placement(options: TestOptions, contextBuilder: ContextBuilder): void {
   const ctx = contextBuilder(options.elementId, 750, 300);
 
-  const stave = new Stave(10, 50, 750).addClef('treble').setContext(ctx).draw();
+  const stave = new Stave(10, 50, 750).addClef('treble').setContext(ctx).drawWithStyle();
 
   const annotation = (text: string, fontSize: number, vj: number) =>
     new Annotation(text).setFontSize(fontSize).setVerticalJustification(vj);
@@ -315,7 +315,7 @@ function bottom(options: TestOptions, contextBuilder: ContextBuilder): void {
   const ctx = contextBuilder(options.elementId, 500, 240);
   ctx.scale(1.5, 1.5);
 
-  const stave = new Stave(10, 10, 300).addClef('treble').setContext(ctx).draw();
+  const stave = new Stave(10, 10, 300).addClef('treble').setContext(ctx).drawWithStyle();
 
   const annotation = (text: string) =>
     new Annotation(text).setFontSize(FONT_SIZE).setVerticalJustification(Annotation.VerticalJustify.BOTTOM);
@@ -335,7 +335,7 @@ function bottomWithBeam(options: TestOptions, contextBuilder: ContextBuilder): v
   const ctx = contextBuilder(options.elementId, 500, 240);
   ctx.scale(1.5, 1.5);
 
-  const stave = new Stave(10, 10, 300).addClef('treble').setContext(ctx).draw();
+  const stave = new Stave(10, 10, 300).addClef('treble').setContext(ctx).drawWithStyle();
 
   const notes = [
     new StaveNote({ keys: ['a/3'], duration: '8' }).addModifier(
@@ -355,7 +355,7 @@ function bottomWithBeam(options: TestOptions, contextBuilder: ContextBuilder): v
   const beam = new Beam(notes.slice(1));
 
   Formatter.FormatAndDraw(ctx, stave, notes);
-  beam.setContext(ctx).draw();
+  beam.setContext(ctx).drawWithStyle();
   options.assert.ok(true, 'Bottom Annotation with Beams');
 }
 
@@ -370,7 +370,7 @@ function justificationStemUp(options: TestOptions, contextBuilder: ContextBuilde
       .setVerticalJustification(vJustification);
 
   for (let v = 1; v <= 4; ++v) {
-    const stave = new Stave(10, (v - 1) * 150 + 40, 400).addClef('treble').setContext(ctx).draw();
+    const stave = new Stave(10, (v - 1) * 150 + 40, 400).addClef('treble').setContext(ctx).drawWithStyle();
 
     const notes = [
       staveNote({ keys: ['c/3'], duration: 'q' }).addModifier(annotation('Text', 1, v), 0),
@@ -396,7 +396,7 @@ function justificationStemDown(options: TestOptions, contextBuilder: ContextBuil
       .setVerticalJustification(vJustification);
 
   for (let v = 1; v <= 4; ++v) {
-    const stave = new Stave(10, (v - 1) * 150 + 40, 400).addClef('treble').setContext(ctx).draw();
+    const stave = new Stave(10, (v - 1) * 150 + 40, 400).addClef('treble').setContext(ctx).drawWithStyle();
     const notes = [
       staveNote({ keys: ['c/3'], duration: 'q', stemDirection: -1 }).addModifier(annotation('Text', 1, v), 0),
       staveNote({ keys: ['c/4', 'e/4', 'c/5'], duration: 'q', stemDirection: -1 }).addModifier(
@@ -417,7 +417,7 @@ function tabNotes(options: TestOptions, contextBuilder: ContextBuilder): void {
   ctx.font = '10pt Arial, sans-serif';
   const stave = new TabStave(10, 10, 550);
   stave.setContext(ctx);
-  stave.draw();
+  stave.drawWithStyle();
 
   const specs = [
     {

--- a/tests/articulation_tests.ts
+++ b/tests/articulation_tests.ts
@@ -63,7 +63,7 @@ function drawArticulations(options: TestOptions): void {
       .Stave({ x, y, width: nwidth + Stave.defaultPadding })
       .setEndBarType(barline)
       .setContext(ctx)
-      .draw();
+      .drawWithStyle();
     voices.forEach((voice) => voice.draw(ctx, stave));
     return stave.getWidth();
   };
@@ -148,7 +148,7 @@ function drawFermata(options: TestOptions): void {
       .Stave({ x, y, width: nwidth + Stave.defaultPadding })
       .setEndBarType(barline)
       .setContext(ctx)
-      .draw();
+      .drawWithStyle();
     voices.forEach((voice) => voice.draw(ctx, stave));
     return stave.getWidth();
   };
@@ -187,7 +187,7 @@ function verticalPlacement(options: TestOptions, contextBuilder: ContextBuilder)
   const ctx = contextBuilder(options.elementId, 750, 300);
 
   const staveNote = (noteStruct: StaveNoteStruct) => new StaveNote(noteStruct);
-  const stave = new Stave(10, 50, 750).addClef('treble').setContext(ctx).draw();
+  const stave = new Stave(10, 50, 750).addClef('treble').setContext(ctx).drawWithStyle();
 
   const notes = [
     staveNote({ keys: ['f/4'], duration: 'q' })
@@ -257,7 +257,7 @@ function verticalPlacement2(options: TestOptions, contextBuilder: ContextBuilder
   const ctx = contextBuilder(options.elementId, 750, 300);
 
   const staveNote = (noteStruct: StaveNoteStruct) => new StaveNote(noteStruct);
-  const stave = new Stave(10, 50, 750).addClef('treble').setContext(ctx).draw();
+  const stave = new Stave(10, 50, 750).addClef('treble').setContext(ctx).drawWithStyle();
 
   const notes = [
     staveNote({ keys: ['f/4'], duration: 'q' })
@@ -324,7 +324,7 @@ function drawArticulations2(options: TestOptions): void {
   ctx.scale(scale, scale);
 
   // bar 1
-  const stave1 = new Stave(10, 50, 500).setContext(ctx).draw();
+  const stave1 = new Stave(10, 50, 500).setContext(ctx).drawWithStyle();
   const notesBar1 = [
     f.StaveNote({ keys: ['c/4'], duration: '16', stemDirection: 1 }),
     f.StaveNote({ keys: ['d/4'], duration: '16', stemDirection: 1 }),
@@ -356,11 +356,11 @@ function drawArticulations2(options: TestOptions): void {
   const beam2 = new Beam(notesBar1.slice(8, 16));
   Formatter.FormatAndDraw(ctx, stave1, notesBar1);
 
-  beam1.setContext(ctx).draw();
-  beam2.setContext(ctx).draw();
+  beam1.setContext(ctx).drawWithStyle();
+  beam2.setContext(ctx).drawWithStyle();
 
   // bar 2 - juxtaposing second bar next to first bar
-  const stave2 = new Stave(510, 50, 500).setContext(ctx).draw();
+  const stave2 = new Stave(510, 50, 500).setContext(ctx).drawWithStyle();
   const notesBar2 = [
     f.StaveNote({ keys: ['f/3'], duration: '16', stemDirection: 1 }),
     f.StaveNote({ keys: ['g/3'], duration: '16', stemDirection: 1 }),
@@ -391,11 +391,11 @@ function drawArticulations2(options: TestOptions): void {
   const beam4 = new Beam(notesBar2.slice(8, 16));
   Formatter.FormatAndDraw(ctx, stave2, notesBar2);
 
-  beam3.setContext(ctx).draw();
-  beam4.setContext(ctx).draw();
+  beam3.setContext(ctx).drawWithStyle();
+  beam4.setContext(ctx).drawWithStyle();
 
   // bar 3 - juxtaposing second bar next to first bar
-  const stave3 = new Stave(1010, 50, 100).setContext(ctx).draw();
+  const stave3 = new Stave(1010, 50, 100).setContext(ctx).drawWithStyle();
   const notesBar3 = [f.StaveNote({ keys: ['c/4'], duration: 'w', stemDirection: 1 })];
   notesBar3[0].addModifier(new Articulation('a-').setPosition(3), 0);
   notesBar3[0].addModifier(new Articulation('a>').setPosition(3), 0);
@@ -404,7 +404,7 @@ function drawArticulations2(options: TestOptions): void {
   Formatter.FormatAndDraw(ctx, stave3, notesBar3);
 
   // bar 4 - juxtaposing second bar next to first bar
-  const stave4 = new Stave(1110, 50, 250).setContext(ctx).draw();
+  const stave4 = new Stave(1110, 50, 250).setContext(ctx).drawWithStyle();
   const notesBar4 = [
     f.StaveNote({ keys: ['c/5'], duration: 'q', stemDirection: -1 }),
     f.StaveNote({ keys: ['a/5'], duration: 'q', stemDirection: -1 }),
@@ -427,7 +427,7 @@ function tabNotes(options: TestOptions, contextBuilder: ContextBuilder): void {
   ctx.font = '10pt ' + Metrics.get('fontFamily');
   const stave = new TabStave(10, 10, 550);
   stave.setContext(ctx);
-  stave.draw();
+  stave.drawWithStyle();
 
   const specs = [
     {

--- a/tests/auto_beam_formatting_tests.ts
+++ b/tests/auto_beam_formatting_tests.ts
@@ -69,7 +69,7 @@ function simpleAuto(options: TestOptions): void {
 
   f.draw();
 
-  beams.forEach((beam) => beam.setContext(f.getContext()).draw());
+  beams.forEach((beam) => beam.setContext(f.getContext()).drawWithStyle());
 
   options.assert.ok(true, 'Auto Beaming Applicator Test');
 }
@@ -91,7 +91,7 @@ function simpleAutoWithOverflowGroup(options: TestOptions): void {
 
   f.draw();
 
-  beams.forEach((beam) => beam.setContext(f.getContext()).draw());
+  beams.forEach((beam) => beam.setContext(f.getContext()).drawWithStyle());
 
   options.assert.ok(true, 'Auto Beaming Applicator Test');
 }
@@ -110,7 +110,7 @@ function evenGroupStemDirections(options: TestOptions): void {
 
   f.draw();
 
-  beams.forEach((beam) => beam.setContext(f.getContext()).draw());
+  beams.forEach((beam) => beam.setContext(f.getContext()).drawWithStyle());
 
   options.assert.equal(beams[0].getStemDirection(), Stem.UP);
   options.assert.equal(beams[1].getStemDirection(), Stem.UP);
@@ -143,7 +143,7 @@ function oddGroupStemDirections(options: TestOptions): void {
 
   f.draw();
 
-  beams.forEach((beam) => beam.setContext(f.getContext()).draw());
+  beams.forEach((beam) => beam.setContext(f.getContext()).drawWithStyle());
 
   options.assert.ok(true, 'Auto Beaming Applicator Test');
 }
@@ -164,7 +164,7 @@ function oddBeamGroups(options: TestOptions): void {
 
   f.draw();
 
-  beams.forEach((beam) => beam.setContext(f.getContext()).draw());
+  beams.forEach((beam) => beam.setContext(f.getContext()).drawWithStyle());
 
   options.assert.ok(true, 'Auto Beam Applicator Test');
 }
@@ -182,7 +182,7 @@ function moreSimple0(options: TestOptions): void {
 
   f.draw();
 
-  beams.forEach((beam) => beam.setContext(f.getContext()).draw());
+  beams.forEach((beam) => beam.setContext(f.getContext()).drawWithStyle());
 
   options.assert.ok(true, 'Auto Beam Applicator Test');
 }
@@ -203,7 +203,7 @@ function moreSimple1(options: TestOptions): void {
 
   f.draw();
 
-  beams.forEach((beam) => beam.setContext(f.getContext()).draw());
+  beams.forEach((beam) => beam.setContext(f.getContext()).drawWithStyle());
 
   options.assert.ok(true, 'Auto Beam Applicator Test');
 }
@@ -226,7 +226,7 @@ function breakBeamsOnRests(options: TestOptions): void {
 
   f.draw();
 
-  beams.forEach((beam) => beam.setContext(f.getContext()).draw());
+  beams.forEach((beam) => beam.setContext(f.getContext()).drawWithStyle());
 
   options.assert.ok(true, 'Auto Beam Applicator Test');
 }
@@ -250,7 +250,7 @@ function beamAcrossAllRestsWithStemlets(options: TestOptions): void {
 
   f.draw();
 
-  beams.forEach((beam) => beam.setContext(f.getContext()).draw());
+  beams.forEach((beam) => beam.setContext(f.getContext()).drawWithStyle());
 
   options.assert.ok(true, 'Auto Beam Applicator Test');
 }
@@ -273,7 +273,7 @@ function beamAcrossAllRests(options: TestOptions): void {
 
   f.draw();
 
-  beams.forEach((beam) => beam.setContext(f.getContext()).draw());
+  beams.forEach((beam) => beam.setContext(f.getContext()).drawWithStyle());
 
   options.assert.ok(true, 'Auto Beam Applicator Test');
 }
@@ -297,7 +297,7 @@ function beamAcrossMiddleRests(options: TestOptions): void {
 
   f.draw();
 
-  beams.forEach((beam) => beam.setContext(f.getContext()).draw());
+  beams.forEach((beam) => beam.setContext(f.getContext()).drawWithStyle());
 
   options.assert.ok(true, 'Auto Beam Applicator Test');
 }
@@ -330,7 +330,7 @@ function maintainStemDirections(options: TestOptions): void {
 
   f.draw();
 
-  beams.forEach((beam) => beam.setContext(f.getContext()).draw());
+  beams.forEach((beam) => beam.setContext(f.getContext()).drawWithStyle());
 
   options.assert.ok(true, 'Auto Beam Applicator Test');
 }
@@ -362,7 +362,7 @@ function maintainStemDirectionsBeamAcrossRests(options: TestOptions): void {
 
   f.draw();
 
-  beams.forEach((beam) => beam.setContext(f.getContext()).draw());
+  beams.forEach((beam) => beam.setContext(f.getContext()).drawWithStyle());
 
   options.assert.ok(true, 'Auto Beam Applicator Test');
 }
@@ -384,7 +384,7 @@ function groupWithUnbeamableNote(options: TestOptions): void {
 
   f.draw();
 
-  beams.forEach((beam) => beam.setContext(f.getContext()).draw());
+  beams.forEach((beam) => beam.setContext(f.getContext()).drawWithStyle());
 
   options.assert.ok(true, 'Auto Beam Applicator Test');
 }
@@ -406,7 +406,7 @@ function groupWithUnbeamableNote1(options: TestOptions): void {
 
   f.draw();
 
-  beams.forEach((beam) => beam.setContext(f.getContext()).draw());
+  beams.forEach((beam) => beam.setContext(f.getContext()).drawWithStyle());
 
   options.assert.ok(true, 'Auto Beam Applicator Test');
 }
@@ -438,7 +438,7 @@ function autoOddBeamGroups(options: TestOptions): void {
 
   f.draw();
 
-  beams.forEach((beam) => beam.setContext(f.getContext()).draw());
+  beams.forEach((beam) => beam.setContext(f.getContext()).drawWithStyle());
 
   options.assert.ok(true, 'Auto Beam Applicator Test');
 }
@@ -473,7 +473,7 @@ function customBeamGroups(options: TestOptions): void {
 
   f.draw();
 
-  beams.forEach((beam) => beam.setContext(f.getContext()).draw());
+  beams.forEach((beam) => beam.setContext(f.getContext()).drawWithStyle());
 
   options.assert.ok(true, 'Auto Beam Applicator Test');
 }
@@ -511,7 +511,7 @@ function simpleTuplets(options: TestOptions): void {
 
   f.draw();
 
-  beams.forEach((beam) => beam.setContext(f.getContext()).draw());
+  beams.forEach((beam) => beam.setContext(f.getContext()).drawWithStyle());
 
   options.assert.ok(true, 'Auto Beam Applicator Test');
 }
@@ -531,7 +531,7 @@ function moreSimpleTuplets(options: TestOptions): void {
 
   f.draw();
 
-  beams.forEach((beam) => beam.setContext(f.getContext()).draw());
+  beams.forEach((beam) => beam.setContext(f.getContext()).drawWithStyle());
 
   options.assert.ok(true, 'Auto Beam Applicator Test');
 }
@@ -549,7 +549,7 @@ function moreBeaming(options: TestOptions): void {
 
   f.draw();
 
-  beams.forEach((beam) => beam.setContext(f.getContext()).draw());
+  beams.forEach((beam) => beam.setContext(f.getContext()).drawWithStyle());
 
   options.assert.ok(true, 'Auto Beam Applicator Test');
 }
@@ -567,7 +567,7 @@ function beamingWithSeveralGroups1(options: TestOptions): void {
 
   f.draw();
 
-  beams.forEach((beam) => beam.setContext(f.getContext()).draw());
+  beams.forEach((beam) => beam.setContext(f.getContext()).drawWithStyle());
 
   options.assert.ok(true, 'Auto Beam Applicator Test');
 }
@@ -585,7 +585,7 @@ function beamingWithSeveralGroupsOverflow(options: TestOptions): void {
 
   f.draw();
 
-  beams.forEach((beam) => beam.setContext(f.getContext()).draw());
+  beams.forEach((beam) => beam.setContext(f.getContext()).drawWithStyle());
 
   options.assert.ok(true, 'Auto Beam Applicator Test');
 }
@@ -605,7 +605,7 @@ function beamingWithSeveralGroupsOverflow2(options: TestOptions): void {
 
   f.draw();
 
-  beams.forEach((beam) => beam.setContext(f.getContext()).draw());
+  beams.forEach((beam) => beam.setContext(f.getContext()).drawWithStyle());
 
   options.assert.ok(true, 'Auto Beam Applicator Test');
 }
@@ -623,7 +623,7 @@ function beamingWithSeveralGroupsOverflow3(options: TestOptions): void {
 
   f.draw();
 
-  beams.forEach((beam) => beam.setContext(f.getContext()).draw());
+  beams.forEach((beam) => beam.setContext(f.getContext()).drawWithStyle());
 
   options.assert.ok(true, 'Auto Beam Applicator Test');
 }
@@ -650,7 +650,7 @@ function secondaryBreaks1(options: TestOptions): void {
 
   f.draw();
 
-  beams.forEach((beam) => beam.setContext(f.getContext()).draw());
+  beams.forEach((beam) => beam.setContext(f.getContext()).drawWithStyle());
 
   options.assert.ok(true, 'Duration-Based Secondary Breaks Test');
 }
@@ -680,7 +680,7 @@ function secondaryBreaks2(options: TestOptions): void {
 
   f.draw();
 
-  beams.forEach((beam) => beam.setContext(f.getContext()).draw());
+  beams.forEach((beam) => beam.setContext(f.getContext()).drawWithStyle());
 
   options.assert.ok(true, 'Duration-Based Secondary Breaks Test');
 }
@@ -710,7 +710,7 @@ function flatBeamsUp(options: TestOptions): void {
 
   f.draw();
 
-  beams.forEach((beam) => beam.setContext(f.getContext()).draw());
+  beams.forEach((beam) => beam.setContext(f.getContext()).drawWithStyle());
 
   options.assert.ok(true, 'Flat Beams Up Test');
 }
@@ -735,7 +735,7 @@ function flatBeamsDown(options: TestOptions): void {
 
   f.draw();
 
-  beams.forEach((beam) => beam.setContext(f.getContext()).draw());
+  beams.forEach((beam) => beam.setContext(f.getContext()).drawWithStyle());
 
   options.assert.ok(true, 'Flat Beams Down Test');
 }
@@ -757,7 +757,7 @@ function flatBeamsMixed(options: TestOptions): void {
 
   f.draw();
 
-  beams.forEach((beam) => beam.setContext(f.getContext()).draw());
+  beams.forEach((beam) => beam.setContext(f.getContext()).drawWithStyle());
 
   options.assert.ok(true, 'Flat Beams Mixed Direction Test');
 }
@@ -784,7 +784,7 @@ function flatBeamsUpUniform(options: TestOptions): void {
 
   f.draw();
 
-  beams.forEach((beam) => beam.setContext(f.getContext()).draw());
+  beams.forEach((beam) => beam.setContext(f.getContext()).drawWithStyle());
 
   options.assert.ok(true, 'Flat Beams Up (uniform) Test');
 }
@@ -810,7 +810,7 @@ function flatBeamsDownUniform(options: TestOptions): void {
 
   f.draw();
 
-  beams.forEach((beam) => beam.setContext(f.getContext()).draw());
+  beams.forEach((beam) => beam.setContext(f.getContext()).drawWithStyle());
 
   options.assert.ok(true, 'Flat Beams Down (uniform) Test');
 }
@@ -837,7 +837,7 @@ function flatBeamsUpBounds(options: TestOptions): void {
 
   f.draw();
 
-  beams.forEach((beam) => beam.setContext(f.getContext()).draw());
+  beams.forEach((beam) => beam.setContext(f.getContext()).drawWithStyle());
 
   options.assert.ok(true, 'Flat Beams Up (uniform) Test');
 }
@@ -869,7 +869,7 @@ function flatBeamsDownBounds(options: TestOptions): void {
 
   f.draw();
 
-  beams.forEach((beam) => beam.setContext(f.getContext()).draw());
+  beams.forEach((beam) => beam.setContext(f.getContext()).drawWithStyle());
 
   options.assert.ok(true, 'Flat Beams Down (uniform) Test');
 }

--- a/tests/beam_tests.ts
+++ b/tests/beam_tests.ts
@@ -672,7 +672,7 @@ function autoTabBeams(options: TestOptions): void {
 
   f.draw();
 
-  beams.forEach((beam) => beam.setContext(f.getContext()).draw());
+  beams.forEach((beam) => beam.setContext(f.getContext()).drawWithStyle());
 
   options.assert.ok(true, 'All objects have been drawn');
 }

--- a/tests/bend_tests.ts
+++ b/tests/bend_tests.ts
@@ -40,7 +40,7 @@ function doubleBends(options: TestOptions, contextBuilder: ContextBuilder): void
   ctx.scale(1.5, 1.5);
 
   ctx.font = '10pt Arial';
-  const stave = new TabStave(10, 10, 450).addClef('tab').setContext(ctx).draw();
+  const stave = new TabStave(10, 10, 450).addClef('tab').setContext(ctx).drawWithStyle();
 
   const notes = [
     note({
@@ -81,7 +81,7 @@ function doubleBendsWithRelease(options: TestOptions, contextBuilder: ContextBui
   ctx.scale(1.0, 1.0);
   ctx.setBackgroundFillStyle('#FFF');
   ctx.setFont('Arial', VexFlowTests.Font.size);
-  const stave = new TabStave(10, 10, 550).addClef('tab').setContext(ctx).draw();
+  const stave = new TabStave(10, 10, 550).addClef('tab').setContext(ctx).drawWithStyle();
 
   const notes = [
     note({
@@ -163,7 +163,7 @@ function reverseBends(options: TestOptions, contextBuilder: ContextBuilder): voi
 
   ctx.setFont('10pt Arial');
 
-  const stave = new TabStave(10, 10, 450).addClef('tab').setContext(ctx).draw();
+  const stave = new TabStave(10, 10, 450).addClef('tab').setContext(ctx).drawWithStyle();
 
   const notes = [
     note({
@@ -203,7 +203,7 @@ function reverseBends(options: TestOptions, contextBuilder: ContextBuilder): voi
       .preFormat()
       .setX(75 * i);
 
-    note.setStave(stave).setContext(ctx).draw();
+    note.setStave(stave).setContext(ctx).drawWithStyle();
     Note.plotMetrics(ctx, note, 140);
     options.assert.ok(true, 'Bend ' + i);
   }
@@ -214,7 +214,7 @@ function bendPhrase(options: TestOptions, contextBuilder: ContextBuilder): void 
   ctx.scale(1.5, 1.5);
 
   ctx.font = Metrics.get('Bend.fontSize') + Metrics.get('Bend.fontFamily'); // Optionally use constants defined in Font.
-  const stave = new TabStave(10, 10, 450).addClef('tab').setContext(ctx).draw();
+  const stave = new TabStave(10, 10, 450).addClef('tab').setContext(ctx).drawWithStyle();
 
   const phrase1 = [
     { type: Bend.UP, text: 'Full' },
@@ -241,7 +241,7 @@ function bendPhrase(options: TestOptions, contextBuilder: ContextBuilder): void 
       .preFormat()
       .setX(75 * i);
 
-    note.setStave(stave).setContext(ctx).draw();
+    note.setStave(stave).setContext(ctx).drawWithStyle();
     Note.plotMetrics(ctx, note, 140);
     options.assert.ok(true, 'Bend ' + i);
   }
@@ -252,7 +252,7 @@ function whackoBends(options: TestOptions, contextBuilder: ContextBuilder): void
   ctx.scale(1.0, 1.0);
   ctx.setBackgroundFillStyle('#FFF');
   ctx.setFont('Arial', VexFlowTests.Font.size);
-  const stave = new TabStave(10, 10, 350).addClef('tab').setContext(ctx).draw();
+  const stave = new TabStave(10, 10, 350).addClef('tab').setContext(ctx).drawWithStyle();
 
   const phrase1 = [
     { type: Bend.UP, text: 'Full' },

--- a/tests/chordsymbol_tests.ts
+++ b/tests/chordsymbol_tests.ts
@@ -65,7 +65,7 @@ function withModifiers(options: TestOptions): void {
     const voiceW = formatter.preCalculateMinTotalWidth([voice]);
     const staffW = voiceW + Stave.defaultPadding + getGlyphWidth(0xe050 /*gClef*/);
     formatter.format([voice], voiceW);
-    const staff = f.Stave({ x: 10, y, width: staffW }).addClef('treble').draw();
+    const staff = f.Stave({ x: 10, y, width: staffW }).addClef('treble').drawWithStyle();
     voice.draw(ctx, staff);
   }
 
@@ -247,7 +247,7 @@ function kern(options: TestOptions): void {
   ctx.scale(1.5, 1.5);
 
   function draw(chords: ChordSymbol[], y: number) {
-    const stave = f.Stave({ x: 10, y, width: 450 }).addClef('treble').setContext(ctx).draw();
+    const stave = f.Stave({ x: 10, y, width: 450 }).addClef('treble').setContext(ctx).drawWithStyle();
 
     const notes = [
       note(f, ['C/4'], 'q', chords[0]),
@@ -306,7 +306,7 @@ function top(options: TestOptions): void {
     factory.StaveNote({ keys, duration, stemDirection: direction }).addModifier(chordSymbol, 0);
 
   function draw(c1: ChordSymbol, c2: ChordSymbol, y: number) {
-    const stave = f.Stave({ x: 10, y, width: 450 }).addClef('treble').setContext(ctx).draw();
+    const stave = f.Stave({ x: 10, y, width: 450 }).addClef('treble').setContext(ctx).drawWithStyle();
     const notes = [
       note(f, ['e/4', 'a/4', 'd/5'], 'h', c1, 1).addModifier(new Accidental('b'), 0),
       note(f, ['c/5', 'e/5', 'c/6'], 'h', c2, -1),
@@ -349,7 +349,7 @@ function topJustify(options: TestOptions): void {
   ctx.scale(1.5, 1.5);
 
   function draw(chord1: ChordSymbol, chord2: ChordSymbol, y: number) {
-    const stave = new Stave(10, y, 450).addClef('treble').setContext(ctx).draw();
+    const stave = new Stave(10, y, 450).addClef('treble').setContext(ctx).drawWithStyle();
 
     const notes = [
       note(f, ['e/4', 'a/4', 'd/5'], 'h', chord1).addModifier(new Accidental('b'), 0),
@@ -397,7 +397,7 @@ function bottom(options: TestOptions): void {
   ctx.scale(1.5, 1.5);
 
   function draw(chords: ChordSymbol[], y: number) {
-    const stave = new Stave(10, y, 400).addClef('treble').setContext(ctx).draw();
+    const stave = new Stave(10, y, 400).addClef('treble').setContext(ctx).drawWithStyle();
 
     const notes = [
       note(f, ['c/4', 'f/4', 'a/4'], 'q', chords[0]),
@@ -429,7 +429,7 @@ function bottomStemDown(options: TestOptions): void {
     const note = (keys: string[], duration: string, chordSymbol: ChordSymbol) =>
       new StaveNote({ keys, duration, stemDirection: -1 }).addModifier(chordSymbol, 0);
 
-    const stave = new Stave(10, y, 400).addClef('treble').setContext(ctx).draw();
+    const stave = new Stave(10, y, 400).addClef('treble').setContext(ctx).drawWithStyle();
     const notes = [
       note(['c/4', 'f/4', 'a/4'], 'q', chords[0]),
       note(['c/4', 'e/4', 'b/4'], 'q', chords[1]).addModifier(new Accidental('b'), 2),
@@ -460,7 +460,7 @@ function doubleBottom(options: TestOptions): void {
     const note = (keys: string[], duration: string, chordSymbol1: ChordSymbol, chordSymbol2: ChordSymbol) =>
       new StaveNote({ keys, duration }).addModifier(chordSymbol1, 0).addModifier(chordSymbol2, 0);
 
-    const stave = f.Stave({ x: 10, y, width: 450 }).addClef('treble').setContext(ctx).draw();
+    const stave = f.Stave({ x: 10, y, width: 450 }).addClef('treble').setContext(ctx).drawWithStyle();
     const notes = [
       note(['c/4', 'f/4', 'a/4'], 'q', chords[0], chords2[0]),
       note(['c/4', 'e/4', 'b/4'], 'q', chords[1], chords2[1]).addModifier(f.Accidental({ type: 'b' }), 2),
@@ -493,7 +493,7 @@ function wide(options: TestOptions): void {
   ctx.scale(1.5, 1.5);
 
   function draw(chord1: ChordSymbol, chord2: ChordSymbol, y: number) {
-    const stave = new Stave(10, y, 250).addClef('treble').setContext(ctx).draw();
+    const stave = new Stave(10, y, 250).addClef('treble').setContext(ctx).drawWithStyle();
 
     const notes = [
       note(f, ['e/4', 'a/4', 'd/5'], 'h', chord1).addModifier(new Accidental('b'), 0),

--- a/tests/dot_tests.ts
+++ b/tests/dot_tests.ts
@@ -33,7 +33,7 @@ function showOneNote(note1: StaveNote, stave: Stave, ctx: RenderContext, x: numb
   const modifierContext = new ModifierContext();
   note1.setStave(stave).addToModifierContext(modifierContext);
   new TickContext().addTickable(note1).preFormat().setX(x);
-  note1.setContext(ctx).draw();
+  note1.setContext(ctx).drawWithStyle();
   Note.plotMetrics(ctx, note1, 140);
 }
 
@@ -42,7 +42,7 @@ function basic(options: TestOptions, contextBuilder: ContextBuilder): void {
 
   const stave = new Stave(10, 10, 975);
   stave.setContext(ctx);
-  stave.draw();
+  stave.drawWithStyle();
 
   const notes = [
     new StaveNote({ keys: ['c/4', 'e/4', 'a/4', 'b/4'], duration: 'w' }),
@@ -94,7 +94,7 @@ function basic(options: TestOptions, contextBuilder: ContextBuilder): void {
     }
   }
 
-  beam.setContext(ctx).draw();
+  beam.setContext(ctx).drawWithStyle();
 
   VexFlowTests.plotLegendForNoteWidth(ctx, 890, 140);
 
@@ -104,7 +104,7 @@ function basic(options: TestOptions, contextBuilder: ContextBuilder): void {
 function multiVoice(options: TestOptions, contextBuilder: ContextBuilder): void {
   const ctx = contextBuilder(options.elementId, 750, 300);
 
-  const stave = new Stave(30, 45, 700).setContext(ctx).draw();
+  const stave = new Stave(30, 45, 700).setContext(ctx).drawWithStyle();
 
   const notes1 = [
     new StaveNote({ keys: ['c/4', 'e/4', 'a/4'], duration: '2', stemDirection: -1 }),

--- a/tests/formatter_tests.ts
+++ b/tests/formatter_tests.ts
@@ -133,7 +133,7 @@ function rightJustify(options: TestOptions): void {
 
     const voice = getTickables(time, n, duration, duration2);
     formatter.joinVoices([voice]).formatToStave([voice], stave);
-    stave.draw();
+    stave.drawWithStyle();
     voice.draw(f.getContext(), stave);
   };
   renderTest({ numBeats: 4, beatValue: 4, resolution: 4 * 4096 }, 3, '4', '2', 10, 300);
@@ -214,11 +214,11 @@ function noteHeadPadding(options: TestOptions): void {
   const staveWidth = width + Stave.defaultPadding;
   const stave1 = f.Stave({ y: 50, width: staveWidth });
   const stave2 = f.Stave({ y: 150, width: staveWidth });
-  stave1.draw();
-  stave2.draw();
+  stave1.drawWithStyle();
+  stave2.drawWithStyle();
   voice1.draw(f.getContext(), stave1);
   voice2.draw(f.getContext(), stave2);
-  beams.forEach((b) => b.setContext(f.getContext()).draw());
+  beams.forEach((b) => b.setContext(f.getContext()).drawWithStyle());
   options.assert.ok(true);
 }
 
@@ -244,8 +244,8 @@ function longMeasureProblems(options: TestOptions): void {
   formatter.format([voice1, voice2], width);
   const stave1 = f.Stave({ y: 50, width: width + Stave.defaultPadding });
   const stave2 = f.Stave({ y: 200, width: width + Stave.defaultPadding });
-  stave1.draw();
-  stave2.draw();
+  stave1.drawWithStyle();
+  stave2.drawWithStyle();
   voice1.draw(f.getContext(), stave1);
   voice2.draw(f.getContext(), stave2);
   options.assert.ok(true);
@@ -271,11 +271,11 @@ function accidentalJustification(options: TestOptions): void {
   const stave21 = f.Stave({ y: 130, width: width + Stave.defaultPadding });
   formatter.format([voice11, voice21], width);
   const ctx = f.getContext();
-  stave11.setContext(ctx).draw();
-  stave21.setContext(ctx).draw();
+  stave11.setContext(ctx).drawWithStyle();
+  stave21.setContext(ctx).drawWithStyle();
   voice11.draw(ctx, stave11);
   voice21.draw(ctx, stave21);
-  beams.forEach((b) => b.setContext(ctx).draw());
+  beams.forEach((b) => b.setContext(ctx).drawWithStyle());
   options.assert.ok(true);
 }
 
@@ -308,13 +308,13 @@ function unalignedNoteDurations1(options: TestOptions): void {
   const stave11 = f.Stave({ y: 20, width: width + Stave.defaultPadding });
   const stave21 = f.Stave({ y: 130, width: width + Stave.defaultPadding });
   formatter.format([voice11, voice21], width);
-  stave11.setContext(ctx).draw();
-  stave21.setContext(ctx).draw();
+  stave11.setContext(ctx).drawWithStyle();
+  stave21.setContext(ctx).drawWithStyle();
   voice11.draw(ctx, stave11);
   voice21.draw(ctx, stave21);
 
-  beams21.forEach((b) => b.setContext(ctx).draw());
-  beams11.forEach((b) => b.setContext(ctx).draw());
+  beams21.forEach((b) => b.setContext(ctx).drawWithStyle());
+  beams11.forEach((b) => b.setContext(ctx).drawWithStyle());
 
   options.assert.ok(voice11.getTickables()[1].getX() > voice21.getTickables()[1].getX());
 }
@@ -361,8 +361,8 @@ function unalignedNoteDurations2(options: TestOptions): void {
   formatter.format([voice1, voice2], width);
   const stave1 = new Stave(10, 40, width + Stave.defaultPadding);
   const stave2 = new Stave(10, 100, width + Stave.defaultPadding);
-  stave1.setContext(context).draw();
-  stave2.setContext(context).draw();
+  stave1.setContext(context).drawWithStyle();
+  stave2.setContext(context).drawWithStyle();
   voice1.draw(context, stave1);
   voice2.draw(context, stave2);
 
@@ -430,10 +430,10 @@ function alignedMixedElements(options: TestOptions): void {
 
   Formatter.FormatAndDraw(context, stave, notes);
   Formatter.FormatAndDraw(context, stave2, notes2);
-  stave.setContext(context).draw();
-  stave2.setContext(context).draw();
-  tuplet.setContext(context).draw();
-  tuplet2.setContext(context).draw();
+  stave.setContext(context).drawWithStyle();
+  stave2.setContext(context).drawWithStyle();
+  tuplet.setContext(context).drawWithStyle();
+  tuplet2.setContext(context).drawWithStyle();
 
   options.assert.ok(true);
 }
@@ -562,10 +562,10 @@ function multiStaves(options: TestOptions): void {
     type: 'brace',
   });
   for (let i = 0; i < staves.length; ++i) {
-    staves[i].setContext(ctx).draw();
+    staves[i].setContext(ctx).drawWithStyle();
     voices[i].draw(ctx, staves[i]);
   }
-  beams.forEach((beam) => beam.setContext(ctx).draw());
+  beams.forEach((beam) => beam.setContext(ctx).drawWithStyle());
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Draw 3 more staves (one measure each).
@@ -598,11 +598,11 @@ function multiStaves(options: TestOptions): void {
     new Beam(notes32.slice(3, 6), true),
   ];
   for (let i = 0; i < staves.length; ++i) {
-    staves[i].setContext(ctx).draw();
+    staves[i].setContext(ctx).drawWithStyle();
     voices[i].draw(ctx, staves[i]);
     voices[i].getTickables().forEach((note) => Note.plotMetrics(ctx, note, staveYs[i] - 20));
   }
-  beams.forEach((beam) => beam.setContext(ctx).draw());
+  beams.forEach((beam) => beam.setContext(ctx).drawWithStyle());
   options.assert.ok(true);
 }
 
@@ -873,10 +873,10 @@ function annotations(options: TestOptions): void {
     const fmt = new Formatter({ softmaxFactor: sm.sm, maxIterations: 2 }).joinVoices([voice1]);
     fmt.format([voice1], sm.width - 11);
 
-    stave.setContext(context).draw();
+    stave.setContext(context).drawWithStyle();
     voice1.draw(context, stave);
 
-    beams.forEach((b) => b.setContext(context).draw());
+    beams.forEach((b) => b.setContext(context).drawWithStyle());
   });
 
   options.assert.ok(true);

--- a/tests/gracetabnote_tests.ts
+++ b/tests/gracetabnote_tests.ts
@@ -35,7 +35,7 @@ const graceTabNote = (noteStruct: TabNoteStruct) => new GraceTabNote(noteStruct)
  */
 function setupContext(opts: TestOptions, ctxBuilder: ContextBuilder): { context: RenderContext; stave: TabStave } {
   const context = ctxBuilder(opts.elementId, 350, 140);
-  const stave = new TabStave(10, 10, 350).addTabGlyph().setContext(context).draw();
+  const stave = new TabStave(10, 10, 350).addTabGlyph().setContext(context).drawWithStyle();
   return { context, stave };
 }
 

--- a/tests/key_clef_tests.ts
+++ b/tests/key_clef_tests.ts
@@ -87,9 +87,9 @@ function keys(options: TestOptions, contextBuilder: ContextBuilder): void {
 
   for (i = 0; i < clefs.length; i++) {
     staves[i].setContext(ctx);
-    staves[i].draw();
+    staves[i].drawWithStyle();
     staves[i + clefs.length].setContext(ctx);
-    staves[i + clefs.length].draw();
+    staves[i + clefs.length].drawWithStyle();
   }
   options.assert.ok(true, 'all pass');
 }
@@ -123,13 +123,13 @@ function staveHelper(options: TestOptions, contextBuilder: ContextBuilder): void
   }
 
   stave1.setContext(ctx);
-  stave1.draw();
+  stave1.drawWithStyle();
   stave2.setContext(ctx);
-  stave2.draw();
+  stave2.drawWithStyle();
   stave3.setContext(ctx);
-  stave3.draw();
+  stave3.drawWithStyle();
   stave4.setContext(ctx);
-  stave4.draw();
+  stave4.drawWithStyle();
 
   options.assert.ok(true, 'all pass');
 }

--- a/tests/keysignature_tests.ts
+++ b/tests/keysignature_tests.ts
@@ -92,9 +92,9 @@ function majorKeys(options: TestOptions, contextBuilder: ContextBuilder): void {
   }
 
   stave1.setContext(ctx);
-  stave1.draw();
+  stave1.drawWithStyle();
   stave2.setContext(ctx);
-  stave2.draw();
+  stave2.drawWithStyle();
 
   options.assert.ok(true, 'all pass');
 }
@@ -156,13 +156,13 @@ function majorKeysCanceled(options: TestOptions, contextBuilder: ContextBuilder)
   }
 
   stave1.setContext(ctx);
-  stave1.draw();
+  stave1.drawWithStyle();
   stave2.setContext(ctx);
-  stave2.draw();
+  stave2.drawWithStyle();
   stave3.setContext(ctx);
-  stave3.draw();
+  stave3.drawWithStyle();
   stave4.setContext(ctx);
-  stave4.draw();
+  stave4.drawWithStyle();
 
   options.assert.ok(true, 'all pass');
 }
@@ -197,7 +197,7 @@ function keysCanceledForEachClef(options: TestOptions, contextBuilder: ContextBu
       stave.addKeySignature(cancelKey);
       stave.addKeySignature(key, cancelKey);
       stave.addKeySignature(key);
-      stave.setContext(ctx).draw();
+      stave.setContext(ctx).drawWithStyle();
       tx += width;
     });
     tx = x;
@@ -248,13 +248,13 @@ function majorKeysAltered(options: TestOptions, contextBuilder: ContextBuilder):
   }
 
   stave1.setContext(ctx);
-  stave1.draw();
+  stave1.drawWithStyle();
   stave2.setContext(ctx);
-  stave2.draw();
+  stave2.drawWithStyle();
   stave3.setContext(ctx);
-  stave3.draw();
+  stave3.drawWithStyle();
   stave4.setContext(ctx);
-  stave4.draw();
+  stave4.drawWithStyle();
 
   options.assert.ok(true, 'all pass');
 }
@@ -284,9 +284,9 @@ function minorKeys(options: TestOptions, contextBuilder: ContextBuilder): void {
   }
 
   stave1.setContext(ctx);
-  stave1.draw();
+  stave1.drawWithStyle();
   stave2.setContext(ctx);
-  stave2.draw();
+  stave2.drawWithStyle();
 
   options.assert.ok(true, 'all pass');
 }
@@ -306,8 +306,8 @@ function endKeyWithClef(options: TestOptions, contextBuilder: ContextBuilder): v
   const stave2 = new Stave(10, 90, 350);
   stave2.setKeySignature('Cb').setClef('bass').setEndClef('treble').setEndKeySignature('G');
 
-  stave1.setContext(ctx).draw();
-  stave2.setContext(ctx).draw();
+  stave1.setContext(ctx).drawWithStyle();
+  stave2.setContext(ctx).drawWithStyle();
   options.assert.ok(true, 'all pass');
 }
 
@@ -333,9 +333,9 @@ function staveHelper(options: TestOptions, contextBuilder: ContextBuilder): void
   }
 
   stave1.setContext(ctx);
-  stave1.draw();
+  stave1.drawWithStyle();
   stave2.setContext(ctx);
-  stave2.draw();
+  stave2.drawWithStyle();
 
   options.assert.ok(true, 'all pass');
 }

--- a/tests/notehead_tests.ts
+++ b/tests/notehead_tests.ts
@@ -47,7 +47,7 @@ function basic(options: TestOptions, contextBuilder: ContextBuilder): void {
   setContextStyle(ctx);
 
   const stave = new Stave(10, 0, 250).addClef('treble');
-  stave.setContext(ctx).draw();
+  stave.setContext(ctx).drawWithStyle();
 
   const formatter = new Formatter();
   const voice = new Voice(VexFlow.TIME4_4).setStrict(false);
@@ -70,7 +70,7 @@ function basic(options: TestOptions, contextBuilder: ContextBuilder): void {
 function showNote(noteStruct: StaveNoteStruct, stave: Stave, ctx: RenderContext, x: number) {
   const note = new StaveNote(noteStruct).setStave(stave);
   new TickContext().addTickable(note).preFormat().setX(x);
-  note.setContext(ctx).draw();
+  note.setContext(ctx).drawWithStyle();
   return note;
 }
 
@@ -109,7 +109,7 @@ function variousHeads(options: TestOptions, contextBuilder: ContextBuilder): voi
     const stave = new Stave(10, 10 + staveNum * 120, notes.length * 25 + 75)
       .addClef('percussion')
       .setContext(ctx)
-      .draw();
+      .drawWithStyle();
 
     for (let i = 0; i < notes.length; ++i) {
       const note = notes[i];
@@ -178,7 +178,7 @@ function variousNoteHeads(options: TestOptions, contextBuilder: ContextBuilder):
     const stave = new Stave(10, 10 + staveNum * 120, notes.length * 25 + 75)
       .addClef('percussion')
       .setContext(ctx)
-      .draw();
+      .drawWithStyle();
 
     for (let i = 0; i < notes.length; ++i) {
       const note = notes[i];
@@ -205,7 +205,7 @@ function variousNoteHeads2(options: TestOptions, contextBuilder: ContextBuilder)
 
   const ctx = contextBuilder(options.elementId, notes.length * 25 + 100, 240);
 
-  const stave = new Stave(10, 10, notes.length * 25 + 75).addClef('percussion').setContext(ctx).draw();
+  const stave = new Stave(10, 10, notes.length * 25 + 75).addClef('percussion').setContext(ctx).drawWithStyle();
 
   for (let i = 0; i < notes.length; ++i) {
     const note = notes[i];
@@ -244,7 +244,10 @@ function drumChordHeads(options: TestOptions, contextBuilder: ContextBuilder): v
 
   // Draw two staves, one with up-stems and one with down-stems.
   for (let h = 0; h < 2; ++h) {
-    const stave = new Stave(10, 10 + h * 120, notes.length * 25 + 75).addClef('percussion').setContext(ctx).draw();
+    const stave = new Stave(10, 10 + h * 120, notes.length * 25 + 75)
+      .addClef('percussion')
+      .setContext(ctx)
+      .drawWithStyle();
 
     for (let i = 0; i < notes.length; ++i) {
       const note = notes[i];
@@ -263,7 +266,7 @@ function basicBoundingBoxes(options: TestOptions, contextBuilder: ContextBuilder
 
   // 250 is 450/1.8
   const stave = new Stave(10, 0, 250).addClef('treble');
-  stave.setContext(ctx).draw();
+  stave.setContext(ctx).drawWithStyle();
 
   const formatter = new Formatter();
   const voice = new Voice(VexFlow.TIME4_4).setStrict(false);

--- a/tests/notesubgroup_tests.ts
+++ b/tests/notesubgroup_tests.ts
@@ -80,7 +80,7 @@ function multiVoiceSingleDraw(options: TestOptions): void {
 }
 
 /**
- * Call Factory.draw() twice. It should look identical to the multiVoice test case above.
+ * Call Factory.drawWithStyle() twice. It should look identical to the multiVoice test case above.
  */
 function multiVoiceDoubleDraw(options: TestOptions): void {
   multiVoiceHelper(options, 2);

--- a/tests/offscreencanvas_tests.ts
+++ b/tests/offscreencanvas_tests.ts
@@ -40,7 +40,7 @@ function simpleTest(assert: Assert): void {
   // Render to the OffscreenCavans.
   const stave = new Stave(10, 50, 200);
   stave.setEndBarType(BarlineType.END);
-  stave.addClef('treble').setContext(ctx).draw();
+  stave.addClef('treble').setContext(ctx).drawWithStyle();
   const notes = [
     new StaveNote({ keys: ['c/4'], duration: 'q' }),
     new StaveNote({ keys: ['d/4'], duration: 'q' }),

--- a/tests/ornament_tests.ts
+++ b/tests/ornament_tests.ts
@@ -43,7 +43,7 @@ function drawOrnaments(options: TestOptions, contextBuilder: ContextBuilder): vo
   const ctx = contextBuilder(options.elementId, 750, 195);
 
   const stave = new Stave(10, 30, 700);
-  stave.setContext(ctx).draw();
+  stave.setContext(ctx).drawWithStyle();
   const notes = [
     new StaveNote({ keys: ['c/4'], duration: '4', stemDirection: 1 }),
     new StaveNote({ keys: ['c/4'], duration: '4', stemDirection: 1 }),
@@ -85,7 +85,7 @@ function drawOrnamentsDisplaced(options: TestOptions, contextBuilder: ContextBui
   const ctx = contextBuilder(options.elementId, 750, 195);
 
   const stave = new Stave(10, 30, 700);
-  stave.setContext(ctx).draw();
+  stave.setContext(ctx).drawWithStyle();
   const notes = [
     new StaveNote({ keys: ['a/5'], duration: '4', stemDirection: -1 }),
     new StaveNote({ keys: ['a/5'], duration: '4', stemDirection: -1 }),
@@ -130,7 +130,7 @@ const addDelayedTurns = (f: Factory) => {
   const context = f.getContext();
 
   const stave = f.Stave({ x: 10, y: 30, width: 500 });
-  stave.setContext(context).draw();
+  stave.setContext(context).drawWithStyle();
 
   const notes = [
     f.StaveNote({ keys: ['a/4'], duration: '4', stemDirection: 1 }),
@@ -204,7 +204,7 @@ function drawOrnamentsDelayedMultipleVoices(options: TestOptions, contextBuilder
   formatter.joinVoices([voice2]);
   formatter.format([voice1, voice2], formatWidth);
 
-  stave.setContext(ctx).draw();
+  stave.setContext(ctx).drawWithStyle();
   voice1.draw(ctx, stave);
   voice2.draw(ctx, stave);
 }
@@ -217,7 +217,7 @@ function drawOrnamentsStacked(options: TestOptions): void {
   const ctx = f.getContext();
 
   const stave = f.Stave({ x: 10, y: 30, width: 500 });
-  stave.setContext(ctx).draw();
+  stave.setContext(ctx).drawWithStyle();
   const notes = [
     f.StaveNote({ keys: ['a/4'], duration: '4', stemDirection: 1 }),
     f.StaveNote({ keys: ['a/4'], duration: '4', stemDirection: 1 }),
@@ -247,7 +247,7 @@ function drawOrnamentsWithAccidentals(options: TestOptions): void {
   const ctx = f.getContext();
 
   const stave = f.Stave({ x: 10, y: 60, width: 600 });
-  stave.setContext(ctx).draw();
+  stave.setContext(ctx).drawWithStyle();
   const notes = [
     f.StaveNote({ keys: ['f/4'], duration: '4', stemDirection: 1 }),
     f.StaveNote({ keys: ['f/4'], duration: '4', stemDirection: 1 }),
@@ -295,7 +295,7 @@ function jazzOrnaments(options: TestOptions): void {
       return n;
     };
 
-    const stave = new Stave(x, y, width).addClef('treble').setContext(ctx).draw();
+    const stave = new Stave(x, y, width).addClef('treble').setContext(ctx).drawWithStyle();
 
     const notes = [
       note(keys, '4d', modifiers[0], stemDirection),
@@ -316,7 +316,7 @@ function jazzOrnaments(options: TestOptions): void {
     voice.addTickables(notes);
     const formatter = new Formatter().joinVoices([voice]);
     formatter.format([voice], width - Stave.defaultPadding - clefWidth);
-    stave.setContext(ctx).draw();
+    stave.setContext(ctx).drawWithStyle();
     voice.draw(ctx, stave);
   }
 

--- a/tests/percussion_tests.ts
+++ b/tests/percussion_tests.ts
@@ -43,7 +43,7 @@ const PercussionTests = {
 
 function draw(options: TestOptions, contextBuilder: ContextBuilder): void {
   const ctx = contextBuilder(options.elementId, 400, 120);
-  new Stave(10, 10, 300).addClef('percussion').setContext(ctx).draw();
+  new Stave(10, 10, 300).addClef('percussion').setContext(ctx).drawWithStyle();
   options.assert.ok(true);
 }
 
@@ -53,7 +53,7 @@ function draw(options: TestOptions, contextBuilder: ContextBuilder): void {
 function showNote(struct: StaveNoteStruct, stave: Stave, ctx: RenderContext, x: number): StaveNote {
   const staveNote = new StaveNote(struct).setStave(stave);
   new TickContext().addTickable(staveNote).preFormat().setX(x);
-  staveNote.setContext(ctx).draw();
+  staveNote.setContext(ctx).drawWithStyle();
   return staveNote;
 }
 
@@ -81,7 +81,10 @@ function drawNotes(options: TestOptions, contextBuilder: ContextBuilder): void {
 
   // Draw two staves, one with up-stems and one with down-stems.
   for (let h = 0; h < 2; ++h) {
-    const stave = new Stave(10, 10 + h * 120, notes.length * 25 + 75).addClef('percussion').setContext(ctx).draw();
+    const stave = new Stave(10, 10 + h * 120, notes.length * 25 + 75)
+      .addClef('percussion')
+      .setContext(ctx)
+      .drawWithStyle();
 
     for (let i = 0; i < notes.length; ++i) {
       const note = notes[i];

--- a/tests/renderer_tests.ts
+++ b/tests/renderer_tests.ts
@@ -57,7 +57,7 @@ const RendererTests = {
  * Helper function to add three notes to a stave.
  */
 function drawStave(stave: Stave, context: RenderContext): void {
-  stave.addClef('bass').addTimeSignature('3/4').draw();
+  stave.addClef('bass').addTimeSignature('3/4').drawWithStyle();
   Formatter.FormatAndDraw(context, stave, [
     new StaveNote({ keys: ['C/4'], duration: '4' }),
     new StaveNote({ keys: ['E/4'], duration: '4' }),

--- a/tests/rests_tests.ts
+++ b/tests/rests_tests.ts
@@ -53,7 +53,7 @@ function setupContext(
 
   context.font = '10pt Arial';
 
-  const stave = new Stave(10, 30, width).addClef('treble').addTimeSignature('4/4').setContext(context).draw();
+  const stave = new Stave(10, 30, width).addClef('treble').addTimeSignature('4/4').setContext(context).drawWithStyle();
 
   return { context, stave };
 }
@@ -133,9 +133,9 @@ function beamsUp(options: TestOptions, contextBuilder: ContextBuilder): void {
 
   Formatter.FormatAndDraw(context, stave, notes);
 
-  beam1.setContext(context).draw();
-  beam2.setContext(context).draw();
-  beam3.setContext(context).draw();
+  beam1.setContext(context).drawWithStyle();
+  beam2.setContext(context).drawWithStyle();
+  beam3.setContext(context).drawWithStyle();
 
   options.assert.ok(true, 'Auto Align Rests - Beams Up Test');
 }
@@ -169,9 +169,9 @@ function beamsDown(options: TestOptions, contextBuilder: ContextBuilder): void {
 
   Formatter.FormatAndDraw(context, stave, notes);
 
-  beam1.setContext(context).draw();
-  beam2.setContext(context).draw();
-  beam3.setContext(context).draw();
+  beam1.setContext(context).drawWithStyle();
+  beam2.setContext(context).drawWithStyle();
+  beam3.setContext(context).drawWithStyle();
 
   options.assert.ok(true, 'Auto Align Rests - Beams Down Test');
 }
@@ -208,10 +208,10 @@ function tupletsUp(options: TestOptions, contextBuilder: ContextBuilder): void {
 
   Formatter.FormatAndDraw(context, stave, notes);
 
-  tuplet1.setContext(context).draw();
-  tuplet2.setContext(context).draw();
-  tuplet3.setContext(context).draw();
-  tuplet4.setContext(context).draw();
+  tuplet1.setContext(context).drawWithStyle();
+  tuplet2.setContext(context).drawWithStyle();
+  tuplet3.setContext(context).drawWithStyle();
+  tuplet4.setContext(context).drawWithStyle();
 
   options.assert.ok(true, 'Auto Align Rests - Tuplets Stem Up Test');
 }
@@ -253,15 +253,15 @@ function tupletsDown(options: TestOptions, contextBuilder: ContextBuilder): void
 
   Formatter.FormatAndDraw(context, stave, notes);
 
-  tuplet1.setContext(context).draw();
-  tuplet2.setContext(context).draw();
-  tuplet3.setContext(context).draw();
-  tuplet4.setContext(context).draw();
+  tuplet1.setContext(context).drawWithStyle();
+  tuplet2.setContext(context).drawWithStyle();
+  tuplet3.setContext(context).drawWithStyle();
+  tuplet4.setContext(context).drawWithStyle();
 
-  beam1.setContext(context).draw();
-  beam2.setContext(context).draw();
-  beam3.setContext(context).draw();
-  beam4.setContext(context).draw();
+  beam1.setContext(context).drawWithStyle();
+  beam2.setContext(context).drawWithStyle();
+  beam3.setContext(context).drawWithStyle();
+  beam4.setContext(context).drawWithStyle();
 
   options.assert.ok(true, 'Auto Align Rests - Tuplets Stem Down Test');
 }
@@ -301,8 +301,8 @@ function singleVoiceDefaultAlignment(options: TestOptions, contextBuilder: Conte
 
   Formatter.FormatAndDraw(context, stave, notes);
 
-  tuplet.setContext(context).draw();
-  beam.setContext(context).draw();
+  tuplet.setContext(context).drawWithStyle();
+  beam.setContext(context).drawWithStyle();
 
   options.assert.ok(true, 'Auto Align Rests - Default Test');
 }
@@ -342,8 +342,8 @@ function singleVoiceAlignAll(options: TestOptions, contextBuilder: ContextBuilde
   // Set { alignRests: true } to align rests (vertically) with nearby notes in each voice.
   Formatter.FormatAndDraw(context, stave, notes, { alignRests: true });
 
-  tuplet.setContext(context).draw();
-  beam.setContext(context).draw();
+  tuplet.setContext(context).drawWithStyle();
+  beam.setContext(context).drawWithStyle();
 
   options.assert.ok(true, 'Auto Align Rests - Align All Test');
 }
@@ -355,7 +355,7 @@ function singleVoiceAlignAll(options: TestOptions, contextBuilder: ContextBuilde
  */
 function multiVoice(options: TestOptions, contextBuilder: ContextBuilder): void {
   const ctx = contextBuilder(options.elementId, 600, 200);
-  const stave = new Stave(50, 10, 500).addClef('treble').setContext(ctx).addTimeSignature('4/4').draw();
+  const stave = new Stave(50, 10, 500).addClef('treble').setContext(ctx).addTimeSignature('4/4').drawWithStyle();
 
   const noteOnStave = (noteStruct: StaveNoteStruct) => new StaveNote(noteStruct).setStave(stave);
 
@@ -391,8 +391,8 @@ function multiVoice(options: TestOptions, contextBuilder: ContextBuilder): void 
   // Otherwise, the ledger lines will be drawn on top of middle C notes in voice1.
   voice2.draw(ctx);
   voice1.draw(ctx);
-  beam2_1.setContext(ctx).draw();
-  beam2_2.setContext(ctx).draw();
+  beam2_1.setContext(ctx).drawWithStyle();
+  beam2_2.setContext(ctx).drawWithStyle();
 
   options.assert.ok(true, 'Strokes Test Multi Voice');
 }

--- a/tests/rhythm_tests.ts
+++ b/tests/rhythm_tests.ts
@@ -32,7 +32,7 @@ function drawSlash(options: TestOptions, contextBuilder: ContextBuilder): void {
   const ctx = contextBuilder(options.elementId, 350, 180);
   const stave = new Stave(10, 10, 350);
   stave.setContext(ctx);
-  stave.draw();
+  stave.drawWithStyle();
 
   const notes: StaveNoteStruct[] = [
     { keys: ['b/4'], duration: 'ws', stemDirection: -1 },
@@ -51,7 +51,7 @@ function drawSlash(options: TestOptions, contextBuilder: ContextBuilder): void {
       .addTickable(staveNote)
       .preFormat()
       .setX((i + 1) * 25);
-    staveNote.setContext(ctx).draw();
+    staveNote.setContext(ctx).drawWithStyle();
 
     options.assert.ok(staveNote.getX() > 0, 'Note ' + i + ' has X value');
     options.assert.ok(staveNote.getYs().length > 0, 'Note ' + i + ' has Y values');
@@ -69,7 +69,7 @@ function drawBasic(options: TestOptions, contextBuilder: ContextBuilder): void {
   staveBar1.addClef('treble');
   staveBar1.addTimeSignature('4/4');
   staveBar1.addKeySignature('C');
-  staveBar1.setContext(ctx).draw();
+  staveBar1.setContext(ctx).drawWithStyle();
 
   const notesBar1 = [new StaveNote({ keys: ['b/4'], duration: '1s', stemDirection: -1 })];
 
@@ -80,7 +80,7 @@ function drawBasic(options: TestOptions, contextBuilder: ContextBuilder): void {
   const staveBar2 = new Stave(staveBar1.getWidth() + staveBar1.getX(), staveBar1.getY(), 120);
   staveBar2.setBegBarType(BarlineType.SINGLE);
   staveBar2.setEndBarType(BarlineType.SINGLE);
-  staveBar2.setContext(ctx).draw();
+  staveBar2.setContext(ctx).drawWithStyle();
 
   // bar 2
   const notesBar2 = [
@@ -93,7 +93,7 @@ function drawBasic(options: TestOptions, contextBuilder: ContextBuilder): void {
 
   // bar 3 - juxtaposing second bar next to first bar
   const staveBar3 = new Stave(staveBar2.getWidth() + staveBar2.getX(), staveBar2.getY(), 170);
-  staveBar3.setContext(ctx).draw();
+  staveBar3.setContext(ctx).drawWithStyle();
 
   // bar 3
   const notesBar3 = [
@@ -124,7 +124,7 @@ function drawBasic(options: TestOptions, contextBuilder: ContextBuilder): void {
 
   // bar 4 - juxtaposing second bar next to first bar
   const staveBar4 = new Stave(staveBar3.getWidth() + staveBar3.getX(), staveBar3.getY(), 200);
-  staveBar4.setContext(ctx).draw();
+  staveBar4.setContext(ctx).drawWithStyle();
 
   // bar 4
   const notesBar4 = [
@@ -185,7 +185,7 @@ function drawBeamedSlashNotes(options: TestOptions, contextBuilder: ContextBuild
   staveBar1.addClef('treble');
   staveBar1.addTimeSignature('4/4');
   staveBar1.addKeySignature('C');
-  staveBar1.setContext(ctx).draw();
+  staveBar1.setContext(ctx).drawWithStyle();
 
   // bar 4
   const notesBar1Part1 = [
@@ -243,8 +243,8 @@ function drawBeamedSlashNotes(options: TestOptions, contextBuilder: ContextBuild
   Formatter.FormatAndDraw(ctx, staveBar1, notesBar1);
 
   // Render beams
-  beam1.setContext(ctx).draw();
-  beam2.setContext(ctx).draw();
+  beam1.setContext(ctx).drawWithStyle();
+  beam2.setContext(ctx).drawWithStyle();
 
   options.assert.expect(0);
 }
@@ -259,7 +259,7 @@ function drawSlashAndBeamAndRests(options: TestOptions, contextBuilder: ContextB
   staveBar1.addClef('treble');
   staveBar1.addTimeSignature('4/4');
   staveBar1.addKeySignature('F');
-  staveBar1.setContext(ctx).draw();
+  staveBar1.setContext(ctx).drawWithStyle();
 
   // bar 1
   const notesBar1Part1 = [
@@ -313,11 +313,11 @@ function drawSlashAndBeamAndRests(options: TestOptions, contextBuilder: ContextB
   Formatter.FormatAndDraw(ctx, staveBar1, notesBar1Part1.concat(notesBar1Part2));
 
   // Render beams
-  beam1.setContext(ctx).draw();
+  beam1.setContext(ctx).drawWithStyle();
 
   // bar 2 - juxtaposing second bar next to first bar
   const staveBar2 = new Stave(staveBar1.getWidth() + staveBar1.getX(), staveBar1.getY(), 220);
-  staveBar2.setContext(ctx).draw();
+  staveBar2.setContext(ctx).drawWithStyle();
 
   const notesBar2 = [
     new StaveNote({
@@ -344,7 +344,7 @@ function drawSixtenthWithScratches(options: TestOptions, contextBuilder: Context
   staveBar1.addClef('treble');
   staveBar1.addTimeSignature('4/4');
   staveBar1.addKeySignature('F');
-  staveBar1.setContext(ctx).draw();
+  staveBar1.setContext(ctx).drawWithStyle();
 
   // bar 1
   const notesBar1Part1 = [
@@ -403,8 +403,8 @@ function drawSixtenthWithScratches(options: TestOptions, contextBuilder: Context
   Formatter.FormatAndDraw(ctx, staveBar1, notesBar1Part1.concat(notesBar1Part2));
 
   // Render beams
-  beam1.setContext(ctx).draw();
-  beam2.setContext(ctx).draw();
+  beam1.setContext(ctx).drawWithStyle();
+  beam2.setContext(ctx).drawWithStyle();
 
   options.assert.expect(0);
 }
@@ -419,7 +419,7 @@ function drawThirtySecondWithScratches(options: TestOptions, contextBuilder: Con
   staveBar1.addClef('treble');
   staveBar1.addTimeSignature('4/4');
   staveBar1.addKeySignature('F');
-  staveBar1.setContext(ctx).draw();
+  staveBar1.setContext(ctx).drawWithStyle();
 
   // bar 1
   const notesBar1Part1 = [
@@ -474,7 +474,7 @@ function drawThirtySecondWithScratches(options: TestOptions, contextBuilder: Con
   Formatter.FormatAndDraw(ctx, staveBar1, notesBar1Part1);
 
   // Render beams
-  beam1.setContext(ctx).draw();
+  beam1.setContext(ctx).drawWithStyle();
 
   options.assert.expect(0);
 }

--- a/tests/stave_tests.ts
+++ b/tests/stave_tests.ts
@@ -119,7 +119,7 @@ function draw(options: TestOptions, contextBuilder: ContextBuilder): void {
   const ctx = contextBuilder(options.elementId, 400, 150);
   const stave = new Stave(10, 10, 300);
   stave.setContext(ctx);
-  stave.draw();
+  stave.drawWithStyle();
 
   options.assert.equal(stave.getYForNote(0), 100, 'getYForNote(0)');
   options.assert.equal(stave.getYForLine(5), 100, 'getYForLine(5)');
@@ -133,11 +133,11 @@ function drawOpenStave(options: TestOptions, contextBuilder: ContextBuilder): vo
   const ctx = contextBuilder(options.elementId, 400, 350);
   let stave = new Stave(10, 10, 300, { leftBar: false });
   stave.setContext(ctx);
-  stave.draw();
+  stave.drawWithStyle();
 
   stave = new Stave(10, 150, 300, { rightBar: false });
   stave.setContext(ctx);
-  stave.draw();
+  stave.drawWithStyle();
 
   options.assert.ok(true, 'all pass');
 }
@@ -153,7 +153,7 @@ function drawMultipleMeasures(options: TestOptions, contextBuilder: ContextBuild
   staveBar1.setBegBarType(BarlineType.REPEAT_BEGIN);
   staveBar1.setEndBarType(BarlineType.DOUBLE);
   staveBar1.setSection('A', 0, 0, options.params?.fontSize, false);
-  staveBar1.addClef('treble').setContext(ctx).draw();
+  staveBar1.addClef('treble').setContext(ctx).drawWithStyle();
   const notesBar1 = [
     new StaveNote({ keys: ['c/4'], duration: 'q' }),
     new StaveNote({ keys: ['d/4'], duration: 'q' }),
@@ -168,7 +168,7 @@ function drawMultipleMeasures(options: TestOptions, contextBuilder: ContextBuild
   const staveBar2 = new Stave(staveBar1.getWidth() + staveBar1.getX(), staveBar1.getY(), 300);
   staveBar2.addModifier(new StaveSection('B').setFontSize(options.params?.fontSize));
   staveBar2.setEndBarType(BarlineType.END);
-  staveBar2.setContext(ctx).draw();
+  staveBar2.setContext(ctx).drawWithStyle();
 
   const notesBar2Part1 = [
     new StaveNote({ keys: ['c/4'], duration: '8' }),
@@ -193,8 +193,8 @@ function drawMultipleMeasures(options: TestOptions, contextBuilder: ContextBuild
   Formatter.FormatAndDraw(ctx, staveBar2, notesBar2);
 
   // Render beams
-  beam1.setContext(ctx).draw();
-  beam2.setContext(ctx).draw();
+  beam1.setContext(ctx).drawWithStyle();
+  beam2.setContext(ctx).drawWithStyle();
 }
 
 function drawRepeats(options: TestOptions, contextBuilder: ContextBuilder): void {
@@ -209,7 +209,7 @@ function drawRepeats(options: TestOptions, contextBuilder: ContextBuilder): void
   staveBar1.setEndBarType(BarlineType.REPEAT_END);
   staveBar1.addClef('treble');
   staveBar1.addKeySignature('A');
-  staveBar1.setContext(ctx).draw();
+  staveBar1.setContext(ctx).drawWithStyle();
   const notesBar1 = [
     new StaveNote({ keys: ['c/4'], duration: 'q' }),
     new StaveNote({ keys: ['d/4'], duration: 'q' }),
@@ -224,7 +224,7 @@ function drawRepeats(options: TestOptions, contextBuilder: ContextBuilder): void
   const staveBar2 = new Stave(staveBar1.getWidth() + staveBar1.getX(), staveBar1.getY(), 250);
   staveBar2.setBegBarType(BarlineType.REPEAT_BEGIN);
   staveBar2.setEndBarType(BarlineType.REPEAT_END);
-  staveBar2.setContext(ctx).draw();
+  staveBar2.setContext(ctx).drawWithStyle();
 
   const notesBar2Part1 = [
     new StaveNote({ keys: ['c/4'], duration: '8' }),
@@ -251,12 +251,12 @@ function drawRepeats(options: TestOptions, contextBuilder: ContextBuilder): void
   Formatter.FormatAndDraw(ctx, staveBar2, notesBar2);
 
   // Render beams
-  beam1.setContext(ctx).draw();
-  beam2.setContext(ctx).draw();
+  beam1.setContext(ctx).drawWithStyle();
+  beam2.setContext(ctx).drawWithStyle();
 
   // bar 3 - juxtaposing third bar next to second bar
   const staveBar3 = new Stave(staveBar2.getWidth() + staveBar2.getX(), staveBar2.getY(), 50);
-  staveBar3.setContext(ctx).draw();
+  staveBar3.setContext(ctx).drawWithStyle();
   const notesBar3 = [new StaveNote({ keys: ['d/5'], duration: 'wr' })];
 
   // Helper function to justify and draw a 4/4 voice
@@ -270,7 +270,7 @@ function drawRepeats(options: TestOptions, contextBuilder: ContextBuilder): void
   );
   staveBar4.setBegBarType(BarlineType.REPEAT_BEGIN);
   staveBar4.setEndBarType(BarlineType.REPEAT_END);
-  staveBar4.setContext(ctx).draw();
+  staveBar4.setContext(ctx).drawWithStyle();
   const notesBar4 = [
     new StaveNote({ keys: ['c/4'], duration: 'q' }),
     new StaveNote({ keys: ['d/4'], duration: 'q' }),
@@ -327,7 +327,7 @@ function drawEndModifiers(options: TestOptions, contextBuilder: ContextBuilder):
         }
       }
 
-      staveBar.setContext(ctx).draw();
+      staveBar.setContext(ctx).drawWithStyle();
       const notesBar = [
         new StaveNote({ keys: ['c/4'], duration: 'q' }),
         new StaveNote({ keys: ['d/4'], duration: 'q' }),
@@ -416,7 +416,7 @@ function drawStaveRepetition(options: TestOptions, contextBuilder: ContextBuilde
   mm1.addClef('treble');
   mm1.setRepetitionType(Repetition.type.DS_AL_FINE, options.params.yShift);
   mm1.setMeasure(1);
-  mm1.setContext(ctx).draw();
+  mm1.setContext(ctx).drawWithStyle();
   const notesmm1 = [
     new StaveNote({ keys: ['a/4'], duration: 'q' }),
     new StaveNote({ keys: ['f/4'], duration: 'q' }),
@@ -430,7 +430,7 @@ function drawStaveRepetition(options: TestOptions, contextBuilder: ContextBuilde
   const mm2 = new Stave(mm1.getWidth() + mm1.getX(), mm1.getY(), 150);
   mm2.setRepetitionType(Repetition.type.TO_CODA, options.params.yShift);
   mm2.setMeasure(2);
-  mm2.setContext(ctx).draw();
+  mm2.setContext(ctx).drawWithStyle();
   const notesmm2 = [
     new StaveNote({ keys: ['a/4'], duration: 'q' }),
     new StaveNote({ keys: ['f/4'], duration: 'q' }),
@@ -444,7 +444,7 @@ function drawStaveRepetition(options: TestOptions, contextBuilder: ContextBuilde
   const mm3 = new Stave(mm2.getWidth() + mm2.getX(), mm1.getY(), 150);
   mm3.setRepetitionType(Repetition.type.DS_AL_CODA, options.params.yShift);
   mm3.setMeasure(3);
-  mm3.setContext(ctx).draw();
+  mm3.setContext(ctx).drawWithStyle();
   const notesmm3 = [
     new StaveNote({ keys: ['a/4'], duration: 'q' }),
     new StaveNote({ keys: ['f/4'], duration: 'q' }),
@@ -458,7 +458,7 @@ function drawStaveRepetition(options: TestOptions, contextBuilder: ContextBuilde
   const mm4 = new Stave(mm3.getWidth() + mm3.getX(), mm1.getY(), 150);
   mm4.setRepetitionType(Repetition.type.CODA_LEFT, options.params.yShift);
   mm4.setMeasure(4);
-  mm4.setContext(ctx).draw();
+  mm4.setContext(ctx).drawWithStyle();
   const notesmm4 = [
     new StaveNote({ keys: ['a/4'], duration: 'q' }),
     new StaveNote({ keys: ['f/4'], duration: 'q' }),
@@ -483,7 +483,7 @@ function drawVolta(options: TestOptions, contextBuilder: ContextBuilder): void {
   mm1.addKeySignature('A');
   mm1.setMeasure(1);
   mm1.addModifier(new StaveSection('A'));
-  mm1.setContext(ctx).draw();
+  mm1.setContext(ctx).drawWithStyle();
   const notesmm1 = [new StaveNote({ keys: ['c/4'], duration: 'w' })];
   // Helper function to justify and draw a 4/4 voice
   Formatter.FormatAndDraw(ctx, mm1, notesmm1);
@@ -492,7 +492,7 @@ function drawVolta(options: TestOptions, contextBuilder: ContextBuilder): void {
   const mm2 = new Stave(mm1.getWidth() + mm1.getX(), mm1.getY(), 60);
   mm2.setRepetitionType(Repetition.type.CODA_RIGHT);
   mm2.setMeasure(2);
-  mm2.setContext(ctx).draw();
+  mm2.setContext(ctx).drawWithStyle();
   const notesmm2 = [new StaveNote({ keys: ['d/4'], duration: 'w' })];
   // Helper function to justify and draw a 4/4 voice
   Formatter.FormatAndDraw(ctx, mm2, notesmm2);
@@ -501,7 +501,7 @@ function drawVolta(options: TestOptions, contextBuilder: ContextBuilder): void {
   const mm3 = new Stave(mm2.getWidth() + mm2.getX(), mm1.getY(), 60);
   mm3.setVoltaType(VoltaType.BEGIN, '1.', -5);
   mm3.setMeasure(3);
-  mm3.setContext(ctx).draw();
+  mm3.setContext(ctx).drawWithStyle();
   const notesmm3 = [new StaveNote({ keys: ['e/4'], duration: 'w' })];
   // Helper function to justify and draw a 4/4 voice
   Formatter.FormatAndDraw(ctx, mm3, notesmm3);
@@ -510,7 +510,7 @@ function drawVolta(options: TestOptions, contextBuilder: ContextBuilder): void {
   const mm4 = new Stave(mm3.getWidth() + mm3.getX(), mm1.getY(), 60);
   mm4.setVoltaType(VoltaType.MID, '', -5);
   mm4.setMeasure(4);
-  mm4.setContext(ctx).draw();
+  mm4.setContext(ctx).drawWithStyle();
   const notesmm4 = [new StaveNote({ keys: ['f/4'], duration: 'w' })];
   // Helper function to justify and draw a 4/4 voice
   Formatter.FormatAndDraw(ctx, mm4, notesmm4);
@@ -520,7 +520,7 @@ function drawVolta(options: TestOptions, contextBuilder: ContextBuilder): void {
   mm5.setEndBarType(BarlineType.REPEAT_END);
   mm5.setVoltaType(VoltaType.END, '', -5);
   mm5.setMeasure(5);
-  mm5.setContext(ctx).draw();
+  mm5.setContext(ctx).drawWithStyle();
   const notesmm5 = [new StaveNote({ keys: ['g/4'], duration: 'w' })];
   // Helper function to justify and draw a 4/4 voice
   Formatter.FormatAndDraw(ctx, mm5, notesmm5);
@@ -530,7 +530,7 @@ function drawVolta(options: TestOptions, contextBuilder: ContextBuilder): void {
   mm6.setVoltaType(VoltaType.BEGIN_END, '2.', -5);
   mm6.setEndBarType(BarlineType.DOUBLE);
   mm6.setMeasure(6);
-  mm6.setContext(ctx).draw();
+  mm6.setContext(ctx).drawWithStyle();
   const notesmm6 = [new StaveNote({ keys: ['a/4'], duration: 'w' })];
   // Helper function to justify and draw a 4/4 voice
   Formatter.FormatAndDraw(ctx, mm6, notesmm6);
@@ -539,7 +539,7 @@ function drawVolta(options: TestOptions, contextBuilder: ContextBuilder): void {
   const mm7 = new Stave(mm6.getWidth() + mm6.getX(), mm1.getY(), 60);
   mm7.setMeasure(7);
   mm7.addModifier(new StaveSection('B').setPadding(4));
-  mm7.setContext(ctx).draw();
+  mm7.setContext(ctx).drawWithStyle();
   const notesmm7 = [new StaveNote({ keys: ['b/4'], duration: 'w' })];
   // Helper function to justify and draw a 4/4 voice
   Formatter.FormatAndDraw(ctx, mm7, notesmm7);
@@ -549,7 +549,7 @@ function drawVolta(options: TestOptions, contextBuilder: ContextBuilder): void {
   mm8.setEndBarType(BarlineType.DOUBLE);
   mm8.setRepetitionType(Repetition.type.DS_AL_CODA);
   mm8.setMeasure(8);
-  mm8.setContext(ctx).draw();
+  mm8.setContext(ctx).drawWithStyle();
   const notesmm8 = [new StaveNote({ keys: ['c/5'], duration: 'w' })];
   // Helper function to justify and draw a 4/4 voice
   Formatter.FormatAndDraw(ctx, mm8, notesmm8);
@@ -561,7 +561,7 @@ function drawVolta(options: TestOptions, contextBuilder: ContextBuilder): void {
   mm9.addClef('treble');
   mm9.addKeySignature('A');
   mm9.setMeasure(9);
-  mm9.setContext(ctx).draw();
+  mm9.setContext(ctx).drawWithStyle();
   const notesmm9 = [new StaveNote({ keys: ['d/5'], duration: 'w' })];
 
   // Helper function to justify and draw a 4/4 voice
@@ -582,7 +582,7 @@ function drawVoltaModifier(options: TestOptions, contextBuilder: ContextBuilder)
   mm1.addKeySignature('A');
   mm1.setMeasure(1);
   mm1.setSection('A', 0);
-  mm1.setContext(ctx).draw();
+  mm1.setContext(ctx).drawWithStyle();
   const notesmm1 = [new StaveNote({ keys: ['c/4'], duration: 'w' })];
   // Helper function to justify and draw a 4/4 voice
   Formatter.FormatAndDraw(ctx, mm1, notesmm1);
@@ -595,7 +595,7 @@ function drawVoltaModifier(options: TestOptions, contextBuilder: ContextBuilder)
   mm2.addClef('treble');
   mm2.addKeySignature('A');
   mm2.setMeasure(2);
-  mm2.setContext(ctx).draw();
+  mm2.setContext(ctx).drawWithStyle();
   const notesmm2 = [new StaveNote({ keys: ['c/4'], duration: 'w' })];
   Formatter.FormatAndDraw(ctx, mm2, notesmm2);
 
@@ -607,7 +607,7 @@ function drawVoltaModifier(options: TestOptions, contextBuilder: ContextBuilder)
   mm3.addKeySignature('B');
   mm3.setMeasure(3);
   mm3.setSection('B', 0);
-  mm3.setContext(ctx).draw();
+  mm3.setContext(ctx).drawWithStyle();
   const notesmm3 = [new StaveNote({ keys: ['c/4'], duration: 'w' })];
   Formatter.FormatAndDraw(ctx, mm3, notesmm3);
 
@@ -619,7 +619,7 @@ function drawVoltaModifier(options: TestOptions, contextBuilder: ContextBuilder)
   mm4.addKeySignature('A');
   mm4.setMeasure(4);
   mm4.setSection('C', 0);
-  mm4.setContext(ctx).draw();
+  mm4.setContext(ctx).drawWithStyle();
   const notesmm4 = [new StaveNote({ keys: ['c/4'], duration: 'w' })];
   Formatter.FormatAndDraw(ctx, mm4, notesmm4);
 
@@ -632,7 +632,7 @@ function drawVoltaModifier(options: TestOptions, contextBuilder: ContextBuilder)
   mm5.addKeySignature('A');
   mm5.setMeasure(5);
   mm5.addModifier(new StaveSection('D'));
-  mm5.setContext(ctx).draw();
+  mm5.setContext(ctx).drawWithStyle();
   const notesmm5 = [new StaveNote({ keys: ['c/4'], duration: 'w' })];
   Formatter.FormatAndDraw(ctx, mm5, notesmm5);
 
@@ -642,7 +642,7 @@ function drawVoltaModifier(options: TestOptions, contextBuilder: ContextBuilder)
   mm6.setRepetitionType(Repetition.type.DS);
   mm6.setMeasure(6);
   mm6.addModifier(new StaveSection('E'));
-  mm6.setContext(ctx).draw();
+  mm6.setContext(ctx).drawWithStyle();
   const notesmm6 = [new StaveNote({ keys: ['c/4'], duration: 'w' })];
   Formatter.FormatAndDraw(ctx, mm6, notesmm6);
 }
@@ -659,7 +659,7 @@ function drawTempo(options: TestOptions, contextBuilder: ContextBuilder): void {
     const staveBar = new Stave(padding + x, y, width);
     if (x === 0) staveBar.addClef('treble');
     staveBar.setTempo(tempo, tempoY);
-    staveBar.setContext(ctx).draw();
+    staveBar.setContext(ctx).drawWithStyle();
 
     const notesBar = notes || [
       new StaveNote({ keys: ['c/4'], duration: 'q' }),
@@ -715,7 +715,7 @@ function configureSingleLine(options: TestOptions, contextBuilder: ContextBuilde
     .setConfigForLine(2, { visible: true })
     .setConfigForLine(3, { visible: false })
     .setConfigForLine(4, { visible: true });
-  stave.setContext(ctx).draw();
+  stave.setContext(ctx).drawWithStyle();
 
   const config = stave.getConfigForLines();
   options.assert.equal(config[0].visible, true, 'getLinesConfiguration() - Line 0');
@@ -733,7 +733,7 @@ function configureAllLines(options: TestOptions, contextBuilder: ContextBuilder)
   stave
     .setConfigForLines([{ visible: false }, {}, { visible: false }, { visible: true }, { visible: false }])
     .setContext(ctx)
-    .draw();
+    .drawWithStyle();
 
   const config = stave.getConfigForLines();
   options.assert.equal(config[0].visible, false, 'getLinesConfiguration() - Line 0');
@@ -752,7 +752,7 @@ function drawStaveText(options: TestOptions, contextBuilder: ContextBuilder): vo
   stave.setStaveText('Right Text', Modifier.Position.RIGHT);
   stave.setStaveText('Above Text', Modifier.Position.ABOVE);
   stave.setStaveText('Below Text', Modifier.Position.BELOW);
-  stave.setContext(ctx).draw();
+  stave.setContext(ctx).drawWithStyle();
 
   options.assert.ok(true, 'all pass');
 }
@@ -774,7 +774,7 @@ function drawStaveTextMultiLine(options: TestOptions, contextBuilder: ContextBui
     shiftY: 10,
     justification: TextJustification.RIGHT,
   });
-  stave.setContext(ctx).draw();
+  stave.setContext(ctx).drawWithStyle();
 
   options.assert.ok(true, 'all pass');
 }

--- a/tests/staveconnector_tests.ts
+++ b/tests/staveconnector_tests.ts
@@ -44,9 +44,9 @@ function drawSingle(options: TestOptions, contextBuilder: ContextBuilder): void 
   const connector = new StaveConnector(stave1, stave2);
   connector.setType(StaveConnector.type.SINGLE);
   connector.setContext(ctx);
-  stave1.draw();
-  stave2.draw();
-  connector.draw();
+  stave1.drawWithStyle();
+  stave2.drawWithStyle();
+  connector.drawWithStyle();
 
   options.assert.ok(true, 'all pass');
 }
@@ -62,9 +62,9 @@ function drawSingle4pxStaveLines(options: TestOptions, contextBuilder: ContextBu
   const connector = new StaveConnector(stave1, stave2);
   connector.setType(StaveConnector.type.SINGLE);
   connector.setContext(ctx);
-  stave1.draw();
-  stave2.draw();
-  connector.draw();
+  stave1.drawWithStyle();
+  stave2.drawWithStyle();
+  connector.drawWithStyle();
   VexFlow.STAVE_LINE_THICKNESS = oldThickness;
 
   options.assert.ok(true, 'all pass');
@@ -82,10 +82,10 @@ function drawSingleBoth(options: TestOptions, contextBuilder: ContextBuilder): v
   const connector2 = new StaveConnector(stave1, stave2);
   connector2.setType(StaveConnector.type.SINGLE_RIGHT);
   connector2.setContext(ctx);
-  stave1.draw();
-  stave2.draw();
-  connector1.draw();
-  connector2.draw();
+  stave1.drawWithStyle();
+  stave2.drawWithStyle();
+  connector1.drawWithStyle();
+  connector2.drawWithStyle();
 
   options.assert.ok(true, 'all pass');
 }
@@ -103,10 +103,10 @@ function drawDouble(options: TestOptions, contextBuilder: ContextBuilder): void 
   line.setType(StaveConnector.type.SINGLE);
   connector.setContext(ctx);
   line.setContext(ctx);
-  stave1.draw();
-  stave2.draw();
-  connector.draw();
-  line.draw();
+  stave1.drawWithStyle();
+  stave2.drawWithStyle();
+  connector.drawWithStyle();
+  line.drawWithStyle();
 
   options.assert.ok(true, 'all pass');
 }
@@ -125,10 +125,10 @@ function drawBrace(options: TestOptions, contextBuilder: ContextBuilder): void {
   line.setType(StaveConnector.type.SINGLE);
   connector.setContext(ctx);
   line.setContext(ctx);
-  stave1.draw();
-  stave2.draw();
-  connector.draw();
-  line.draw();
+  stave1.drawWithStyle();
+  stave2.drawWithStyle();
+  connector.drawWithStyle();
+  line.drawWithStyle();
 
   options.assert.ok(true, 'all pass');
 }
@@ -146,10 +146,10 @@ function drawBraceWide(options: TestOptions, contextBuilder: ContextBuilder): vo
   line.setType(StaveConnector.type.SINGLE);
   connector.setContext(ctx);
   line.setContext(ctx);
-  stave1.draw();
-  stave2.draw();
-  connector.draw();
-  line.draw();
+  stave1.drawWithStyle();
+  stave2.drawWithStyle();
+  connector.drawWithStyle();
+  line.drawWithStyle();
 
   options.assert.ok(true, 'all pass');
 }
@@ -167,10 +167,10 @@ function drawBracket(options: TestOptions, contextBuilder: ContextBuilder): void
   line.setType(StaveConnector.type.SINGLE);
   connector.setContext(ctx);
   line.setContext(ctx);
-  stave1.draw();
-  stave2.draw();
-  connector.draw();
-  line.draw();
+  stave1.drawWithStyle();
+  stave2.drawWithStyle();
+  connector.drawWithStyle();
+  line.drawWithStyle();
 
   options.assert.ok(true, 'all pass');
 }
@@ -187,9 +187,9 @@ function drawRepeatBegin(options: TestOptions, contextBuilder: ContextBuilder): 
   const line = new StaveConnector(stave1, stave2);
   line.setType(StaveConnector.type.BOLD_DOUBLE_LEFT);
   line.setContext(ctx);
-  stave1.draw();
-  stave2.draw();
-  line.draw();
+  stave1.drawWithStyle();
+  stave2.drawWithStyle();
+  line.drawWithStyle();
 
   options.assert.ok(true, 'all pass');
 }
@@ -206,9 +206,9 @@ function drawRepeatEnd(options: TestOptions, contextBuilder: ContextBuilder): vo
   const line = new StaveConnector(stave1, stave2);
   line.setType(StaveConnector.type.BOLD_DOUBLE_RIGHT);
   line.setContext(ctx);
-  stave1.draw();
-  stave2.draw();
-  line.draw();
+  stave1.drawWithStyle();
+  stave2.drawWithStyle();
+  line.drawWithStyle();
 
   options.assert.ok(true, 'all pass');
 }
@@ -225,9 +225,9 @@ function drawThinDouble(options: TestOptions, contextBuilder: ContextBuilder): v
   const line = new StaveConnector(stave1, stave2);
   line.setType(StaveConnector.type.THIN_DOUBLE);
   line.setContext(ctx);
-  stave1.draw();
-  stave2.draw();
-  line.draw();
+  stave1.drawWithStyle();
+  stave2.drawWithStyle();
+  line.drawWithStyle();
 
   options.assert.ok(true, 'all pass');
 }
@@ -264,14 +264,14 @@ function drawRepeatAdjacent(options: TestOptions, contextBuilder: ContextBuilder
   connector2.setType(StaveConnector.type.BOLD_DOUBLE_RIGHT);
   connector3.setType(StaveConnector.type.BOLD_DOUBLE_LEFT);
   connector4.setType(StaveConnector.type.BOLD_DOUBLE_RIGHT);
-  stave1.draw();
-  stave2.draw();
-  stave3.draw();
-  stave4.draw();
-  connector1.draw();
-  connector2.draw();
-  connector3.draw();
-  connector4.draw();
+  stave1.drawWithStyle();
+  stave2.drawWithStyle();
+  stave3.drawWithStyle();
+  stave4.drawWithStyle();
+  connector1.drawWithStyle();
+  connector2.drawWithStyle();
+  connector3.drawWithStyle();
+  connector4.drawWithStyle();
 
   options.assert.ok(true, 'all pass');
 }
@@ -328,15 +328,15 @@ function drawRepeatOffset2(options: TestOptions, contextBuilder: ContextBuilder)
   connector1.setXShift(stave1.getModifierXShift());
   connector3.setXShift(stave3.getModifierXShift());
 
-  stave1.draw();
-  stave2.draw();
-  stave3.draw();
-  stave4.draw();
-  connector1.draw();
-  connector2.draw();
-  connector3.draw();
-  connector4.draw();
-  connector5.draw();
+  stave1.drawWithStyle();
+  stave2.drawWithStyle();
+  stave3.drawWithStyle();
+  stave4.drawWithStyle();
+  connector1.drawWithStyle();
+  connector2.drawWithStyle();
+  connector3.drawWithStyle();
+  connector4.drawWithStyle();
+  connector5.drawWithStyle();
 
   options.assert.ok(true, 'all pass');
 }
@@ -396,15 +396,15 @@ function drawRepeatOffset(options: TestOptions, contextBuilder: ContextBuilder):
   connector1.setXShift(stave1.getModifierXShift());
   connector3.setXShift(stave3.getModifierXShift());
 
-  stave1.draw();
-  stave2.draw();
-  stave3.draw();
-  stave4.draw();
-  connector1.draw();
-  connector2.draw();
-  connector3.draw();
-  connector4.draw();
-  connector5.draw();
+  stave1.drawWithStyle();
+  stave2.drawWithStyle();
+  stave3.drawWithStyle();
+  stave4.drawWithStyle();
+  connector1.drawWithStyle();
+  connector2.drawWithStyle();
+  connector3.drawWithStyle();
+  connector4.drawWithStyle();
+  connector5.drawWithStyle();
 
   options.assert.ok(true, 'all pass');
 }
@@ -445,18 +445,18 @@ function drawCombined(options: TestOptions, contextBuilder: ContextBuilder): voi
   connBracket.setContext(ctx);
   connNone.setContext(ctx);
   connBrace.setContext(ctx);
-  stave1.draw();
-  stave2.draw();
-  stave3.draw();
-  stave4.draw();
-  stave5.draw();
-  stave6.draw();
-  stave7.draw();
-  connSingle.draw();
-  connDouble.draw();
-  connBracket.draw();
-  connNone.draw();
-  connBrace.draw();
+  stave1.drawWithStyle();
+  stave2.drawWithStyle();
+  stave3.drawWithStyle();
+  stave4.drawWithStyle();
+  stave5.drawWithStyle();
+  stave6.drawWithStyle();
+  stave7.drawWithStyle();
+  connSingle.drawWithStyle();
+  connDouble.drawWithStyle();
+  connBracket.drawWithStyle();
+  connNone.drawWithStyle();
+  connBrace.drawWithStyle();
 
   options.assert.ok(true, 'all pass');
 }

--- a/tests/stavehairpin_tests.ts
+++ b/tests/stavehairpin_tests.ts
@@ -40,7 +40,7 @@ function drawHairpin(
   if (options) {
     hairpin.setRenderOptions(options);
   }
-  hairpin.draw();
+  hairpin.drawWithStyle();
 }
 
 /**

--- a/tests/stavemodifier_tests.ts
+++ b/tests/stavemodifier_tests.ts
@@ -23,7 +23,7 @@ function draw(options: TestOptions, contextBuilder: ContextBuilder): void {
   const ctx = contextBuilder(options.elementId, 400, 120);
   const stave = new Stave(10, 10, 300);
   stave.setContext(ctx);
-  stave.draw();
+  stave.drawWithStyle();
 
   options.assert.equal(stave.getYForNote(0), 100, 'getYForNote(0)');
   options.assert.equal(stave.getYForLine(5), 100, 'getYForLine(5)');
@@ -45,7 +45,7 @@ function drawBeginAndEnd(options: TestOptions, contextBuilder: ContextBuilder): 
   stave.setEndTimeSignature('9/8');
   stave.setEndKeySignature('G', 'C#');
   stave.setEndBarType(BarlineType.DOUBLE);
-  stave.draw();
+  stave.drawWithStyle();
 
   // change
   const END = StaveModifierPosition.END;
@@ -58,7 +58,7 @@ function drawBeginAndEnd(options: TestOptions, contextBuilder: ContextBuilder): 
   stave.setTimeSignature('C', undefined, END);
   stave.setKeySignature('F', undefined, END);
   stave.setEndBarType(BarlineType.SINGLE);
-  stave.draw();
+  stave.drawWithStyle();
 
   options.assert.ok(true, 'all pass');
 }

--- a/tests/stavenote_tests.ts
+++ b/tests/stavenote_tests.ts
@@ -106,7 +106,7 @@ function draw(
   }
 
   new TickContext().addTickable(note).preFormat().setX(x);
-  note.setContext(context).draw();
+  note.setContext(context).drawWithStyle();
 
   if (drawBoundingBox) {
     const bb = note.getBoundingBox();
@@ -349,7 +349,7 @@ function drawBasic(options: TestOptions, contextBuilder: ContextBuilder): void {
   const stave = new Stave(10, 30, 750);
   stave.setContext(ctx);
   stave.addClef(clef);
-  stave.draw();
+  stave.drawWithStyle();
 
   const lowerKeys = ['c/', 'e/', 'a/'];
   const higherKeys = ['c/', 'e/', 'a/'];
@@ -424,7 +424,7 @@ function drawBoundingBoxes(options: TestOptions, contextBuilder: ContextBuilder)
   const stave = new Stave(10, 30, 750);
   stave.setContext(ctx);
   stave.addClef(clef);
-  stave.draw();
+  stave.drawWithStyle();
 
   const lowerKeys = ['c/', 'e/', 'a/'];
   const higherKeys = ['c/', 'e/', 'a/'];
@@ -489,7 +489,7 @@ function drawBass(options: TestOptions, contextBuilder: ContextBuilder): void {
   const stave = new Stave(10, 10, 650);
   stave.setContext(ctx);
   stave.addClef('bass');
-  stave.draw();
+  stave.drawWithStyle();
 
   const noteStructs: StaveNoteStruct[] = [
     { clef: 'bass', keys: ['c/3', 'e/3', 'a/3'], duration: '1/2' },
@@ -529,7 +529,7 @@ function displacements(options: TestOptions, contextBuilder: ContextBuilder): vo
 
   const stave = new Stave(10, 10, 675);
   stave.setContext(ctx);
-  stave.draw();
+  stave.drawWithStyle();
 
   const noteStructs = [
     { keys: ['g/3', 'a/3', 'c/4', 'd/4', 'e/4'], duration: '1/2' },
@@ -565,7 +565,7 @@ function drawHarmonicAndMuted(options: TestOptions, contextBuilder: ContextBuild
   const ctx = contextBuilder(options.elementId, 1000, 180);
   const stave = new Stave(10, 10, 950);
   stave.setContext(ctx);
-  stave.draw();
+  stave.drawWithStyle();
 
   const noteStructs = [
     { keys: ['c/4', 'e/4', 'a/4'], duration: '1/2h' },
@@ -620,7 +620,7 @@ function drawSlash(options: TestOptions, contextBuilder: ContextBuilder): void {
   const ctx = contextBuilder(options.elementId, 700, 180);
   const stave = new Stave(10, 10, 650);
   stave.setContext(ctx);
-  stave.draw();
+  stave.drawWithStyle();
 
   const notes = [
     { keys: ['b/4'], duration: '1/2s', stemDirection: Stem.DOWN },
@@ -656,8 +656,8 @@ function drawSlash(options: TestOptions, contextBuilder: ContextBuilder): void {
 
   Formatter.FormatAndDraw(ctx, stave, staveNotes, false);
 
-  beam1.setContext(ctx).draw();
-  beam2.setContext(ctx).draw();
+  beam1.setContext(ctx).drawWithStyle();
+  beam2.setContext(ctx).drawWithStyle();
 
   options.assert.ok('Slash Note Heads');
 }
@@ -675,8 +675,8 @@ function drawKeyStyles(options: TestOptions, contextBuilder: ContextBuilder): vo
 
   new TickContext().addTickable(note).preFormat().setX(25);
 
-  stave.setContext(ctx).draw();
-  note.setContext(ctx).draw();
+  stave.setContext(ctx).drawWithStyle();
+  note.setContext(ctx).drawWithStyle();
 
   options.assert.ok(note.getX() > 0, 'Note has X value');
   options.assert.ok(note.getYs().length > 0, 'Note has Y values');
@@ -695,8 +695,8 @@ function drawNoteStyles(options: TestOptions, contextBuilder: ContextBuilder): v
 
   new TickContext().addTickable(note).preFormat().setX(25);
 
-  stave.setContext(ctx).draw();
-  note.setContext(ctx).draw();
+  stave.setContext(ctx).drawWithStyle();
+  note.setContext(ctx).drawWithStyle();
 
   options.assert.ok(note.getX() > 0, 'Note has X value');
   options.assert.ok(note.getYs().length > 0, 'Note has Y values');
@@ -715,8 +715,8 @@ function drawNoteStemStyles(options: TestOptions, contextBuilder: ContextBuilder
 
   new TickContext().addTickable(note).preFormat().setX(25);
 
-  stave.setContext(ctx).draw();
-  note.setContext(ctx).draw();
+  stave.setContext(ctx).drawWithStyle();
+  note.setContext(ctx).drawWithStyle();
 
   options.assert.ok('Note Stem Style');
 }
@@ -724,7 +724,7 @@ function drawNoteStemStyles(options: TestOptions, contextBuilder: ContextBuilder
 function drawNoteStemLengths(options: TestOptions, contextBuilder: ContextBuilder): void {
   const ctx = contextBuilder(options.elementId, 975, 150);
   const stave = new Stave(10, 10, 975);
-  stave.setContext(ctx).draw();
+  stave.setContext(ctx).drawWithStyle();
 
   const keys = [
     'e/3',
@@ -788,8 +788,8 @@ function drawNoteStylesWithFlag(options: TestOptions, contextBuilder: ContextBui
 
   new TickContext().addTickable(note).preFormat().setX(25);
 
-  stave.setContext(ctx).draw();
-  note.setContext(ctx).draw();
+  stave.setContext(ctx).drawWithStyle();
+  note.setContext(ctx).drawWithStyle();
 
   options.assert.ok(note.getX() > 0, 'Note has X value');
   options.assert.ok(note.getYs().length > 0, 'Note has Y values');
@@ -800,7 +800,7 @@ function drawBeamStyles(options: TestOptions, contextBuilder: ContextBuilder): v
   const stave = new Stave(10, 10, 380);
   stave.setStyle({ strokeStyle: '#EEAAEE', lineWidth: 3 });
   stave.setContext(ctx);
-  stave.draw();
+  stave.drawWithStyle();
 
   const notes = [
     // beam1
@@ -853,10 +853,10 @@ function drawBeamStyles(options: TestOptions, contextBuilder: ContextBuilder): v
 
   Formatter.FormatAndDraw(ctx, stave, staveNotes, false);
 
-  beam1.setContext(ctx).draw();
-  beam2.setContext(ctx).draw();
-  beam3.setContext(ctx).draw();
-  beam4.setContext(ctx).draw();
+  beam1.setContext(ctx).drawWithStyle();
+  beam2.setContext(ctx).drawWithStyle();
+  beam3.setContext(ctx).drawWithStyle();
+  beam4.setContext(ctx).drawWithStyle();
 
   options.assert.ok('draw beam styles');
 }
@@ -884,7 +884,7 @@ function dotsAndFlagsStemUp(options: TestOptions, contextBuilder: ContextBuilder
   Dot.buildAndAttach(notes, { all: true });
   Dot.buildAndAttach([notes[5], notes[11]], { all: true });
 
-  stave.setContext(ctx).draw();
+  stave.setContext(ctx).drawWithStyle();
 
   for (let i = 0; i < notes.length; ++i) {
     draw(notes[i], stave, ctx, i * 65);
@@ -915,7 +915,7 @@ function dotsAndFlagsStemDown(options: TestOptions, contextBuilder: ContextBuild
   ];
   Dot.buildAndAttach(staveNotes, { all: true });
 
-  stave.setContext(ctx).draw();
+  stave.setContext(ctx).drawWithStyle();
 
   for (let i = 0; i < staveNotes.length; ++i) {
     draw(staveNotes[i], stave, ctx, i * 65);
@@ -947,13 +947,13 @@ function dotsAndBeamsUp(options: TestOptions, contextBuilder: ContextBuilder): v
 
   const beam = new Beam(staveNotes);
 
-  stave.setContext(ctx).draw();
+  stave.setContext(ctx).drawWithStyle();
 
   for (let i = 0; i < staveNotes.length; ++i) {
     draw(staveNotes[i], stave, ctx, i * 65);
   }
 
-  beam.setContext(ctx).draw();
+  beam.setContext(ctx).drawWithStyle();
 
   options.assert.ok(true, 'Full Dot');
 }
@@ -980,13 +980,13 @@ function dotsAndBeamsDown(options: TestOptions, contextBuilder: ContextBuilder):
 
   const beam = new Beam(staveNotes);
 
-  stave.setContext(ctx).draw();
+  stave.setContext(ctx).drawWithStyle();
 
   for (let i = 0; i < staveNotes.length; ++i) {
     draw(staveNotes[i], stave, ctx, i * 65);
   }
 
-  beam.setContext(ctx).draw();
+  beam.setContext(ctx).drawWithStyle();
 
   options.assert.ok(true, 'Full Dot');
 }

--- a/tests/stringnumber_tests.ts
+++ b/tests/stringnumber_tests.ts
@@ -345,7 +345,7 @@ function drawAccidentals(options: TestOptions): void {
     .setContext(ctx)
     .setEndBarType(BarlineType.DOUBLE)
     .addClef('treble')
-    .draw();
+    .drawWithStyle();
   voice.draw(ctx, stave);
   options.assert.ok(true, 'String Number');
 }

--- a/tests/strokes_tests.ts
+++ b/tests/strokes_tests.ts
@@ -301,7 +301,7 @@ function drawTabStrokes(options: TestOptions): void {
 
   f.Formatter().joinVoices([tabVoice2]).formatToStave([tabVoice2], stave2);
 
-  f.draw();
+  f.drawWithStyle();
 
   options.assert.ok(true, 'Strokes Tab test');
 }
@@ -431,7 +431,7 @@ function notesWithTab(options: TestOptions): void {
   f.draw();
 
   beams.forEach(function (beam) {
-    beam.setContext(f.getContext()).draw();
+    beam.setContext(f.getContext()).drawWithStyle();
   });
 
   options.assert.ok(true);

--- a/tests/style_tests.ts
+++ b/tests/style_tests.ts
@@ -75,7 +75,7 @@ function stave(options: TestOptions): void {
     f.StaveNote({ keys: ['e/4'], stemDirection: 1, duration: '4' }),
     f.StaveNote({ keys: ['f/4'], stemDirection: 1, duration: '8' }),
 
-    // voice.draw() test.
+    // voice.drawWithStyle() test.
     f.TextDynamics({ text: 'sfz', duration: '16' }).setStyle(FS('blue')),
 
     // GhostNote modifiers test.
@@ -114,7 +114,7 @@ function tab(options: TestOptions, contextBuilder: ContextBuilder): void {
   ctx.font = '10pt Arial';
   const stave = new TabStave(10, 10, 450).addTabGlyph();
   stave.getModifiers()[2].setStyle(FS('blue'));
-  stave.setContext(ctx).draw();
+  stave.setContext(ctx).drawWithStyle();
 
   const tabNote = (noteStruct: TabNoteStruct) => new TabNote(noteStruct);
 

--- a/tests/tabnote_tests.ts
+++ b/tests/tabnote_tests.ts
@@ -87,7 +87,7 @@ function draw(options: TestOptions, contextBuilder: ContextBuilder): void {
   ctx.font = '10pt Arial';
   const stave = new TabStave(10, 10, 550);
   stave.setContext(ctx);
-  stave.draw();
+  stave.drawWithStyle();
 
   const notes = [
     { positions: [{ str: 6, fret: 6 }], duration: '4' },
@@ -145,7 +145,7 @@ function draw(options: TestOptions, contextBuilder: ContextBuilder): void {
     const tickContext = new TickContext();
     tickContext.addTickable(tabNote).preFormat().setX(x);
     tabNote.setContext(ctx).setStave(stave);
-    tabNote.draw();
+    tabNote.drawWithStyle();
     return tabNote;
   }
 
@@ -163,7 +163,7 @@ function drawStemsUp(options: TestOptions, contextBuilder: ContextBuilder): void
   ctx.font = '10pt Arial';
   const stave = new TabStave(10, 30, 550);
   stave.setContext(ctx);
-  stave.draw();
+  stave.drawWithStyle();
 
   const specs: TabNoteStruct[] = [
     {
@@ -235,7 +235,7 @@ function drawStemsDown(options: TestOptions, contextBuilder: ContextBuilder): vo
   ctx.font = '10pt Arial';
   const stave = new TabStave(10, 10, 550);
   stave.setContext(ctx);
-  stave.draw();
+  stave.drawWithStyle();
 
   const specs: TabNoteStruct[] = [
     {
@@ -308,7 +308,7 @@ function drawStemsUpThrough(options: TestOptions, contextBuilder: ContextBuilder
   ctx.font = '10pt Arial';
   const stave = new TabStave(10, 30, 550);
   stave.setContext(ctx);
-  stave.draw();
+  stave.drawWithStyle();
 
   const specs: TabNoteStruct[] = [
     {
@@ -382,7 +382,7 @@ function drawStemsDownThrough(options: TestOptions, contextBuilder: ContextBuild
   ctx.font = '10pt Arial';
   const stave = new TabStave(10, 10, 550, { numLines: 8 });
   stave.setContext(ctx);
-  stave.draw();
+  stave.drawWithStyle();
 
   const specs: TabNoteStruct[] = [
     {
@@ -461,7 +461,7 @@ function drawStemsDotted(options: TestOptions, contextBuilder: ContextBuilder): 
   ctx.font = '10pt Arial';
   const stave = new TabStave(10, 10, 550);
   stave.setContext(ctx);
-  stave.draw();
+  stave.drawWithStyle();
 
   const specs: TabNoteStruct[] = [
     {

--- a/tests/tabslide_tests.ts
+++ b/tests/tabslide_tests.ts
@@ -43,7 +43,7 @@ function tieNotes(notes: TabNote[], indexes: number[], stave: TabStave, ctx: Ren
   );
 
   tie.setContext(ctx);
-  tie.draw();
+  tie.drawWithStyle();
 }
 
 function setupContext(options: TestOptions, width?: number): { context: RenderContext; stave: TabStave } {
@@ -51,7 +51,7 @@ function setupContext(options: TestOptions, width?: number): { context: RenderCo
   context.scale(0.9, 0.9);
 
   context.font = '10pt Arial';
-  const stave = new TabStave(10, 10, width || 350).addTabGlyph().setContext(context).draw();
+  const stave = new TabStave(10, 10, width || 350).addTabGlyph().setContext(context).drawWithStyle();
 
   return { context, stave };
 }
@@ -130,7 +130,7 @@ function multiTest(options: TestOptions, buildTabSlide: (notes: TieNotes) => Tab
     lastIndexes: [0],
   })
     .setContext(context)
-    .draw();
+    .drawWithStyle();
 
   options.assert.ok(true, 'Single note');
 
@@ -141,7 +141,7 @@ function multiTest(options: TestOptions, buildTabSlide: (notes: TieNotes) => Tab
     lastIndexes: [0, 1],
   })
     .setContext(context)
-    .draw();
+    .drawWithStyle();
 
   options.assert.ok(true, 'Chord');
 
@@ -152,7 +152,7 @@ function multiTest(options: TestOptions, buildTabSlide: (notes: TieNotes) => Tab
     lastIndexes: [0],
   })
     .setContext(context)
-    .draw();
+    .drawWithStyle();
 
   options.assert.ok(true, 'Single note high-fret');
 
@@ -163,7 +163,7 @@ function multiTest(options: TestOptions, buildTabSlide: (notes: TieNotes) => Tab
     lastIndexes: [0, 1],
   })
     .setContext(context)
-    .draw();
+    .drawWithStyle();
 
   options.assert.ok(true, 'Chord high-fret');
 }

--- a/tests/tabstave_tests.ts
+++ b/tests/tabstave_tests.ts
@@ -22,7 +22,7 @@ function draw(options: TestOptions, contextBuilder: ContextBuilder): void {
   stave.setMeasure(1);
   stave.setNumLines(6);
   stave.setContext(ctx);
-  stave.draw();
+  stave.drawWithStyle();
 
   options.assert.equal(stave.getYForNote(0), 127, 'getYForNote(0)');
   options.assert.equal(stave.getYForLine(5), 127, 'getYForLine(5)');

--- a/tests/tabtie_tests.ts
+++ b/tests/tabtie_tests.ts
@@ -43,7 +43,7 @@ function setupContext(options: TestOptions, w: number = 0, h: number = 0): { con
 
   context.setFont('Arial', VexFlowTests.Font.size);
 
-  const stave = new TabStave(10, 10, w || 350).addTabGlyph().setContext(context).draw();
+  const stave = new TabStave(10, 10, w || 350).addTabGlyph().setContext(context).drawWithStyle();
 
   return { context, stave };
 }
@@ -69,7 +69,7 @@ function tieNotes(notes: Note[], indexes: number[], stave: Stave, ctx: RenderCon
   );
 
   tie.setContext(ctx);
-  tie.draw();
+  tie.drawWithStyle();
 }
 
 /**
@@ -148,7 +148,7 @@ function multiTest(options: TestOptions, createTabTie: (notes: TieNotes) => TabT
     lastIndexes: [0],
   })
     .setContext(context)
-    .draw();
+    .drawWithStyle();
 
   options.assert.ok(true, 'Single note');
 
@@ -159,7 +159,7 @@ function multiTest(options: TestOptions, createTabTie: (notes: TieNotes) => TabT
     lastIndexes: [0, 1],
   })
     .setContext(context)
-    .draw();
+    .drawWithStyle();
 
   options.assert.ok(true, 'Chord');
 
@@ -170,7 +170,7 @@ function multiTest(options: TestOptions, createTabTie: (notes: TieNotes) => TabT
     lastIndexes: [0],
   })
     .setContext(context)
-    .draw();
+    .drawWithStyle();
 
   options.assert.ok(true, 'Single note high-fret');
 
@@ -181,7 +181,7 @@ function multiTest(options: TestOptions, createTabTie: (notes: TieNotes) => TabT
     lastIndexes: [0, 1],
   })
     .setContext(context)
-    .draw();
+    .drawWithStyle();
 
   options.assert.ok(true, 'Chord high-fret');
 }
@@ -218,7 +218,7 @@ function continuous(options: TestOptions, contextBuilder: ContextBuilder): void 
     lastIndexes: [0],
   })
     .setContext(context)
-    .draw();
+    .drawWithStyle();
 
   TabTie.createPulloff({
     firstNote: notes[1],
@@ -227,7 +227,7 @@ function continuous(options: TestOptions, contextBuilder: ContextBuilder): void 
     lastIndexes: [0],
   })
     .setContext(context)
-    .draw();
+    .drawWithStyle();
   options.assert.ok(true, 'Continuous Hammeron');
 }
 

--- a/tests/textnote_tests.ts
+++ b/tests/textnote_tests.ts
@@ -272,7 +272,7 @@ function textDynamics(options: TestOptions): void {
   const width = formatter.preCalculateMinTotalWidth([voice]);
   formatter.format([voice]);
   const stave = f.Stave({ y: 40, width: width + Stave.defaultPadding });
-  stave.draw();
+  stave.drawWithStyle();
   voice.draw(f.getContext(), stave);
   options.assert.ok(true);
 }

--- a/tests/threevoice_tests.ts
+++ b/tests/threevoice_tests.ts
@@ -59,7 +59,7 @@ function createThreeVoicesTest(
     factory.draw();
 
     for (let i = 0; i < beams.length; i++) {
-      beams[i].setContext(factory.getContext()).draw();
+      beams[i].setContext(factory.getContext()).drawWithStyle();
     }
 
     options.assert.ok(true);
@@ -154,7 +154,7 @@ function autoRestTwoVoices(options: TestOptions): void {
   f.draw();
 
   for (let i = 0; i < beams.length; i++) {
-    beams[i].setContext(f.getContext()).draw();
+    beams[i].setContext(f.getContext()).drawWithStyle();
   }
 
   options.assert.ok(true, 'Auto Adjust Rests - Two Voices');

--- a/tests/timesignature_tests.ts
+++ b/tests/timesignature_tests.ts
@@ -69,7 +69,7 @@ function basic(options: TestOptions, contextBuilder: ContextBuilder): void {
     .addEndTimeSignature('C')
     .addEndTimeSignature('C|')
     .setContext(ctx)
-    .draw();
+    .drawWithStyle();
 
   options.assert.ok(true, 'all pass');
 }
@@ -83,7 +83,7 @@ function big(options: TestOptions, contextBuilder: ContextBuilder): void {
     .addTimeSignature('1234567/890')
     .addTimeSignature('987/654321')
     .setContext(ctx)
-    .draw();
+    .drawWithStyle();
 
   options.assert.ok(true, 'all pass');
 }
@@ -91,7 +91,7 @@ function big(options: TestOptions, contextBuilder: ContextBuilder): void {
 function additive(options: TestOptions, contextBuilder: ContextBuilder): void {
   const ctx = contextBuilder(options.elementId, 400, 120);
 
-  new Stave(10, 10, 300).addTimeSignature('2+3+2/8').setContext(ctx).draw();
+  new Stave(10, 10, 300).addTimeSignature('2+3+2/8').setContext(ctx).drawWithStyle();
 
   options.assert.ok(true, 'all pass');
 }
@@ -99,7 +99,12 @@ function additive(options: TestOptions, contextBuilder: ContextBuilder): void {
 function alternating(options: TestOptions, contextBuilder: ContextBuilder): void {
   const ctx = contextBuilder(options.elementId, 400, 120);
 
-  new Stave(10, 10, 300).addTimeSignature('6/8').addTimeSignature('+').addTimeSignature('3/4').setContext(ctx).draw();
+  new Stave(10, 10, 300)
+    .addTimeSignature('6/8')
+    .addTimeSignature('+')
+    .addTimeSignature('3/4')
+    .setContext(ctx)
+    .drawWithStyle();
 
   options.assert.ok(true, 'all pass');
 }
@@ -107,7 +112,12 @@ function alternating(options: TestOptions, contextBuilder: ContextBuilder): void
 function interchangeable(options: TestOptions, contextBuilder: ContextBuilder): void {
   const ctx = contextBuilder(options.elementId, 400, 120);
 
-  new Stave(10, 10, 300).addTimeSignature('3/4').addTimeSignature('-').addTimeSignature('2/4').setContext(ctx).draw();
+  new Stave(10, 10, 300)
+    .addTimeSignature('3/4')
+    .addTimeSignature('-')
+    .addTimeSignature('2/4')
+    .setContext(ctx)
+    .drawWithStyle();
 
   options.assert.ok(true, 'all pass');
 }
@@ -122,7 +132,7 @@ function agregate(options: TestOptions, contextBuilder: ContextBuilder): void {
     .addTimeSignature('+')
     .addTimeSignature('5/4')
     .setContext(ctx)
-    .draw();
+    .drawWithStyle();
 
   options.assert.ok(true, 'all pass');
 }
@@ -135,7 +145,7 @@ function complex(options: TestOptions, contextBuilder: ContextBuilder): void {
     .addTimeSignature('+')
     .addTimeSignature('3/8')
     .setContext(ctx)
-    .draw();
+    .drawWithStyle();
 
   options.assert.ok(true, 'all pass');
 }
@@ -150,15 +160,15 @@ function multiple(options: TestOptions, contextBuilder: ContextBuilder): void {
     .addClef('percussion')
     .addTimeSignature('4/4', 25) // passing the custom padding in pixels
     .setContext(ctx)
-    .draw();
-  const stave2 = new Stave(15, 110, 300).addClef('treble').addTimeSignature('4/4').setContext(ctx).draw();
-  const stave3 = new Stave(15, 220, 300).addClef('bass').addTimeSignature('4/4').setContext(ctx).draw();
+    .drawWithStyle();
+  const stave2 = new Stave(15, 110, 300).addClef('treble').addTimeSignature('4/4').setContext(ctx).drawWithStyle();
+  const stave3 = new Stave(15, 220, 300).addClef('bass').addTimeSignature('4/4').setContext(ctx).drawWithStyle();
 
   Stave.formatBegModifiers([stave1, stave2, stave3]);
 
-  new StaveConnector(stave1, stave2).setType('single').setContext(ctx).draw();
-  new StaveConnector(stave2, stave3).setType('single').setContext(ctx).draw();
-  new StaveConnector(stave2, stave3).setType('brace').setContext(ctx).draw();
+  new StaveConnector(stave1, stave2).setType('single').setContext(ctx).drawWithStyle();
+  new StaveConnector(stave2, stave3).setType('single').setContext(ctx).drawWithStyle();
+  new StaveConnector(stave2, stave3).setType('brace').setContext(ctx).drawWithStyle();
 
   options.assert.ok(true, 'all pass');
 }

--- a/tests/vibrato_tests.ts
+++ b/tests/vibrato_tests.ts
@@ -30,7 +30,7 @@ function simple(options: TestOptions, contextBuilder: ContextBuilder): void {
   ctx.scale(1.5, 1.5);
 
   ctx.font = '10pt Arial';
-  const stave = new TabStave(10, 10, 450).addTabGlyph().setContext(ctx).draw();
+  const stave = new TabStave(10, 10, 450).addTabGlyph().setContext(ctx).drawWithStyle();
 
   const notes = [
     tabNote({
@@ -60,7 +60,7 @@ function harsh(options: TestOptions, contextBuilder: ContextBuilder): void {
   ctx.scale(1.5, 1.5);
 
   ctx.font = '10pt Arial';
-  const stave = new TabStave(10, 10, 450).addTabGlyph().setContext(ctx).draw();
+  const stave = new TabStave(10, 10, 450).addTabGlyph().setContext(ctx).drawWithStyle();
 
   const notes = [
     tabNote({
@@ -85,7 +85,7 @@ function withBend(options: TestOptions, contextBuilder: ContextBuilder): void {
   ctx.scale(1.3, 1.3);
 
   ctx.setFont(Metrics.get('fontFamily'), VexFlowTests.Font.size);
-  const stave = new TabStave(10, 10, 450).addTabGlyph().setContext(ctx).draw();
+  const stave = new TabStave(10, 10, 450).addTabGlyph().setContext(ctx).drawWithStyle();
 
   const notes = [
     tabNote({

--- a/tests/voice_tests.ts
+++ b/tests/voice_tests.ts
@@ -88,7 +88,7 @@ function full(options: TestOptions, contextBuilder: ContextBuilder): void {
 
   new Formatter().joinVoices([voice]).formatToStave([voice], stave);
 
-  stave.setContext(ctx).draw();
+  stave.setContext(ctx).drawWithStyle();
   voice.draw(ctx);
   const bb = voice.getBoundingBox();
   if (bb) {


### PR DESCRIPTION
This is part of #225:
- it calls drawWithStyle in tests
- fix some minor linting issues

This change already produce the visual change in #225: the style of the beams now affect the associated stems, which I believe makes sense.

Current
![StaveNote Stave__Ledger_Line__Beam__Stem_and_Flag_Styles Bravura jsdom_current](https://github.com/user-attachments/assets/fd55b281-c98f-47f1-a20b-9d8209bef080)
Reference
![StaveNote Stave__Ledger_Line__Beam__Stem_and_Flag_Styles Bravura jsdom_reference](https://github.com/user-attachments/assets/44ab8295-b9af-434a-b5e3-6c1e14824cc5)

