### PR TITLE
Grace notes accidentals' size and right position

### DIFF
--- a/src/gracenotegroup.ts
+++ b/src/gracenotegroup.ts
@@ -53,7 +53,7 @@ export class GraceNoteGroup extends Modifier {
 
     const groupList = [];
     let prevNote = null;
-    let shiftL = 0;
+    let shift = 0;
 
     for (let i = 0; i < gracenoteGroups.length; ++i) {
       const gracenoteGroup = gracenoteGroups[i];
@@ -64,19 +64,23 @@ export class GraceNoteGroup extends Modifier {
       if (isStavenote && note !== prevNote) {
         // Iterate through all notes to get the displaced pixels
         for (let n = 0; n < note.keys.length; ++n) {
-          shiftL = Math.max(note.getLeftDisplacedHeadPx(), shiftL);
+          shift = Math.max(note.getLeftDisplacedHeadPx(), shift);
         }
         prevNote = note;
       }
 
-      groupList.push({ shift: shiftL, gracenoteGroup, spacing });
+      groupList.push({ shift: shift, gracenoteGroup, spacing });
     }
 
     // If first note left shift in case it is displaced
     let groupShift = groupList[0].shift;
     let formatWidth;
+    let right = false;
+    let left = false;
     for (let i = 0; i < groupList.length; ++i) {
       const gracenoteGroup = groupList[i].gracenoteGroup;
+      if (gracenoteGroup.position === Modifier.Position.RIGHT) right = true;
+      else left = true;
       gracenoteGroup.preFormat();
       formatWidth = gracenoteGroup.getWidth() + groupList[i].spacing;
       groupShift = Math.max(formatWidth, groupShift);
@@ -90,7 +94,8 @@ export class GraceNoteGroup extends Modifier {
       );
     }
 
-    state.leftShift += groupShift;
+    if (right) state.rightShift += groupShift;
+    if (left) state.leftShift += groupShift;
     return true;
   }
 
@@ -167,7 +172,7 @@ export class GraceNoteGroup extends Modifier {
 
     L('Drawing grace note group for:', note);
 
-    this.alignSubNotesWithNote(this.getGraceNotes(), note); // Modifier function
+    this.alignSubNotesWithNote(this.getGraceNotes(), note, this.position); // Modifier function
 
     // Draw grace notes.
     this.graceNotes.forEach((graceNote) => graceNote.setContext(ctx).drawWithStyle());

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -97,7 +97,7 @@ export const MetricsDefaults: Record<string, any> = {
       fontSize: 20,
     },
     grace: {
-      fontSize: 25,
+      fontSize: 20,
     },
     noteheadAccidentalPadding: 1,
     leftPadding: 2,

--- a/src/modifier.ts
+++ b/src/modifier.ts
@@ -199,13 +199,15 @@ export class Modifier extends Element {
   }
 
   // aligns sub notes of NoteSubGroup (or GraceNoteGroup) to the main note with correct x-offset
-  alignSubNotesWithNote(subNotes: Note[], note: Note): void {
+  alignSubNotesWithNote(subNotes: Note[], note: Note, position = Modifier.Position.LEFT): void {
     // Shift over the tick contexts of each note
     const tickContext = note.getTickContext();
     const metrics = tickContext.getMetrics();
     const stave = note.getStave();
     const subNoteXOffset =
-      tickContext.getX() - metrics.modLeftPx - metrics.modRightPx + this.getSpacingFromNextModifier();
+      position === Modifier.Position.RIGHT
+        ? tickContext.getX() + this.getSpacingFromNextModifier() * subNotes.length + 10
+        : tickContext.getX() - metrics.modLeftPx - metrics.modRightPx + this.getSpacingFromNextModifier();
 
     subNotes.forEach((subNote) => {
       const subTickContext = subNote.getTickContext();

--- a/tests/gracenote_tests.ts
+++ b/tests/gracenote_tests.ts
@@ -7,6 +7,7 @@
 
 import { TestOptions, VexFlowTests } from './vexflow_test_helpers';
 
+import { ModifierPosition } from '../src';
 import { Accidental } from '../src/accidental';
 import { Annotation } from '../src/annotation';
 import { Articulation } from '../src/articulation';
@@ -99,7 +100,7 @@ function basic(options: TestOptions): void {
       .addModifier(f.GraceNoteGroup({ notes: gracenotes3 }).beamNotes(), 0),
     f
       .StaveNote({ keys: ['a/4'], duration: '4', autoStem: true })
-      .addModifier(f.GraceNoteGroup({ notes: gracenotes4 }).beamNotes(), 0),
+      .addModifier(f.GraceNoteGroup({ notes: gracenotes4 }).beamNotes().setPosition(ModifierPosition.RIGHT), 0),
   ];
 
   const voice = f.Voice().setStrict(false).addTickables(notes);


### PR DESCRIPTION
fixes #174 

Not required for 5.0

Accidentals on grace notes have now the same as the notes (see grace notes on note 1 & 4)
It is also allowed to place grace notes on the right (see note 5).
@jaredjj3 does this address your comments?

current
![Grace_Notes Grace_Note_Basic Bravura jsdom_current](https://github.com/user-attachments/assets/b6438923-9c33-4ae5-97af-d05e3f24bfe0)
reference
![Grace_Notes Grace_Note_Basic Bravura jsdom_reference](https://github.com/user-attachments/assets/b20d3db6-4460-4824-9d7d-f3842d4e6d80)
