### PR TITLE
Added longa, maxima, 256th, 512th and 1024th notes support

### DIFF
--- a/src/beam.ts
+++ b/src/beam.ts
@@ -920,7 +920,7 @@ export class Beam extends Element {
 
   // Render the beam lines
   protected drawBeamLines(ctx: RenderContext): void {
-    const validBeamDurations = ['4', '8', '16', '32', '64'];
+    const validBeamDurations = ['4', '8', '16', '32', '64', '128', '256', '512', '1024'];
 
     const firstNote = this.notes[0];
     let beamY = this.getBeamYToDraw();

--- a/src/stavenote.ts
+++ b/src/stavenote.ts
@@ -787,7 +787,6 @@ export class StaveNote extends StemmableNote {
     // addtional y shifts for rests
     let restShift = 0;
     switch (this._noteHeads[index].getText()) {
-      case Glyphs.restDoubleWhole:
       case Glyphs.restWhole:
         restShift += 0.5;
         break;
@@ -802,7 +801,14 @@ export class StaveNote extends StemmableNote {
         restShift -= 1.5;
         break;
       case Glyphs.rest128th:
+      case Glyphs.rest256th:
         restShift -= 2.5;
+        break;
+      case Glyphs.rest512th:
+        restShift -= 3.5;
+        break;
+      case Glyphs.rest1024th:
+        restShift -= 4.5;
         break;
     }
 

--- a/src/stemmablenote.ts
+++ b/src/stemmablenote.ts
@@ -113,6 +113,15 @@ export abstract class StemmableNote extends Note {
       case '128':
         length = beamIsUndefined ? 55 : 45;
         break;
+      case '256':
+        length = beamIsUndefined ? 60 : 55;
+        break;
+      case '512':
+        length = beamIsUndefined ? 65 : 60;
+        break;
+      case '1024':
+        length = beamIsUndefined ? 70 : 65;
+        break;
       default:
         break;
     }

--- a/src/tables.ts
+++ b/src/tables.ts
@@ -13,6 +13,8 @@ const RESOLUTION = 16384;
  * For example, a quarter note is 4, so it maps to RESOLUTION / 4 = 4096 ticks.
  */
 const durations: Record<string, number> = {
+  '1/8': RESOLUTION * 8, // Maxima
+  '1/4': RESOLUTION * 4, // Longa
   '1/2': RESOLUTION * 2,
   1: RESOLUTION / 1,
   2: RESOLUTION / 2,
@@ -23,9 +25,13 @@ const durations: Record<string, number> = {
   64: RESOLUTION / 64,
   128: RESOLUTION / 128,
   256: RESOLUTION / 256,
+  512: RESOLUTION / 512,
+  1024: RESOLUTION / 1024,
 };
 
 const durationAliases: Record<string, string> = {
+  m: '1/8', // Maxima
+  l: '1/4', // Longa
   w: '1',
   h: '2',
   q: '4',
@@ -296,11 +302,19 @@ export class Tables {
   static RENDER_PRECISION_PLACES = 3;
   static RESOLUTION = RESOLUTION;
 
-  // 1/2, 1, 2, 4, 8, 16, 32, 64, 128
+  // 1/8, 1/4, 1/2, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024
   // NOTE: There is no 256 here! However, there are other mentions of 256 in this file.
   // For example, in durations has a 256 key, and sanitizeDuration() can return 256.
   // The sanitizeDuration() bit may need to be removed by 0xfe.
   static durationCodes: Record<string, Partial<GlyphProps>> = {
+    '1/8': {
+      stem: true,
+    },
+
+    '1/4': {
+      stem: false,
+    },
+
     '1/2': {
       stem: false,
     },
@@ -350,6 +364,27 @@ export class Tables {
       stemBeamExtension: 22.5,
       stem: true,
       codeFlagUp: Glyphs.flag128thUp,
+    },
+
+    256: {
+      beamCount: 6,
+      stemBeamExtension: 25,
+      stem: true,
+      codeFlagUp: Glyphs.flag256thUp,
+    },
+
+    512: {
+      beamCount: 7,
+      stemBeamExtension: 27.5,
+      stem: true,
+      codeFlagUp: Glyphs.flag512thUp,
+    },
+
+    1024: {
+      beamCount: 8,
+      stemBeamExtension: 30,
+      stem: true,
+      codeFlagUp: Glyphs.flag1024thUp,
     },
   };
 
@@ -738,6 +773,10 @@ export class Tables {
         }
       case 'R':
         switch (duration) {
+          case '1/8':
+            return Glyphs.restMaxima;
+          case '1/4':
+            return Glyphs.restLonga;
           case '1/2':
             return Glyphs.restDoubleWhole;
           case '1':
@@ -756,6 +795,12 @@ export class Tables {
             return Glyphs.rest64th;
           case '128':
             return Glyphs.rest128th;
+          case '256':
+            return Glyphs.rest256th;
+          case '512':
+            return Glyphs.rest512th;
+          case '1024':
+            return Glyphs.rest1024th;
         }
         break;
       case 'S':
@@ -771,6 +816,10 @@ export class Tables {
         }
       default:
         switch (duration) {
+          case '1/8':
+            return Glyphs.mensuralNoteheadMaximaBlack;
+          case '1/4':
+            return Glyphs.mensuralNoteheadLongaBlack;
           case '1/2':
             return Glyphs.noteheadDoubleWhole;
           case '1':

--- a/tests/beam_tests.ts
+++ b/tests/beam_tests.ts
@@ -33,6 +33,7 @@ const BeamTests = {
     run('Auto-stemmed Beam', autoStem);
     run('Mixed Beam 1', mixed);
     run('Mixed Beam 2', mixed2);
+    run('Mixed Beam 3', mixed3);
     run('Dotted Beam', dotted);
     run('Partial Beam', partial);
     run('Close Trade-offs Beam', tradeoffs);
@@ -316,6 +317,41 @@ function mixed2(options: TestOptions): void {
   f.draw();
 
   options.assert.ok(true, 'Multi Test');
+}
+
+function mixed3(options: TestOptions): void {
+  const f = VexFlowTests.makeFactory(options, 450, 230);
+  const stave = f.Stave({ y: 20 });
+  const score = f.EasyScore();
+
+  const voice = score.voice(
+    score.notes(
+      'f5/32, d5/16, c5/32, c5/64, d5/128, e5/8, f5/16, d5/32, c5/64, c5/32, d5/16, e5/1024, e5/512, e5/512, e5/512, e5/1024',
+      {
+        stem: 'up',
+      }
+    ),
+    { time: '31/64' }
+  );
+
+  const voice2 = score.voice(
+    score.notes(
+      'f4/32, d4/16, c4/32, c4/64, d4/128, e4/8, f4/16, e4/256, e4/512, e4/1024, e4/1024, d4/32, c4/64, c4/32, d4/16',
+      {
+        stem: 'down',
+      }
+    ),
+    { time: '31/64' }
+  );
+
+  f.Beam({ notes: voice.getTickables().slice(0, 12) as StemmableNote[] });
+  f.Beam({ notes: voice2.getTickables().slice(0, 12) as StemmableNote[] });
+
+  f.Formatter().joinVoices([voice, voice2]).formatToStave([voice, voice2], stave);
+
+  f.draw();
+
+  options.assert.ok(true, 'Multi Test with 1024th, 512th, and 256th notes');
 }
 
 function dotted(options: TestOptions): void {

--- a/tests/beam_tests.ts
+++ b/tests/beam_tests.ts
@@ -321,7 +321,7 @@ function mixed2(options: TestOptions): void {
 
 function mixed3(options: TestOptions): void {
   const f = VexFlowTests.makeFactory(options, 450, 230);
-  const stave = f.Stave({ y: 20 });
+  const stave = f.Stave({ y: 25 });
   const score = f.EasyScore();
 
   const voice = score.voice(
@@ -344,8 +344,8 @@ function mixed3(options: TestOptions): void {
     { time: '31/64' }
   );
 
-  f.Beam({ notes: voice.getTickables().slice(0, 12) as StemmableNote[] });
-  f.Beam({ notes: voice2.getTickables().slice(0, 12) as StemmableNote[] });
+  f.Beam({ notes: voice.getTickables() as StemmableNote[] });
+  f.Beam({ notes: voice2.getTickables() as StemmableNote[] });
 
   f.Formatter().joinVoices([voice, voice2]).formatToStave([voice, voice2], stave);
 

--- a/tests/rests_tests.ts
+++ b/tests/rests_tests.ts
@@ -66,6 +66,9 @@ function basic(options: TestOptions, contextBuilder: ContextBuilder): void {
   const { context, stave } = setupContext(options, contextBuilder, 700);
 
   const notes = [
+    new StaveNote({ keys: ['b/4'], stemDirection: 1, duration: 'mr' }),
+    new StaveNote({ keys: ['b/4'], stemDirection: 1, duration: 'lr' }),
+    new StaveNote({ keys: ['b/4'], stemDirection: 1, duration: '1/2r' }),
     new StaveNote({ keys: ['b/4'], stemDirection: 1, duration: 'wr' }),
     new StaveNote({ keys: ['b/4'], stemDirection: 1, duration: 'hr' }),
     new StaveNote({ keys: ['b/4'], stemDirection: 1, duration: '4r' }),
@@ -74,6 +77,9 @@ function basic(options: TestOptions, contextBuilder: ContextBuilder): void {
     new StaveNote({ keys: ['b/4'], stemDirection: 1, duration: '32r' }),
     new StaveNote({ keys: ['b/4'], stemDirection: 1, duration: '64r' }),
     new StaveNote({ keys: ['b/4'], stemDirection: 1, duration: '128r' }),
+    new StaveNote({ keys: ['b/4'], stemDirection: 1, duration: '256r' }),
+    new StaveNote({ keys: ['b/4'], stemDirection: 1, duration: '512r' }),
+    new StaveNote({ keys: ['b/4'], stemDirection: 1, duration: '1024r' }),
   ];
   Dot.buildAndAttach(notes, { all: true });
 


### PR DESCRIPTION
Updated Vexflow to support **longa**, **maxima**, **256th**, **512th** and **1024th** notes.
List of changes:
• Added respective glyphs for each note (also 128th); 
• Ensured each note has a correct tick number;
• Supported rests (updated rests "basic" test to include all new notes);
• Added l (Longa) and m (Maxima) aliases.
• Updated supported beam durations with 128, 256, 512, 1024.
• Added "mixed3" test on beam_tests.ts which simply renders two beams (one beam per voice) with new notes. I noticed that the last notes in the measure do not get beamed, but it doesn't seem to be caused by the added durations.

### New Rests Example
![Screenshot 2025-02-27 alle 20 15 57](https://github.com/user-attachments/assets/4e099676-c80d-43ec-bd89-49c7146a377f)

### Beam Example with new Durations
![Screenshot 2025-02-27 alle 20 18 32](https://github.com/user-attachments/assets/8224f15a-17b2-495c-baa0-31b00afbc536)

As you can see, there is a problem with the last beam notes connection. I checked if I missed something in the updated code, but I couldn't find any problem. Please tell me if I did something wrong on my side, I'm willing to help to solve this issue.

As for the rest, everything seems to work fine. Thanks.