### PR TITLE
stavemodifiers calling  drawwithstyle (part of #225)

### DIFF
--- a/src/barnote.ts
+++ b/src/barnote.ts
@@ -85,12 +85,11 @@ export class BarNote extends Note {
   draw(): void {
     const ctx = this.checkContext();
     L('Rendering bar line at: ', this.getAbsoluteX());
-    ctx.save();
-    this.applyStyle(ctx);
     const barline = new Barline(this.type);
     barline.setX(this.getAbsoluteX());
-    barline.draw(this.checkStave());
-    ctx.restore();
+    barline.setStave(this.checkStave());
+    barline.setContext(ctx);
+    barline.drawWithStyle();
     this.setRendered();
   }
 }

--- a/src/clef.ts
+++ b/src/clef.ts
@@ -153,13 +153,10 @@ export class Clef extends StaveModifier {
     const ctx = stave.checkContext();
     this.setRendered();
 
-    ctx.save();
-    this.applyStyle(ctx);
     ctx.openGroup('clef', this.getAttribute('id'));
 
     this.y = stave.getYForLine(this.line);
     this.renderText(ctx, 0, 0);
     ctx.closeGroup();
-    ctx.restore();
   }
 }

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -683,12 +683,12 @@ export class Factory {
   draw(): void {
     const ctx = this.context;
     this.systems.forEach((s) => s.setContext(ctx).format());
-    this.staves.forEach((s) => s.setContext(ctx).draw());
-    this.voices.forEach((v) => v.setContext(ctx).draw());
+    this.staves.forEach((s) => s.setContext(ctx).drawWithStyle());
+    this.voices.forEach((v) => v.setContext(ctx).drawWithStyle());
     this.renderQ.forEach((e) => {
-      if (!e.isRendered()) e.setContext(ctx).draw();
+      if (!e.isRendered()) e.setContext(ctx).drawWithStyle();
     });
-    this.systems.forEach((s) => s.setContext(ctx).draw());
+    this.systems.forEach((s) => s.setContext(ctx).drawWithStyle());
     this.reset();
   }
 }

--- a/src/keysignature.ts
+++ b/src/keysignature.ts
@@ -260,14 +260,11 @@ export class KeySignature extends StaveModifier {
     if (!this.formatted) this.format();
     this.setRendered();
 
-    ctx.save();
-    this.applyStyle(ctx);
     ctx.openGroup('keysignature', this.getAttribute('id'));
     for (let i = 0; i < this.glyphs.length; i++) {
       const glyph = this.glyphs[i];
       glyph.renderText(ctx, this.x, 0);
     }
     ctx.closeGroup();
-    ctx.restore();
   }
 }

