### PR TITLE
changed stave line drawing to place them more correctly so that the stroke-width doesn't get anti aliased

### DIFF
--- a/src/stave.ts
+++ b/src/stave.ts
@@ -110,7 +110,7 @@ export class Stave extends Element {
       ...options,
     };
     this.bounds = { x: this.x, y: this.y, w: this.width, h: 0 };
-    this.defaultLedgerLineStyle = { strokeStyle: '#444', lineWidth: 1.4 };
+    this.defaultLedgerLineStyle = { strokeStyle: '#444', lineWidth: 2 };
 
     this.resetLines();
 
@@ -181,11 +181,11 @@ export class Stave extends Element {
   }
 
   getTopLineTopY(): number {
-    return this.getYForLine(0) - (this.getStyle().lineWidth ?? 1) / 2;
+    return this.getYForLine(0);
   }
 
   getBottomLineBottomY(): number {
-    return this.getYForLine(this.getNumLines() - 1) + (this.getStyle().lineWidth ?? 1) / 2;
+    return this.getYForLine(this.getNumLines() - 1) + (this.getStyle().lineWidth ?? 1);
   }
 
   setX(x: number): this {
@@ -688,14 +688,17 @@ export class Stave extends Element {
     const x = this.x;
     let y;
 
+    const lineWidth = this.getStyle().lineWidth ?? 1;
+    const lineWidthCorrection = lineWidth % 2 === 0 ? 0 : 0.5;
+
     // Render lines
     for (let line = 0; line < numLines; line++) {
       y = this.getYForLine(line);
 
       if (this.options.lineConfig[line].visible) {
         ctx.beginPath();
-        ctx.moveTo(x, y);
-        ctx.lineTo(x + width, y);
+        ctx.moveTo(x, y + lineWidthCorrection);
+        ctx.lineTo(x + width, y + lineWidthCorrection);
         ctx.stroke();
       }
     }


### PR DESCRIPTION
In the current main version, stave lines are drawn on exact integers. With a stroke-width of 1px, this means that the stroked version ends up half a pixel above and under the staff line, which ends up anti-aliased and blurry.

![blurry](https://github.com/user-attachments/assets/3cdb0c67-8ec5-45ee-b60b-cc8d59104a2e)

What is interesting is that the barlines are drawn with the width / 2 to account for it and thus also start at `y` positions that have `0.5` offsets.

This PR aims to address that : if the width is an odd number, then it will draw the staff line on a `0.5` offset, thus having its stroke nicely go from one rounded number to another.

This is the result :

![nicer](https://github.com/user-attachments/assets/599aa497-7275-4dca-be3f-1d3db2e3e1d0)

The line is much crispier that way. A workaround I played with otherwise was to set `shape-rendering: crispedges` in css on `g.vf-stave path`, but while it was indeed crispier, it ended up messing with barlines vertical alignment.

Also, for similar reasons, since a stroke-width of 1.4 ends up being antialiased by the renderer I took the liberty of upping the `defaultLedgerLineStyle` to have a width of 2 since when it gets antialiased this is the number of pixels it uses anyways.

Caveat : if `scale()` is used in the renderer, we're back at having anti-aliased stuff and it's ugly again. I guess that scaling the context or the viewbox is easy, but if we want stuff to stay crisp and pixel-aligned we'd have to rewrite a buch of stuff to actually draw on pixel boundaries taking scale into account (mostly whenever `rect` or `moveTo` / `lineTo` is called)

Let me know what you think.