### PR TITLE
VexFlow Sandbox

### DIFF
--- a/tests/sandbox.html
+++ b/tests/sandbox.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sandbox</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        overflow: hidden;
+      }
+
+      iframe {
+        width: 100%;
+        height: 100%;
+        border: none;
+        display: block;
+      }
+    </style>
+  </head>
+  <body>
+    <script>
+      const iframeURL = 'https://vexflow.github.io/vexflow-sandbox/?dev=1&parent=' + window.location.origin;
+      const iframe = document.createElement('iframe');
+      iframe.tabIndex = 0;
+      iframe.src = iframeURL;
+      document.body.appendChild(iframe);
+      setTimeout(() => {
+        iframe.focus();
+      }, 100);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Fixes https://github.com/vexflow/vexflow/issues/249

The new VexFlow Sandbox is at: https://vexflow.github.io/vexflow-sandbox/

It allows you to compare V5, V4, V3, V2.

---

This PR adds a `sandbox.html` file to the main vexflow repository.

It wraps the sandbox website in an `<iframe>`, so you can load your local development build of `vexflow-debug.js` into the sandbox.

Change to your `vexflow/` directory, and run `grunt` to make a local build.

Then start a local webserver with `npx http-server` and load up the sandbox at:

<a href="http://127.0.0.1:8080/tests/sandbox.html">http://127.0.0.1:8080/tests/sandbox.html</a>

When you make changes to your local copy, you can just refresh the localhost sandbox to see the new changes.

Questions / Comments?
@rvilarl 
@mscuthbert

There are still some small bugs I need to fix, but I wanted to get it out there so folks can play with it and provide feedback.

<img width="1137" alt="image" src="https://github.com/user-attachments/assets/775a4e52-1219-41ae-8ff1-2d0bec539ea9" />
