### PR TITLE
refactor applyStyle on Modifiers (part of #225)

### DIFF
--- a/src/annotation.ts
+++ b/src/annotation.ts
@@ -224,8 +224,6 @@ export class Annotation extends Modifier {
     const start = note.getModifierStartXY(ModifierPosition.ABOVE, this.index);
 
     this.setRendered();
-    ctx.save();
-    this.applyStyle();
     ctx.openGroup('annotation', this.getAttribute('id'));
 
     const textWidth = this.getWidth();
@@ -286,6 +284,5 @@ export class Annotation extends Modifier {
     this.y = y;
     this.renderText(ctx, 0, 0);
     ctx.closeGroup();
-    ctx.restore();
   }
 }

--- a/src/bend.ts
+++ b/src/bend.ts
@@ -171,8 +171,6 @@ export class Bend extends Modifier {
     const ctx = this.checkContext();
     const note = this.checkAttachedNote();
     this.setRendered();
-    ctx.save();
-    this.applyStyle();
 
     const start = note.getModifierStartXY(Modifier.Position.RIGHT, this.index);
     start.x += 3;
@@ -190,23 +188,19 @@ export class Bend extends Modifier {
       const cpX = x + width;
       const cpY = y;
 
-      ctx.save();
       this.applyStyle(ctx, this.styleLine);
       ctx.beginPath();
       ctx.moveTo(x, y);
       ctx.quadraticCurveTo(cpX, cpY, x + width, height);
       ctx.stroke();
-      ctx.restore();
     };
 
     const renderRelease = (x: number, y: number, width: number, height: number) => {
-      ctx.save();
       this.applyStyle(ctx, this.styleLine);
       ctx.beginPath();
       ctx.moveTo(x, height);
       ctx.quadraticCurveTo(x + width, height, x + width, y);
       ctx.stroke();
-      ctx.restore();
     };
 
     const renderArrowHead = (x: number, y: number, direction: number) => {
@@ -283,6 +277,5 @@ export class Bend extends Modifier {
     } else if (lastBend.type === Bend.DOWN) {
       renderArrowHead(lastBend.x + lastDrawnWidth, start.y, -1);
     }
-    ctx.restore();
   }
 }

--- a/src/chordsymbol.ts
+++ b/src/chordsymbol.ts
@@ -403,9 +403,6 @@ export class ChordSymbol extends Modifier {
     const note = this.checkAttachedNote() as StemmableNote;
     this.setRendered();
 
-    // We're changing context parameters. Save current state.
-    ctx.save();
-    this.applyStyle();
     ctx.openGroup('chordsymbol', this.getAttribute('id'));
 
     const start = note.getModifierStartXY(Modifier.Position.ABOVE, this.index);
@@ -458,7 +455,6 @@ export class ChordSymbol extends Modifier {
       symbol.renderText(ctx, 0, 0);
     });
     ctx.closeGroup();
-    ctx.restore();
   }
 
   // Get the `BoundingBox` for the entire chord

--- a/src/gracenotegroup.ts
+++ b/src/gracenotegroup.ts
@@ -170,9 +170,9 @@ export class GraceNoteGroup extends Modifier {
     this.alignSubNotesWithNote(this.getGraceNotes(), note); // Modifier function
 
     // Draw grace notes.
-    this.graceNotes.forEach((graceNote) => graceNote.setContext(ctx).draw());
+    this.graceNotes.forEach((graceNote) => graceNote.setContext(ctx).drawWithStyle());
     // Draw beams.
-    this.beams.forEach((beam) => beam.setContext(ctx).draw());
+    this.beams.forEach((beam) => beam.setContext(ctx).drawWithStyle());
 
     if (this.showSlur) {
       // Create and draw slur.
@@ -188,7 +188,7 @@ export class GraceNoteGroup extends Modifier {
 
       this.slur.renderOptions.cp2 = 12;
       this.slur.renderOptions.yShift = (isStavenote ? 7 : 5) + this.renderOptions.slurYShift;
-      this.slur.setContext(ctx).draw();
+      this.slur.setContext(ctx).drawWithStyle();
     }
   }
 }

--- a/src/ornament.ts
+++ b/src/ornament.ts
@@ -225,8 +225,6 @@ export class Ornament extends Modifier {
 
     const stave = note.checkStave();
 
-    ctx.save();
-    this.applyStyle();
     ctx.openGroup('ornament', this.getAttribute('id'));
 
     // Get initial coordinates for the modifier position
@@ -297,6 +295,5 @@ export class Ornament extends Modifier {
       );
     }
     ctx.closeGroup();
-    ctx.restore();
   }
 }

--- a/src/stringnumber.ts
+++ b/src/stringnumber.ts
@@ -239,7 +239,6 @@ export class StringNumber extends Modifier {
         throw new RuntimeError('InvalidPosition', `The position ${this.position} is invalid`);
     }
 
-    ctx.save();
     if (this.drawCircle) {
       ctx.beginPath();
       ctx.arc(dotX, dotY, this.radius, 0, Math.PI * 2, false);
@@ -280,7 +279,5 @@ export class StringNumber extends Modifier {
           break;
       }
     }
-
-    ctx.restore();
   }
 }


### PR DESCRIPTION
This is part of #225:
- avoids duplicated calls to ctx.save on Modifiers

No visual differences.