### PR TITLE
added optional "helper" note after tuplet ratio

### DIFF
--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -271,6 +271,10 @@ export const MetricsDefaults: Record<string, any> = {
     textYOffset: 2,
   },
 
+  TupletNote: {
+    fontSize: 12,
+  },
+
   Volta: {
     fontSize: 9,
     fontWeight: 'bold',

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -272,7 +272,7 @@ export const MetricsDefaults: Record<string, any> = {
   },
 
   TupletNote: {
-    fontSize: 12,
+    fontSize: 16,
   },
 
   Volta: {

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -269,10 +269,12 @@ export const MetricsDefaults: Record<string, any> = {
   Tuplet: {
     yOffset: 0,
     textYOffset: 2,
-  },
-
-  TupletNote: {
-    fontSize: 16,
+    bracketPadding: 5,
+    suffix: {
+      fontScale: 1 / 2,
+      extraSpacing: 1,
+      suffixOffsetY: -3,
+    },
   },
 
   Volta: {

--- a/src/tuplet.ts
+++ b/src/tuplet.ts
@@ -75,10 +75,6 @@ export const enum TupletLocation {
   TOP = +1,
 }
 
-// const BRACKET_PADDING = 5; // padding between inner text and bracket if bracket is enabled
-// const NOTE_OFFSET = -3; // offset of shown note
-// const EXTRA_SPACING = 1; // spacing between ratio and shown note
-
 export class Tuplet extends Element {
   static get CATEGORY(): string {
     return Category.Tuplet;
@@ -114,7 +110,7 @@ export class Tuplet extends Element {
     const location = options.location || Tuplet.LOCATION_TOP;
     const yOffset = options.yOffset || Metrics.get('Tuplet.yOffset');
     const textYOffset = options.textYOffset || Metrics.get('Tuplet.textYOffset');
-    const suffix = options.suffix !== undefined ? options.suffix : '';
+    const suffix = options.suffix || '';
 
     this.options = {
       bracketed,

--- a/tests/tuplet_tests.ts
+++ b/tests/tuplet_tests.ts
@@ -17,8 +17,10 @@ const TupletTests = {
     run('Simple Tuplet', simple);
     run('Beamed Tuplet', beamed);
     run('Ratioed Tuplet', ratio);
+    run('Base Note Length Tuplet', baseDuration);
     run('Bottom Tuplet', bottom);
     run('Bottom Ratioed Tuplet', bottomRatio);
+    run('Bottom Base Note Length Tuplet', bottomBaseDuration);
     run('Awkward Tuplet', awkward);
     run('Complex Tuplet', complex);
     run('Mixed Stem Direction Tuplet', mixedTop);
@@ -154,6 +156,51 @@ function ratio(options: TestOptions): void {
   options.assert.ok(true, 'Ratioed Test');
 }
 
+function baseDuration(options: TestOptions): void {
+  const f = VexFlowTests.makeFactory(options);
+  const stave = f.Stave({ x: 10, y: 10, width: 350 }).addTimeSignature('4/4');
+
+  const notes = [
+    { keys: ['f/4'], duration: '4' },
+    { keys: ['a/4'], duration: '4' },
+    { keys: ['b/4'], duration: '4' },
+    { keys: ['g/4'], duration: '8' },
+    { keys: ['e/4'], duration: '8' },
+    { keys: ['g/4'], duration: '8' },
+  ]
+    .map(setStemUp)
+    .map(f.StaveNote.bind(f));
+
+  f.Beam({
+    notes: notes.slice(3, 6),
+  });
+
+  f.Tuplet({
+    notes: notes.slice(0, 3),
+    options: {
+      ratioed: true,
+      baseNoteLength: 'q',
+    },
+  });
+
+  f.Tuplet({
+    notes: notes.slice(3, 6),
+    options: {
+      ratioed: true,
+      notesOccupied: 4,
+      baseNoteLength: '8',
+    },
+  });
+
+  const voice = f.Voice().setStrict(true).addTickables(notes);
+
+  new Formatter().joinVoices([voice]).formatToStave([voice], stave);
+
+  f.draw();
+
+  options.assert.ok(true, 'Base Duration Test');
+}
+
 function bottom(options: TestOptions): void {
   const f = VexFlowTests.makeFactory(options, 350, 160);
   const stave = f.Stave({ x: 10, y: 10 }).addTimeSignature('3/4');
@@ -240,6 +287,55 @@ function bottomRatio(options: TestOptions): void {
   f.draw();
 
   options.assert.ok(true, 'Bottom Ratioed Test');
+}
+
+function bottomBaseDuration(options: TestOptions): void {
+  const f = VexFlowTests.makeFactory(options, 350, 160);
+  const stave = f.Stave({ x: 10, y: 10 }).addTimeSignature('5/8');
+
+  const notes = [
+    { keys: ['f/4'], duration: '4' },
+    { keys: ['c/4'], duration: '4' },
+    { keys: ['d/4'], duration: '4' },
+    { keys: ['d/5'], duration: '8' },
+    { keys: ['g/5'], duration: '8' },
+    { keys: ['b/4'], duration: '8' },
+  ]
+    .map(setStemDown)
+    .map(f.StaveNote.bind(f));
+
+  f.Beam({
+    notes: notes.slice(3, 6),
+  });
+
+  f.Tuplet({
+    notes: notes.slice(0, 3),
+    options: {
+      location: Tuplet.LOCATION_BOTTOM,
+      ratioed: true,
+      baseNoteLength: 'q',
+    },
+  });
+
+  f.Tuplet({
+    notes: notes.slice(3, 6),
+    options: {
+      location: Tuplet.LOCATION_BOTTOM,
+      notesOccupied: 1,
+      baseNoteLength: '8',
+    },
+  });
+
+  const voice = f
+    .Voice({ time: { numBeats: 5, beatValue: 8 } })
+    .setStrict(true)
+    .addTickables(notes);
+
+  new Formatter().joinVoices([voice]).formatToStave([voice], stave);
+
+  f.draw();
+
+  options.assert.ok(true, 'Bottom Base Duration Test');
 }
 
 function awkward(options: TestOptions): void {

--- a/tests/tuplet_tests.ts
+++ b/tests/tuplet_tests.ts
@@ -7,6 +7,7 @@ import { TestOptions, VexFlowTests } from './vexflow_test_helpers';
 
 import { Dot } from '../src/dot';
 import { Formatter } from '../src/formatter';
+import { Glyphs } from '../src/glyphs';
 import { Stem } from '../src/stem';
 import { Tuplet } from '../src/tuplet';
 
@@ -17,10 +18,10 @@ const TupletTests = {
     run('Simple Tuplet', simple);
     run('Beamed Tuplet', beamed);
     run('Ratioed Tuplet', ratio);
-    run('Base Note Length Tuplet', baseDuration);
+    run('Suffixed Tuplet', suffix);
     run('Bottom Tuplet', bottom);
     run('Bottom Ratioed Tuplet', bottomRatio);
-    run('Bottom Base Note Length Tuplet', bottomBaseDuration);
+    run('Bottom Suffixed Tuplet', bottomSuffix);
     run('Awkward Tuplet', awkward);
     run('Complex Tuplet', complex);
     run('Mixed Stem Direction Tuplet', mixedTop);
@@ -156,7 +157,7 @@ function ratio(options: TestOptions): void {
   options.assert.ok(true, 'Ratioed Test');
 }
 
-function baseDuration(options: TestOptions): void {
+function suffix(options: TestOptions): void {
   const f = VexFlowTests.makeFactory(options);
   const stave = f.Stave({ x: 10, y: 10, width: 350 }).addTimeSignature('4/4');
 
@@ -179,7 +180,7 @@ function baseDuration(options: TestOptions): void {
     notes: notes.slice(0, 3),
     options: {
       ratioed: true,
-      baseNoteLength: 'q',
+      suffix: Glyphs.noteQuarterUp,
     },
   });
 
@@ -188,7 +189,7 @@ function baseDuration(options: TestOptions): void {
     options: {
       ratioed: true,
       notesOccupied: 4,
-      baseNoteLength: '8',
+      suffix: Glyphs.note8thUp,
     },
   });
 
@@ -289,7 +290,7 @@ function bottomRatio(options: TestOptions): void {
   options.assert.ok(true, 'Bottom Ratioed Test');
 }
 
-function bottomBaseDuration(options: TestOptions): void {
+function bottomSuffix(options: TestOptions): void {
   const f = VexFlowTests.makeFactory(options, 350, 160);
   const stave = f.Stave({ x: 10, y: 10 }).addTimeSignature('5/8');
 
@@ -313,7 +314,7 @@ function bottomBaseDuration(options: TestOptions): void {
     options: {
       location: Tuplet.LOCATION_BOTTOM,
       ratioed: true,
-      baseNoteLength: 'q',
+      suffix: Glyphs.metNoteQuarterUp,
     },
   });
 
@@ -322,7 +323,7 @@ function bottomBaseDuration(options: TestOptions): void {
     options: {
       location: Tuplet.LOCATION_BOTTOM,
       notesOccupied: 1,
-      baseNoteLength: '8',
+      suffix: Glyphs.metNote8thUp,
     },
   });
 


### PR DESCRIPTION
Hey all, 
I know noncritical PRs are on hold for the moment, but still thought I would get started contributing this. Useful for notation with complex tuplets and Ferneyhough et al love this kind of thing. I have basic centering at the moment but it would be easy enough to change the layout so that the tuplet ratio itself stays centered. Also, did some small quality life improvements by creating constants for some magic numbers that were in the code. 

Very interested to see if anyone has better ideas for how to structure the API. Could it be possible to make this a flag (something like isBeatShown or showBaseDuration) and have the tuplet itself calculate what the baseNoteLength should be? Also, if it stays as an input value, I am assuming there could maybe be a better name. 

I have a question as well:
I am wanting to refactor the logic in the draw and resolveGlyphs functions into a couple of private helpers but I noticed this is done very little (if at all) in the codebase. Would it be acceptable to make public drawBracket, drawNote etc functions like what seems to be in stavenote or would it be better to just keep the functions as they are?

Thanks so much,
Ben

<img width="786" alt="Screenshot 2025-02-08 at 3 44 03 PM" src="https://github.com/user-attachments/assets/b75ce321-d12c-4de5-95e8-ab0cf745c0f7" />
 