### PR TITLE
grunt eslint

### DIFF
--- a/src/curve.ts
+++ b/src/curve.ts
@@ -191,7 +191,7 @@ export class Curve extends Element {
     if (this.renderOptions.openingDirection === 'down') {
       stemDirection = -1;
     }
-    
+
     this.renderCurve({
       firstX,
       lastX,

--- a/src/easyscore.ts
+++ b/src/easyscore.ts
@@ -68,7 +68,7 @@ export class EasyScoreGrammar implements Grammar {
   CHORD(): Rule {
     return {
       expect: [this.LPAREN, this.NOTES, this.RPAREN],
-      // eslint-disable-next-line
+
       run: (state) => this.builder.addChord(state!.matches[1] as Match[]),
     };
   }
@@ -87,7 +87,6 @@ export class EasyScoreGrammar implements Grammar {
     return {
       expect: [this.NOTENAME, this.ACCIDENTAL, this.OCTAVE],
       run: (state) => {
-        // eslint-disable-next-line
         const s = state!;
         this.builder.addSingleNote(s.matches[0] as string, s.matches[1] as string, s.matches[2] as string);
       },
@@ -104,7 +103,7 @@ export class EasyScoreGrammar implements Grammar {
     return {
       expect: [this.DOT],
       zeroOrMore: true,
-      // eslint-disable-next-line
+
       run: (state) => this.builder.setNoteDots(state!.matches),
     };
   }
@@ -112,7 +111,7 @@ export class EasyScoreGrammar implements Grammar {
     return {
       expect: [this.SLASH, this.MAYBESLASH, this.TYPES],
       maybe: true,
-      // eslint-disable-next-line
+
       run: (state) => this.builder.setNoteType(state!.matches[2] as string),
     };
   }
@@ -120,7 +119,7 @@ export class EasyScoreGrammar implements Grammar {
     return {
       expect: [this.SLASH, this.DURATIONS],
       maybe: true,
-      // eslint-disable-next-line
+
       run: (state) => this.builder.setNoteDuration(state!.matches[1] as string),
     };
   }
@@ -141,7 +140,7 @@ export class EasyScoreGrammar implements Grammar {
 
     return {
       expect: [this.KEY, this.EQUALS, this.VAL],
-      // eslint-disable-next-line
+
       run: (state) => this.builder.addNoteOption(state!.matches[0] as string, unquote(state!.matches[2] as string)),
     };
   }
@@ -467,7 +466,6 @@ export class EasyScore {
    * @returns this
    */
   setOptions(options: EasyScoreOptions): this {
-    // eslint-disable-next-line
     const factory = options.factory!; // ! operator, because options.factory was set in Factory.EasyScore().
     const builder = options.builder ?? new Builder(factory);
 

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -495,7 +495,6 @@ export class Formatter {
 
     this.createTickContexts(voices);
 
-    // eslint-disable-next-line
     const { list: contextList, map: contextMap } = this.tickContexts!;
     this.minTotalWidth = 0;
 
@@ -600,12 +599,12 @@ export class Formatter {
         if (!(staveTickToContextMap ? staveTickToContextMap[integerTicks] : undefined)) {
           const newContext = new ModifierContext();
           contexts.push(newContext);
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+
           staveTickToContextMap![integerTicks] = newContext;
         }
 
         // Add this tickable to the TickContext.
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+
         tickable.addToModifierContext(staveTickToContextMap![integerTicks]);
         ticksUsed.add(tickable.getTicks());
       });
@@ -1088,7 +1087,6 @@ export class Formatter {
   formatToStave(voices: Voice[], stave: Stave, optionsParam?: FormatParams): this {
     const options: FormatParams = { context: stave.getContext(), ...optionsParam };
 
-    // eslint-disable-next-line
     const justifyWidth = stave.getNoteEndX() - stave.getNoteStartX() - Stave.defaultPadding;
     L('Formatting voices to width: ', justifyWidth);
     return this.format(voices, justifyWidth, options);

--- a/src/stavenote.ts
+++ b/src/stavenote.ts
@@ -600,7 +600,7 @@ export class StaveNote extends StemmableNote {
       boundingBox.mergeWith(notehead.getBoundingBox());
     });
     const { yTop, yBottom } = this.getNoteHeadBounds();
-    // eslint-disable-next-line
+
     const noteStemHeight = this.stem!.getHeight();
     const flagX = this.getStemX() - Tables.STEM_WIDTH / 2;
     const flagY =
@@ -1102,7 +1102,7 @@ export class StaveNote extends StemmableNote {
 
     if (this.shouldDrawFlag()) {
       const { yTop, yBottom } = this.getNoteHeadBounds();
-      // eslint-disable-next-line
+
       const noteStemHeight = this.stem!.getHeight();
       const flagX = this.getStemX() - Tables.STEM_WIDTH / 2;
       const flagY =

--- a/src/stavetie.ts
+++ b/src/stavetie.ts
@@ -149,9 +149,9 @@ export class StaveTie extends Element {
 
     // setNotes(...) verified that firstIndexes and lastIndexes are not undefined.
     // As a result, we use the ! non-null assertion operator here.
-    // eslint-disable-next-line
+
     const firstIndexes = this.notes.firstIndexes!;
-    // eslint-disable-next-line
+
     const lastIndexes = this.notes.lastIndexes!;
     ctx.save();
     this.applyStyle();

--- a/src/svgcontext.ts
+++ b/src/svgcontext.ts
@@ -345,7 +345,6 @@ export class SVGContext extends RenderContext {
     while (this.svg.lastChild) {
       this.svg.removeChild(this.svg.lastChild);
     }
-
   }
 
   // ## Rectangles:

--- a/src/tabslide.ts
+++ b/src/tabslide.ts
@@ -94,7 +94,6 @@ export class TabSlide extends TabTie {
       throw new RuntimeError('BadSlide', 'Invalid slide direction');
     }
 
-    // eslint-disable-next-line
     const firstIndexes = this.notes.firstIndexes!;
     for (let i = 0; i < firstIndexes.length; ++i) {
       const slideY = firstYs[firstIndexes[i]] + this.renderOptions.yShift;

--- a/src/util.ts
+++ b/src/util.ts
@@ -112,7 +112,7 @@ export function sumArray(arr: number[]): number {
  * Take `arr` and return a new array consisting of the sorted, unique'd,
  * contents of arr. Does not modify `arr`.
  */
-// eslint-disable-next-line
+
 /*
   static sortAndUnique(arr: any[], cmp: any, eq: any): any[] {
     if (arr.length > 1) {

--- a/tests/accidental_tests.ts
+++ b/tests/accidental_tests.ts
@@ -338,13 +338,12 @@ function genAccidentals(): string[] {
   }
   // Spartan Sagittal multi-shaft accidentals
   for (let u = 0xe310; u <= 0xe335; u++) {
-    switch (
-      u // exclude unused smufls
-    ) {
+    switch (u) {
       case 0xe31a:
       case 0xe31b:
       case 0xe31e:
       case 0xe31f:
+        // Exclude unused SMuFL glyphs.
         break;
       default:
         accs.push(String.fromCodePoint(u));

--- a/tests/accidental_tests.ts
+++ b/tests/accidental_tests.ts
@@ -338,7 +338,9 @@ function genAccidentals(): string[] {
   }
   // Spartan Sagittal multi-shaft accidentals
   for (let u = 0xe310; u <= 0xe335; u++) {
-    switch (u) {  // exclude unused smufls
+    switch (
+      u // exclude unused smufls
+    ) {
       case 0xe31a:
       case 0xe31b:
       case 0xe31e:
@@ -410,10 +412,10 @@ function cautionary(options: TestOptions): void {
 
   const accids = Object.values(accidentals).filter((accid) => accid !== '{' && accid !== '}');
   for (i = 0; i < staveCount; ++i) {
-    const stave = f.Stave({ x: 0, y: 10 + staveHeight / scale * i, width: staveWidth / scale });
+    const stave = f.Stave({ x: 0, y: 10 + (staveHeight / scale) * i, width: staveWidth / scale });
     const score = f.EasyScore();
     const rowMap = [];
-    for (j = 0; j < notesPerStave && (j + i * notesPerStave) < accids.length; ++j) {
+    for (j = 0; j < notesPerStave && j + i * notesPerStave < accids.length; ++j) {
       rowMap.push(accids[j + i * notesPerStave]);
     }
     const notes = rowMap.map((accidType: string) =>

--- a/tests/mocks.ts
+++ b/tests/mocks.ts
@@ -22,7 +22,6 @@ class MockTickable extends Tickable {
   }
 
   getX(): number {
-    // eslint-disable-next-line
     return this.tickContext!.getX();
   }
 

--- a/tests/multimeasurerest_tests.ts
+++ b/tests/multimeasurerest_tests.ts
@@ -92,7 +92,7 @@ function simple(options: TestOptions): void {
   f.draw();
 
   const xs = mmRests[0].getXs();
-  // eslint-disable-next-line
+
   const strY = mmRests[0].getStave()!.getYForLine(-0.5);
   const str = 'TACET';
   const context = f.getContext();
@@ -127,7 +127,7 @@ function staveWithModifiers(options: TestOptions): void {
 
   params.forEach((param) => {
     const staveOptions = param[0];
-    // eslint-disable-next-line
+
     const staveParams = staveOptions.params!;
     const mmrestParams = param[1];
 

--- a/tests/tabslide_tests.ts
+++ b/tests/tabslide_tests.ts
@@ -47,7 +47,6 @@ function tieNotes(notes: TabNote[], indexes: number[], stave: TabStave, ctx: Ren
 }
 
 function setupContext(options: TestOptions, width?: number): { context: RenderContext; stave: TabStave } {
-  // eslint-disable-next-line
   const context = options.contextBuilder!(options.elementId, 350, 140);
   context.scale(0.9, 0.9);
 

--- a/tests/tabtie_tests.ts
+++ b/tests/tabtie_tests.ts
@@ -39,7 +39,6 @@ const tabNote = (noteStruct: TabNoteStruct) => new TabNote(noteStruct);
  * Helper function to create a RenderContext and TabStave.
  */
 function setupContext(options: TestOptions, w: number = 0, h: number = 0): { context: RenderContext; stave: TabStave } {
-  // eslint-disable-next-line
   const context = options.contextBuilder!(options.elementId, w || 350, h || 160);
 
   context.setFont('Arial', VexFlowTests.Font.size);

--- a/tests/vexflow_test_helpers.ts
+++ b/tests/vexflow_test_helpers.ts
@@ -43,7 +43,7 @@ if (!global.$) {
     } else if (param.startsWith('<')) {
       // Extract the tag name: e.g., <div/> => div
       // Assume param.match returns something (! operator).
-      // eslint-disable-next-line
+
       const tagName = param.match(/[A-Za-z]+/g)![0];
       element = document.createElement(tagName);
     } else {


### PR DESCRIPTION
When I ran `grunt eslint` on the most recent version, I get these changes.

Any idea why eslint is removing these directives?

```
// eslint-disable-next-line
```