--- a/src/stave.ts
+++ b/src/stave.ts
@@ -676,12 +676,10 @@ export class Stave extends Element {
   /**
    * All drawing functions below need the context to be set.
    */
-  draw(): this {
+  draw(): void {
     const ctx = this.checkContext();
     this.setRendered();
 
-    ctx.save();
-    this.applyStyle();
     ctx.openGroup('stave', this.getAttribute('id'));
     if (!this.formatted) this.format();
 
@@ -703,27 +701,22 @@ export class Stave extends Element {
     }
 
     ctx.closeGroup();
-    ctx.restore();
 
     // Draw the modifiers (bar lines, coda, segno, repeat brackets, etc.)
     for (let i = 0; i < this.modifiers.length; i++) {
       const modifier: StaveModifier = this.modifiers[i];
-      ctx.save();
-      modifier.applyStyle(ctx);
-      modifier.draw(this, this.getModifierXShift(i));
-      ctx.restore();
+      modifier.setContext(ctx);
+      modifier.setStave(this);
+      modifier.drawWithStyle();
     }
 
     // Render measure numbers
     if (this.measure > 0) {
-      ctx.save();
       ctx.setFont(this.fontInfo);
       const textWidth = ctx.measureText('' + this.measure).width;
       y = this.getYForTopText(0) + 3;
       ctx.fillText('' + this.measure, this.x - textWidth / 2, y);
-      ctx.restore();
     }
-    return this;
   }
 
   getVerticalBarWidth(): number {

--- a/src/stavebarline.ts
+++ b/src/stavebarline.ts
@@ -129,12 +129,11 @@ export class Barline extends StaveModifier {
   }
 
   // Draw barlines
-  draw(stave: Stave): void {
+  draw(): void {
+    const stave = this.checkStave();
     const ctx = stave.checkContext();
     this.setRendered();
 
-    ctx.save();
-    this.applyStyle(ctx);
     ctx.openGroup('stavebarline', this.getAttribute('id'));
     switch (this.type) {
       case BarlineType.SINGLE:
@@ -167,7 +166,6 @@ export class Barline extends StaveModifier {
         break;
     }
     ctx.closeGroup();
-    ctx.restore();
   }
 
   drawVerticalBar(stave: Stave, x: number, doubleBar?: boolean): void {

--- a/src/stavemodifier.ts
+++ b/src/stavemodifier.ts
@@ -85,9 +85,4 @@ export class StaveModifier extends Element {
   getLayoutMetrics(): LayoutMetrics | undefined {
     return this.layoutMetrics;
   }
-
-  // eslint-disable-next-line
-  draw(...args: any[]): void {
-    // DO NOTHING.
-  }
 }

--- a/src/staverepetition.ts
+++ b/src/staverepetition.ts
@@ -52,7 +52,9 @@ export class Repetition extends StaveModifier {
     return this;
   }
 
-  draw(stave: Stave, x: number): this {
+  draw(): void {
+    const stave = this.checkStave();
+    const x = stave.getModifierXShift(this.getPosition());
     this.setRendered();
 
     switch (this.symbolType) {
@@ -95,8 +97,6 @@ export class Repetition extends StaveModifier {
       default:
         break;
     }
-
-    return this;
   }
 
   drawCodaFixed(stave: Stave, x: number): this {

--- a/src/stavetempo.ts
+++ b/src/stavetempo.ts
@@ -4,7 +4,6 @@
 import { Element } from './element';
 import { Glyphs } from './glyphs';
 import { Metrics } from './metrics';
-import { Stave } from './stave';
 import { StaveModifier, StaveModifierPosition } from './stavemodifier';
 import { Category } from './typeguard';
 
@@ -96,7 +95,9 @@ export class StaveTempo extends StaveModifier {
     return this;
   }
 
-  draw(stave: Stave, shiftX: number): this {
+  draw(): void {
+    const stave = this.checkStave();
+    const shiftX = stave.getModifierXShift(this.getPosition());
     const ctx = stave.checkContext();
     this.setRendered();
 
@@ -156,7 +157,5 @@ export class StaveTempo extends StaveModifier {
         elText.renderText(ctx, x + this.xShift, y + this.yShift);
       }
     }
-
-    return this;
   }
 }

--- a/src/stavetext.ts
+++ b/src/stavetext.ts
@@ -1,7 +1,6 @@
 // Copyright (c) 2023-present VexFlow contributors: https://github.com/vexflow/vexflow/graphs/contributors
 // @author: Taehoon Moon 2014
 
-import { Stave } from './stave';
 import { StaveModifier, StaveModifierPosition } from './stavemodifier';
 import { TextJustification, TextNote } from './textnote';
 import { Category } from './typeguard';
@@ -28,7 +27,8 @@ export class StaveText extends StaveModifier {
     this.justification = options.justification ?? TextNote.Justification.CENTER;
   }
 
-  draw(stave: Stave): this {
+  draw(): void {
+    const stave = this.checkStave();
     const ctx = stave.checkContext();
     this.setRendered();
 
@@ -64,6 +64,5 @@ export class StaveText extends StaveModifier {
     }
 
     this.renderText(ctx, x, y + 4);
-    return this;
   }
 }

--- a/src/stavevolta.ts
+++ b/src/stavevolta.ts
@@ -1,7 +1,6 @@
 // Copyright (c) 2023-present VexFlow contributors: https://github.com/vexflow/vexflow/graphs/contributors
 // @author: Larry Kuhns 2011
 
-import { Stave } from './stave';
 import { StaveModifier } from './stavemodifier';
 import { Category } from './typeguard';
 
@@ -32,7 +31,9 @@ export class Volta extends StaveModifier {
     this.text = label;
   }
 
-  draw(stave: Stave, x: number): this {
+  draw(): void {
+    const stave = this.checkStave();
+    const x = stave.getModifierXShift(this.getPosition());
     const ctx = stave.checkContext();
     this.setRendered();
 
@@ -61,6 +62,5 @@ export class Volta extends StaveModifier {
     }
 
     ctx.fillRect(this.x + x, topY, width, 1);
-    return this;
   }
 }

--- a/src/timesignature.ts
+++ b/src/timesignature.ts
@@ -203,15 +203,14 @@ export class TimeSignature extends StaveModifier {
     const stave = this.checkStave();
     const ctx = stave.checkContext();
     this.setRendered();
+    ctx.openGroup('timesignature', this.getAttribute('id'));
     this.drawAt(ctx, stave, this.x);
+    ctx.closeGroup();
   }
 
   drawAt(ctx: RenderContext, stave: Stave, x: number): void {
     this.setRendered();
 
-    ctx.save();
-    this.applyStyle(ctx);
-    ctx.openGroup('timesignature', this.getAttribute('id'));
     if (this.isNumeric) {
       let startX = x + this.topStartX;
       let y = 0;
@@ -224,7 +223,5 @@ export class TimeSignature extends StaveModifier {
     } else {
       this.renderText(ctx, x - this.x, stave.getYForLine(this.line));
     }
-    ctx.closeGroup();
-    ctx.restore();
   }
 }


### PR DESCRIPTION
Not required for release 5.0

- Removes unnecesary calls to `applyStyle`, `save` and `restore` in `draw`
- Refactors `StaveModifiers.draw` to fit `Element.draw` this is no parameters and no returned value.

No visual changes.