### PR TITLE
tuplet text position configurable

### DIFF
--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -259,6 +259,11 @@ export const MetricsDefaults: Record<string, any> = {
     spacing: 7,
   },
 
+  Tuplet: {
+    yOffset: 0,
+    textYOffset: 2,
+  },
+
   Volta: {
     fontSize: 9,
     fontWeight: 'bold',


### PR DESCRIPTION
fixes #62

Not required for 5.0

Visual differences
current
![Auto_Beaming Duration_Based_Secondary_Beam_Breaks_2 Bravura jsdom_current](https://github.com/user-attachments/assets/384fef81-779a-416d-8249-600ecd2b4cb3)
reference
![Auto_Beaming Duration_Based_Secondary_Beam_Breaks_2 Bravura jsdom_reference](https://github.com/user-attachments/assets/6270a35b-1ea4-43c2-8a92-b0b877b033c5)
current
![Auto_Beaming More_Simple_Tuplet_Auto_Beaming Bravura jsdom_current](https://github.com/user-attachments/assets/106a7b40-38c3-4ae3-9bd0-5dc018d37fe1)
reference
![Auto_Beaming More_Simple_Tuplet_Auto_Beaming Bravura jsdom_reference](https://github.com/user-attachments/assets/d12fef41-45f7-4166-8d46-b3d510183e25)
