### PR TITLE
Add complex key signatures

### DIFF
--- a/src/stave.ts
+++ b/src/stave.ts
@@ -476,7 +476,7 @@ export class Stave extends Element {
    *
    * Example:
    * `stave.addKeySignature('Db');`
-   * @param keySpec new key specification `[A-G][b|#]?`
+   * @param keySpec new key specification `[A-G][b|#]?` or `[flats|sharps]_[1-14]?`
    * @param cancelKeySpec
    * @param position
    * @returns

--- a/src/tables.ts
+++ b/src/tables.ts
@@ -36,7 +36,29 @@ const durationAliases: Record<string, string> = {
   b: '256',
 };
 
-const keySignatures: Record<string, { accidental?: string; num: number }> = {
+type KeySignature = {
+  accidental?: string;
+  num: number;
+};
+
+type KeySignatures = Record<string, KeySignature>;
+
+const generateKeySignatures = (): KeySignatures => {
+  const keySignatures: KeySignatures = {};
+
+  for (let i = 1; i <= 14; i++) {
+    keySignatures[`flats_${i}`] = { accidental: 'b', num: i };
+    keySignatures[`sharps_${i}`] = { accidental: 'b', num: i };
+  }
+
+  keySignatures['flats_0'] = { num: 0 };
+  keySignatures['sharps_0'] = { num: 0 };
+
+  return keySignatures;
+};
+
+const keySignatures: Record<string, KeySignature> = {
+  ...generateKeySignatures(),
   C: { num: 0 },
   Am: { num: 0 },
   F: { accidental: 'b', num: 1 },
@@ -53,6 +75,8 @@ const keySignatures: Record<string, { accidental?: string; num: number }> = {
   Ebm: { accidental: 'b', num: 6 },
   Cb: { accidental: 'b', num: 7 },
   Abm: { accidental: 'b', num: 7 },
+  Dbm: { accidental: 'b', num: 8 },
+  Gbm: { accidental: 'b', num: 9 },
   G: { accidental: '#', num: 1 },
   Em: { accidental: '#', num: 1 },
   D: { accidental: '#', num: 2 },
@@ -67,6 +91,9 @@ const keySignatures: Record<string, { accidental?: string; num: number }> = {
   'D#m': { accidental: '#', num: 6 },
   'C#': { accidental: '#', num: 7 },
   'A#m': { accidental: '#', num: 7 },
+  'G#': { accidental: '#', num: 8 },
+  'D#': { accidental: '#', num: 9 },
+  'A#': { accidental: '#', num: 10 },
 };
 
 const clefs: Record<string, { lineShift: number }> = {
@@ -502,13 +529,19 @@ export class Tables {
 
     const notes = accidentalList[keySpec.accidental];
 
-    const accList = [];
-    for (let i = 0; i < keySpec.num; ++i) {
-      const line = notes[i];
-      accList.push({ type: keySpec.accidental, line });
-    }
+    const accidentalCount = Math.min(keySpec.num, 7);
+    const doubleAccidentalCount = Math.max(keySpec.num - 7, 0);
 
-    return accList;
+    const regularAccidentals = notes.slice(doubleAccidentalCount, accidentalCount).map((line) => ({
+      type: `${keySpec.accidental}`,
+      line,
+    }));
+
+    const doubleAccidentals = notes.slice(0, doubleAccidentalCount).map((line) => ({
+      type: `${keySpec.accidental}${keySpec.accidental}`,
+      line,
+    }));
+    return [...regularAccidentals, ...doubleAccidentals];
   }
 
   static getKeySignatures(): Record<string, { accidental?: string; num: number }> {

--- a/tests/keysignature_tests.ts
+++ b/tests/keysignature_tests.ts
@@ -39,7 +39,7 @@ const fontWidths = () => {
 };
 
 function parser(assert: Assert): void {
-  assert.expect(11);
+  assert.expect(16);
 
   function catchError(spec: string): void {
     assert.throws(() => VexFlow.keySignature(spec), /BadKeySignature/);
@@ -48,13 +48,18 @@ function parser(assert: Assert): void {
   catchError('asdf');
   catchError('D!');
   catchError('E#');
-  catchError('D#');
   catchError('#');
   catchError('b');
   catchError('Kb');
   catchError('Fb');
-  catchError('Dbm');
   catchError('B#m');
+  catchError('flats_15');
+  catchError('sharps_16');
+  catchError('flat_1');
+  catchError('sharps_-1');
+  catchError('sharp_0');
+  catchError('sharps_B');
+  catchError('flats_c');
 
   VexFlow.keySignature('B');
   VexFlow.keySignature('C');
@@ -63,6 +68,12 @@ function parser(assert: Assert): void {
   VexFlow.keySignature('Abm');
   VexFlow.keySignature('F#');
   VexFlow.keySignature('G#m');
+  VexFlow.keySignature('flats_8');
+  VexFlow.keySignature('sharps_14');
+  VexFlow.keySignature('flats_10');
+  VexFlow.keySignature('sharps_8');
+  VexFlow.keySignature('flats_0');
+  VexFlow.keySignature('sharps_0');
 
   assert.ok(true, 'all pass');
 }


### PR DESCRIPTION
## Support for Complex Key Signatures and Alternative Definition Method

[Original PR ](https://github.com/vexflow/vexflow/pull/256), remade from main V5 branch following comment

This update introduces support for complex key signatures, including theoretical or rare keys from different modes. It enhances versatility and provides additional options for defining key signatures. This implementation preserves backward compatibility, ensuring that all existing key signature definitions and functionality remain unaffected.

### Key Features

1. **Alternative Key Signature Definition:**  
   The `addKeySignature` method now accepts a new format, allowing direct specification of the number of flats or sharps:
   ```javascript
   stave.addKeySignature('flats_4');
   ```
   This adds four flats to the key signature, suitable for modes such as Ab major, F minor, Bb Dorian, C Phrygian, Db Lydian, Eb Mixolydian, or G Locrian.

2. **Support for Double Alterations:**  
   Numbers between 8 and 14 introduce double alterations (e.g., double flats or double sharps) in the key signature, enabling the rendering of more complex and less common keys.

There are 2 ways to display double alterations on a key signatures that can be found on the web: putting the altered note in the original position (F C G D A E B for sharps, reverse for flats) or shifting the double alterations to the end of the key (C G D A E F for 1 double sharp). The latter seems to be the most used, for example on [wikipedia](https://en.wikipedia.org/wiki/D-flat_minor), hence why I chose this way, but it can be changed easily, on line 544 of tables.ts

### Image examples
```javascript
//Use case example: D flat minor
stave
  .addClef('treble')
  .addTimeSignature('4/4')
  .addKeySignature('flats_8');
```
<img width="211" alt="Capture d’écran 2025-02-24 à 21 48 52" src="https://github.com/user-attachments/assets/6b370db4-7ee5-43a0-9064-a214d16284a8" />

```javascript
//Use case example: G sharp major
stave
  .addClef('treble')
  .addTimeSignature('4/4')
  .addKeySignature('sharps_8');
```
<img width="211" alt="Capture d’écran 2025-02-24 à 21 59 27" src="https://github.com/user-attachments/assets/b2f0e6ad-5c31-4180-b127-c59e80750e63" />

```javascript
//Use case example: D flat locrian
stave
  .addClef('treble')
  .addTimeSignature('4/4')
  .addKeySignature('flats_10');
```
<img width="211" alt="Capture d’écran 2025-02-24 à 22 08 04" src="https://github.com/user-attachments/assets/f513d475-aba2-4ff7-b6ba-2530bdb52907" />


```javascript
stave
  .addClef('treble')
  .addTimeSignature('4/4')
  .addKeySignature('sharps_14');
```
<img width="211" alt="Capture d’écran 2025-02-24 à 22 08 51" src="https://github.com/user-attachments/assets/937b18fe-6a4a-4f89-a626-ba8e5de68022" />


```javascript
//Example use case: E flat major
stave
  .addClef('treble')
  .addTimeSignature('4/4')
  .addKeySignature('flats_3');
```
<img width="194" alt="Capture d’écran 2025-02-24 à 21 33 13" src="https://github.com/user-attachments/assets/516ce62b-7947-4295-9e15-7c16d888f5f3" />


```javascript
// example use case: A major
stave
  .addClef('treble')
  .addTimeSignature('4/4')
  .addKeySignature('sharps_3');
```
<img width="194" alt="Capture d’écran 2025-02-24 à 21 33 21" src="https://github.com/user-attachments/assets/e167e5b1-c9cc-473a-9ef0-81d0f7423638" />




```javascript
//Example use case: C major
stave
  .addClef('treble')
  .addTimeSignature('4/4')
  .addKeySignature('flats_0');
```
or
```javascript
stave
  .addClef('treble')
  .addTimeSignature('4/4')
  .addKeySignature('sharps_0');
```
<img width="211" alt="Capture d’écran 2025-02-24 à 23 01 02" src="https://github.com/user-attachments/assets/1b5abc60-a530-478f-b339-21252a131dfb" />



---

This change enhances the flexibility of the `KeySignature` class, making it suitable for a wider range of musical contexts and theoretical applications.