### PR TITLE
added noImplicitOverride to tsconfig

### DIFF
--- a/src/accidental.ts
+++ b/src/accidental.ts
@@ -53,7 +53,7 @@ export class Accidental extends Modifier {
   protected cautionary: boolean;
 
   /** Accidentals category string. */
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.Accidental;
   }
 
@@ -521,7 +521,7 @@ export class Accidental extends Modifier {
     this.reset();
   }
 
-  protected reset(): void {
+  protected override reset(): void {
     this.text = '';
 
     if (!this.cautionary) {
@@ -540,7 +540,7 @@ export class Accidental extends Modifier {
   }
 
   /** Attach this accidental to `note`, which must be a `StaveNote`. */
-  setNote(note: Note): this {
+  override setNote(note: Note): this {
     defined(note, 'ArgumentError', `Bad note value: ${note}`);
 
     this.note = note;
@@ -556,7 +556,7 @@ export class Accidental extends Modifier {
   }
 
   /** Render accidental onto canvas. */
-  draw(): void {
+  override draw(): void {
     const { type, position, index } = this;
 
     const ctx = this.checkContext();

--- a/src/annotation.ts
+++ b/src/annotation.ts
@@ -41,7 +41,7 @@ export class Annotation extends Modifier {
   static DEBUG: boolean = false;
 
   /** Annotations category string. */
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.Annotation;
   }
 
@@ -217,7 +217,7 @@ export class Annotation extends Modifier {
   }
 
   /** Render text beside the note. */
-  draw(): void {
+  override draw(): void {
     const ctx = this.checkContext();
     const note = this.checkAttachedNote();
     const stemDirection = note.hasStem() ? note.getStemDirection() : Stem.UP;

--- a/src/articulation.ts
+++ b/src/articulation.ts
@@ -168,7 +168,7 @@ export class Articulation extends Modifier {
   static DEBUG: boolean = false;
 
   /** Articulations category string. */
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.Articulation;
   }
 
@@ -311,7 +311,7 @@ export class Articulation extends Modifier {
     this.reset();
   }
 
-  protected reset(): void {
+  protected override reset(): void {
     this.articulation = Tables.articulationCodes(this.type);
     // Use type as glyph code, if not defined as articulation code
     if (!this.articulation) {
@@ -331,7 +331,7 @@ export class Articulation extends Modifier {
   }
 
   /** Render articulation in position next to note. */
-  draw(): void {
+  override draw(): void {
     const ctx = this.checkContext();
     const note = this.checkAttachedNote();
     this.setRendered();

--- a/src/barnote.ts
+++ b/src/barnote.ts
@@ -23,7 +23,7 @@ export class BarNote extends Note {
   /** To enable logging for this class. Set `VexFlow.BarNote.DEBUG` to `true`. */
   static DEBUG: boolean = false;
 
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.BarNote;
   }
 
@@ -70,19 +70,19 @@ export class BarNote extends Note {
 
   /* Overridden to ignore */
   // eslint-disable-next-line
-  addToModifierContext(mc: ModifierContext): this {
+  override addToModifierContext(mc: ModifierContext): this {
     // DO NOTHING.
     return this;
   }
 
   /** Overridden to ignore. */
-  preFormat(): this {
+  override preFormat(): this {
     this.preFormatted = true;
     return this;
   }
 
   /** Render note to stave. */
-  draw(): void {
+  override draw(): void {
     const ctx = this.checkContext();
     L('Rendering bar line at: ', this.getAbsoluteX());
     const barline = new Barline(this.type);

--- a/src/beam.ts
+++ b/src/beam.ts
@@ -45,7 +45,7 @@ export type PartialBeamDirection = typeof BEAM_LEFT | typeof BEAM_RIGHT | typeof
 
 /** `Beams` span over a set of `StemmableNotes`. */
 export class Beam extends Element {
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.Beam;
   }
 
@@ -71,7 +71,7 @@ export class Beam extends Element {
   private readonly _stemDirection: number;
   private readonly _ticks: number;
 
-  protected yShift: number = 0;
+  protected override yShift: number = 0;
   private breakOnIndexes: number[];
   private _beamCount: number;
   // note that this is never set and is a private property.  Remove?
@@ -982,7 +982,7 @@ export class Beam extends Element {
   }
 
   /** Render the beam to the canvas context */
-  draw(): void {
+  override draw(): void {
     const ctx = this.checkContext();
     this.setRendered();
     if (this.unbeamable) return;

--- a/src/bend.ts
+++ b/src/bend.ts
@@ -18,7 +18,7 @@ export interface BendPhrase {
 
 /** Bend implements tablature bends. */
 export class Bend extends Modifier {
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.Bend;
   }
 
@@ -123,7 +123,7 @@ export class Bend extends Modifier {
   }
 
   /** Set horizontal shift in pixels. */
-  setXShift(value: number): this {
+  override setXShift(value: number): this {
     this.xShift = value;
     this.updateWidth();
     return this;
@@ -167,7 +167,7 @@ export class Bend extends Modifier {
   }
 
   /** Draw the bend on the rendering context. */
-  draw(): void {
+  override draw(): void {
     const ctx = this.checkContext();
     const note = this.checkAttachedNote();
     this.setRendered();

--- a/src/chordsymbol.ts
+++ b/src/chordsymbol.ts
@@ -75,7 +75,7 @@ export enum SymbolModifiers {
 export class ChordSymbol extends Modifier {
   static DEBUG: boolean = false;
 
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.ChordSymbol;
   }
 
@@ -398,7 +398,7 @@ export class ChordSymbol extends Modifier {
   }
 
   /** Render text and glyphs above/below the note. */
-  draw(): void {
+  override draw(): void {
     const ctx = this.checkContext();
     const note = this.checkAttachedNote() as StemmableNote;
     this.setRendered();
@@ -459,7 +459,7 @@ export class ChordSymbol extends Modifier {
   }
 
   // Get the `BoundingBox` for the entire chord
-  getBoundingBox(): BoundingBox {
+  override getBoundingBox(): BoundingBox {
     const boundingBox = this.symbolBlocks[0].getBoundingBox();
     for (let i = 1; i < this.symbolBlocks.length; i++) {
       boundingBox.mergeWith(this.symbolBlocks[i].getBoundingBox());

--- a/src/clef.ts
+++ b/src/clef.ts
@@ -23,7 +23,7 @@ export class Clef extends StaveModifier {
   /** To enable logging for this class, set `VexFlow.Clef.DEBUG` to `true`. */
   static DEBUG: boolean = false;
 
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.Clef;
   }
 
@@ -142,13 +142,13 @@ export class Clef extends StaveModifier {
   }
 
   /** Set associated stave. */
-  setStave(stave: Stave): this {
+  override setStave(stave: Stave): this {
     this.stave = stave;
     return this;
   }
 
   /** Render clef. */
-  draw(): void {
+  override draw(): void {
     const stave = this.checkStave();
     const ctx = stave.checkContext();
     this.setRendered();

--- a/src/clefnote.ts
+++ b/src/clefnote.ts
@@ -9,7 +9,7 @@ import { Category } from './typeguard';
 
 /** ClefNote implements clef annotations in measures. */
 export class ClefNote extends Note {
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.ClefNote;
   }
 
@@ -34,13 +34,13 @@ export class ClefNote extends Note {
     return this.clef;
   }
 
-  preFormat(): this {
+  override preFormat(): this {
     this.preFormatted = true;
     return this;
   }
 
   /** Render clef note. */
-  draw(): void {
+  override draw(): void {
     const stave = this.checkStave();
     const ctx = this.checkContext();
 
@@ -50,7 +50,7 @@ export class ClefNote extends Note {
     this.clef.renderText(ctx, 0, 0);
   }
 
-  getBoundingBox(): BoundingBox {
+  override getBoundingBox(): BoundingBox {
     return this.clef.getBoundingBox();
   }
 }

--- a/src/crescendo.ts
+++ b/src/crescendo.ts
@@ -53,7 +53,7 @@ export class Crescendo extends Note {
   static DEBUG: boolean = false;
 
   /** Crescendo category string. */
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.Crescendo;
   }
 
@@ -101,13 +101,13 @@ export class Crescendo extends Note {
   }
 
   // Preformat the note
-  preFormat(): this {
+  override preFormat(): this {
     this.preFormatted = true;
     return this;
   }
 
   // Render the Crescendo object onto the canvas
-  draw(): void {
+  override draw(): void {
     const ctx = this.checkContext();
     const stave = this.checkStave();
     this.setRendered();

--- a/src/curve.ts
+++ b/src/curve.ts
@@ -25,7 +25,7 @@ export enum CurvePosition {
 }
 
 export class Curve extends Element {
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.Curve;
   }
 
@@ -130,7 +130,7 @@ export class Curve extends Element {
     if (!this.style?.lineDash) ctx.fill();
   }
 
-  draw(): boolean {
+  override draw(): boolean {
     this.checkContext();
     this.setRendered();
 

--- a/src/dot.ts
+++ b/src/dot.ts
@@ -10,7 +10,7 @@ import { Category, isStaveNote, isTabNote } from './typeguard';
 import { RuntimeError } from './util';
 
 export class Dot extends Modifier {
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.Dot;
   }
 
@@ -137,7 +137,7 @@ export class Dot extends Modifier {
     this.dotShiftY = 0;
   }
 
-  setNote(note: Note): this {
+  override setNote(note: Note): this {
     this.note = note;
     this.font = note.font;
     return this;
@@ -148,7 +148,7 @@ export class Dot extends Modifier {
     return this;
   }
 
-  draw(): void {
+  override draw(): void {
     const ctx = this.checkContext();
     const note = this.checkAttachedNote();
     this.setRendered();

--- a/src/element.ts
+++ b/src/element.ts
@@ -353,7 +353,7 @@ export class Element {
   drawPointerRect() {
     if (this.shouldDrawPointerRect) {
       const bb = this.getBoundingBox();
-      this.context?.pointerRect(bb.getX(), bb.getY(), bb.getW(), bb.getH());  
+      this.context?.pointerRect(bb.getX(), bb.getY(), bb.getW(), bb.getH());
     }
   }
 

--- a/src/flag.ts
+++ b/src/flag.ts
@@ -18,12 +18,12 @@ export class Flag extends Element {
   /** To enable logging for this class. Set `VexFlow.NoteHead.DEBUG` to `true`. */
   static DEBUG: boolean = false;
 
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.Flag;
   }
 
   /** Draw the notehead. */
-  draw(): void {
+  override draw(): void {
     const ctx = this.checkContext();
     this.setRendered();
     ctx.openGroup('flag', this.getAttribute('id'));

--- a/src/frethandfinger.ts
+++ b/src/frethandfinger.ts
@@ -12,7 +12,7 @@ import { Category } from './typeguard';
 import { RuntimeError } from './util';
 
 export class FretHandFinger extends Modifier {
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.FretHandFinger;
   }
 
@@ -147,7 +147,7 @@ export class FretHandFinger extends Modifier {
     return this;
   }
 
-  draw(): void {
+  override draw(): void {
     const ctx = this.checkContext();
     const note = this.checkAttachedNote();
     this.setRendered();

--- a/src/ghostnote.ts
+++ b/src/ghostnote.ts
@@ -12,7 +12,7 @@ import { RuntimeError } from './util';
 const ERROR_MSG = 'Ghost note must have valid initialization data to identify duration.';
 
 export class GhostNote extends StemmableNote {
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.GhostNote;
   }
 
@@ -40,28 +40,28 @@ export class GhostNote extends StemmableNote {
   /**
    * @returns true if this note is a type of rest. Rests don't have pitches, but take up space in the score.
    */
-  isRest(): boolean {
+  override isRest(): boolean {
     return true;
   }
 
-  setStave(stave: Stave): this {
+  override setStave(stave: Stave): this {
     super.setStave(stave);
     return this;
   }
 
   /* Overridden to ignore */
   // eslint-disable-next-line
-  addToModifierContext(mc: ModifierContext): this {
+  override addToModifierContext(mc: ModifierContext): this {
     // DO NOTHING.
     return this;
   }
 
-  preFormat(): this {
+  override preFormat(): this {
     this.preFormatted = true;
     return this;
   }
 
-  draw(): void {
+  override draw(): void {
     // Draw Annotations
     this.setRendered();
     for (let i = 0; i < this.modifiers.length; ++i) {

--- a/src/glyphnote.ts
+++ b/src/glyphnote.ts
@@ -11,7 +11,7 @@ export interface GlyphNoteOptions {
 }
 
 export class GlyphNote extends Note {
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.GlyphNote;
   }
 
@@ -35,7 +35,7 @@ export class GlyphNote extends Note {
     return this;
   }
 
-  preFormat(): this {
+  override preFormat(): this {
     if (!this.preFormatted && this.modifierContext) {
       this.modifierContext.preFormat();
     }
@@ -52,7 +52,7 @@ export class GlyphNote extends Note {
     }
   }
 
-  draw(): void {
+  override draw(): void {
     const stave = this.checkStave();
     const ctx = stave.checkContext();
     this.setRendered();

--- a/src/gracenote.ts
+++ b/src/gracenote.ts
@@ -11,11 +11,11 @@ export interface GraceNoteStruct extends StaveNoteStruct {
 }
 
 export class GraceNote extends StaveNote {
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.GraceNote;
   }
 
-  static get LEDGER_LINE_OFFSET(): number {
+  static override get LEDGER_LINE_OFFSET(): number {
     return 2;
   }
 
@@ -36,7 +36,7 @@ export class GraceNote extends StaveNote {
     this.width = 3;
   }
 
-  getStemExtension(): number {
+  override getStemExtension(): number {
     if (this.stemExtensionOverride) {
       return this.stemExtensionOverride;
     }
@@ -46,7 +46,7 @@ export class GraceNote extends StaveNote {
     return ret;
   }
 
-  draw(): void {
+  override draw(): void {
     super.draw();
     this.setRendered();
     const stem = this.stem;

--- a/src/gracenotegroup.ts
+++ b/src/gracenotegroup.ts
@@ -30,7 +30,7 @@ function L(...args: any) {
 export class GraceNoteGroup extends Modifier {
   static DEBUG: boolean = false;
 
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.GraceNoteGroup;
   }
 
@@ -152,12 +152,12 @@ export class GraceNoteGroup extends Modifier {
     return this;
   }
 
-  setWidth(width: number): this {
+  override setWidth(width: number): this {
     this.width = width;
     return this;
   }
 
-  getWidth(): number {
+  override getWidth(): number {
     return this.width + StaveNote.minNoteheadPadding;
   }
 
@@ -165,7 +165,7 @@ export class GraceNoteGroup extends Modifier {
     return this.graceNotes;
   }
 
-  draw(): void {
+  override draw(): void {
     const ctx: RenderContext = this.checkContext();
     const note = this.checkAttachedNote();
     this.setRendered();

--- a/src/gracetabnote.ts
+++ b/src/gracetabnote.ts
@@ -12,7 +12,7 @@ import { TabNote, TabNoteStruct } from './tabnote';
 import { Category } from './typeguard';
 
 export class GraceTabNote extends TabNote {
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.GraceTabNote;
   }
 

--- a/src/keysignature.ts
+++ b/src/keysignature.ts
@@ -16,7 +16,7 @@ import { Category } from './typeguard';
 import { defined } from './util';
 
 export class KeySignature extends StaveModifier {
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.KeySignature;
   }
 
@@ -125,13 +125,13 @@ export class KeySignature extends StaveModifier {
   }
 
   // Add this key signature to a stave.
-  setStave(stave: Stave): this {
+  override setStave(stave: Stave): this {
     this.formatted = false;
     return super.setStave(stave);
   }
 
   // Get the `BoundingBox`
-  getBoundingBox(): BoundingBox {
+  override getBoundingBox(): BoundingBox {
     if (!this.formatted) this.format();
 
     return super.getBoundingBox();
@@ -203,14 +203,14 @@ export class KeySignature extends StaveModifier {
   }
 
   // Get the padding required for this modifier
-  getPadding(index: number): number {
+  override getPadding(index: number): number {
     if (!this.formatted) this.format();
 
     return this.children.length === 0 || (!this.paddingForced && index < 2) ? 0 : this.padding;
   }
 
   // Get the width of the modifier
-  getWidth(): number {
+  override getWidth(): number {
     if (!this.formatted) this.format();
 
     return this.width;
@@ -287,7 +287,7 @@ export class KeySignature extends StaveModifier {
   }
 
   // Render the key signature
-  draw(): void {
+  override draw(): void {
     const stave = this.checkStave();
     const ctx = stave.checkContext();
 

--- a/src/keysignote.ts
+++ b/src/keysignote.ts
@@ -7,7 +7,7 @@ import { Note } from './note';
 import { Category } from './typeguard';
 
 export class KeySigNote extends Note {
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.KeySigNote;
   }
 
@@ -24,19 +24,19 @@ export class KeySigNote extends Note {
 
   /* Overridden to ignore */
   // eslint-disable-next-line
-  addToModifierContext(mc: ModifierContext): this {
+  override addToModifierContext(mc: ModifierContext): this {
     // DO NOTHING.
     return this;
   }
 
-  preFormat(): this {
+  override preFormat(): this {
     this.preFormatted = true;
     this.keySignature.setStave(this.checkStave());
     this.setWidth(this.keySignature.getWidth());
     return this;
   }
 
-  draw(): void {
+  override draw(): void {
     const ctx = this.checkStave().checkContext();
     this.setRendered();
     this.keySignature.setX(this.getAbsoluteX());

--- a/src/modifier.ts
+++ b/src/modifier.ts
@@ -35,7 +35,7 @@ export class Modifier extends Element {
    * Modifiers category string. Every modifier has a different category.
    * The `ModifierContext` uses this to determine the type and order of the modifiers.
    */
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.Modifier;
   }
 
@@ -158,7 +158,7 @@ export class Modifier extends Element {
   }
 
   /** Shift modifier down `y` pixels. Negative values shift up. */
-  setYShift(y: number): this {
+  override setYShift(y: number): this {
     this.yShift = y;
     return this;
   }
@@ -177,7 +177,7 @@ export class Modifier extends Element {
    * Shift modifier `x` pixels in the direction of the modifier. Negative values
    * shift reverse.
    */
-  setXShift(x: number): this {
+  override setXShift(x: number): this {
     this.xShift = 0;
     if (this.position === Modifier.Position.LEFT) {
       this.xShift -= x;
@@ -188,12 +188,12 @@ export class Modifier extends Element {
   }
 
   /** Get shift modifier `x` */
-  getXShift(): number {
+  override getXShift(): number {
     return this.xShift;
   }
 
   /** Render the modifier onto the canvas. */
-  draw(): void {
+  override draw(): void {
     this.checkContext();
     throw new RuntimeError('NotImplemented', 'draw() not implemented for this modifier.');
   }

--- a/src/multimeasurerest.ts
+++ b/src/multimeasurerest.ts
@@ -54,7 +54,7 @@ export interface MultimeasureRestRenderOptions {
 }
 
 export class MultiMeasureRest extends Element {
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.MultiMeasureRest;
   }
 
@@ -187,7 +187,7 @@ export class MultiMeasureRest extends Element {
     x += elTop.getWidth();
   }
 
-  draw(): void {
+  override draw(): void {
     const ctx = this.checkContext();
     this.setRendered();
 

--- a/src/note.ts
+++ b/src/note.ts
@@ -92,7 +92,7 @@ export abstract class Note extends Tickable {
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // STATIC MEMBERS
 
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.Note;
   }
 
@@ -412,7 +412,7 @@ export abstract class Note extends Tickable {
   }
 
   /** True if this note has no duration (e.g., bar notes, spacers, etc.). */
-  shouldIgnoreTicks(): boolean {
+  override shouldIgnoreTicks(): boolean {
     return this.ignoreTicks;
   }
 
@@ -467,13 +467,13 @@ export abstract class Note extends Tickable {
   }
 
   /** Return the voice that this note belongs in. */
-  getVoice(): Voice {
+  override getVoice(): Voice {
     if (!this.voice) throw new RuntimeError('NoVoice', 'Note has no voice.');
     return this.voice;
   }
 
   /** Attach this note to `voice`. */
-  setVoice(voice: Voice): this {
+  override setVoice(voice: Voice): this {
     this.voice = voice;
     this.preFormatted = false;
     return this;
@@ -485,7 +485,7 @@ export abstract class Note extends Tickable {
   }
 
   /** Set the `TickContext` for this note. */
-  setTickContext(tc: TickContext): this {
+  override setTickContext(tc: TickContext): this {
     this.tickContext = tc;
     this.preFormatted = false;
     return this;
@@ -538,7 +538,7 @@ export abstract class Note extends Tickable {
    * @param index of the key to modify.
    * @returns this
    */
-  addModifier(modifier: Modifier, index: number = 0): this {
+  override addModifier(modifier: Modifier, index: number = 0): this {
     const signature = 'Note.addModifier(modifier: Modifier, index: number=0)';
     // Backwards compatibility with 3.0.9.
     if (typeof index === 'string') {
@@ -636,7 +636,7 @@ export abstract class Note extends Tickable {
    * excludes xShift, so you'll need to factor it in if you're
    * looking for the post-formatted x-position.
    */
-  getAbsoluteX(): number {
+  override getAbsoluteX(): number {
     const tickContext = this.checkTickContext(`Can't getAbsoluteX() without a TickContext.`);
     // Position note to left edge of tick context.
     let x = tickContext.getX();
@@ -690,7 +690,7 @@ export abstract class Note extends Tickable {
   }
 
   // Get the `BoundingBox` for the entire note
-  getBoundingBox(): BoundingBox {
+  override getBoundingBox(): BoundingBox {
     const boundingBox = super.getBoundingBox();
     for (let i = 0; i < this.modifiers.length; i++) {
       boundingBox.mergeWith(this.modifiers[i].getBoundingBox());

--- a/src/notehead.ts
+++ b/src/notehead.ts
@@ -37,7 +37,7 @@ export class NoteHead extends Note {
   /** To enable logging for this class. Set `VexFlow.NoteHead.DEBUG` to `true`. */
   static DEBUG: boolean = false;
 
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.NoteHead;
   }
 
@@ -93,7 +93,7 @@ export class NoteHead extends Note {
     };
   }
   /** Get the width of the notehead. */
-  getWidth(): number {
+  override getWidth(): number {
     return this.width;
   }
 
@@ -114,7 +114,7 @@ export class NoteHead extends Note {
   }
 
   /** Get the canvas `x` coordinate position of the notehead. */
-  getAbsoluteX(): number {
+  override getAbsoluteX(): number {
     // If the note has not been preformatted, then get the static x value
     // Otherwise, it's been formatted and we should use it's x value relative
     // to its tick context
@@ -128,7 +128,7 @@ export class NoteHead extends Note {
   }
 
   /** Set notehead to a provided `stave`. */
-  setStave(stave: Stave): this {
+  override setStave(stave: Stave): this {
     const line = this.getLine();
 
     this.stave = stave;
@@ -140,7 +140,7 @@ export class NoteHead extends Note {
   }
 
   /** Pre-render formatting. */
-  preFormat(): this {
+  override preFormat(): this {
     if (this.preFormatted) return this;
 
     this.preFormatted = true;
@@ -148,7 +148,7 @@ export class NoteHead extends Note {
   }
 
   /** Draw the notehead. */
-  draw(): void {
+  override draw(): void {
     const ctx = this.checkContext();
     this.setRendered();
     ctx.openGroup('notehead', this.getAttribute('id'));

--- a/src/notesubgroup.ts
+++ b/src/notesubgroup.ts
@@ -17,7 +17,7 @@ import { Category } from './typeguard';
 import { Voice } from './voice';
 
 export class NoteSubGroup extends Modifier {
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.NoteSubGroup;
   }
 
@@ -69,16 +69,16 @@ export class NoteSubGroup extends Modifier {
     this.preFormatted = true;
   }
 
-  setWidth(width: number): this {
+  override setWidth(width: number): this {
     this.width = width;
     return this;
   }
 
-  getWidth(): number {
+  override getWidth(): number {
     return this.width;
   }
 
-  draw(): void {
+  override draw(): void {
     const ctx: RenderContext = this.checkContext();
     const note = this.checkAttachedNote();
     this.setRendered();

--- a/src/ornament.ts
+++ b/src/ornament.ts
@@ -31,7 +31,7 @@ export class Ornament extends Modifier {
   static DEBUG: boolean = false;
 
   /** Ornaments category string. */
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.Ornament;
   }
   static get minPadding(): number {
@@ -182,7 +182,7 @@ export class Ornament extends Modifier {
   }
 
   /** Set note attached to ornament. */
-  setNote(note: Note): this {
+  override setNote(note: Note): this {
     super.setNote(note);
     // articulations above/below the line can be stacked.
     if (Ornament.ornamentArticulation.indexOf(this.type) >= 0) {
@@ -218,7 +218,7 @@ export class Ornament extends Modifier {
   }
 
   /** Render ornament in position next to note. */
-  draw(): void {
+  override draw(): void {
     const ctx = this.checkContext();
     const note = this.checkAttachedNote() as StemmableNote;
     this.setRendered();

--- a/src/parenthesis.ts
+++ b/src/parenthesis.ts
@@ -9,7 +9,7 @@ import { Category } from './typeguard';
 
 /** Parenthesis implements parenthesis modifiers for notes. */
 export class Parenthesis extends Modifier {
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.Parenthesis;
   }
 
@@ -71,14 +71,14 @@ export class Parenthesis extends Modifier {
   }
 
   /** Set the associated note. */
-  setNote(note: Note): this {
+  override setNote(note: Note): this {
     this.note = note;
     this.setFont(note.getFont());
     return this;
   }
 
   /** Render the parenthesis. */
-  draw(): void {
+  override draw(): void {
     const ctx = this.checkContext();
     const note = this.checkAttachedNote();
     this.setRendered();

--- a/src/pedalmarking.ts
+++ b/src/pedalmarking.ts
@@ -24,7 +24,7 @@ export class PedalMarking extends Element {
   /** To enable logging for this class. Set `VexFlow.PedalMarking.DEBUG` to `true`. */
   static DEBUG: boolean = false;
 
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.PedalMarking;
   }
 
@@ -244,7 +244,7 @@ export class PedalMarking extends Element {
   }
 
   /** Render the pedal marking in position on the rendering context. */
-  draw(): void {
+  override draw(): void {
     const ctx = this.checkContext();
     this.setRendered();
 

--- a/src/repeatnote.ts
+++ b/src/repeatnote.ts
@@ -14,7 +14,7 @@ const CODES: Record<string, string> = {
 };
 
 export class RepeatNote extends GlyphNote {
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.RepeatNote;
   }
 

--- a/src/stave.ts
+++ b/src/stave.ts
@@ -53,7 +53,7 @@ const SORT_ORDER_END_MODIFIERS = {
 };
 
 export class Stave extends Element {
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.Stave;
   }
 
@@ -188,7 +188,7 @@ export class Stave extends Element {
     return this.getYForLine(this.getNumLines() - 1) + (this.getStyle().lineWidth ?? 1);
   }
 
-  setX(x: number): this {
+  override setX(x: number): this {
     const shift = x - this.x;
     this.formatted = false;
     this.x = x;
@@ -201,7 +201,7 @@ export class Stave extends Element {
     return this;
   }
 
-  setWidth(width: number): this {
+  override setWidth(width: number): this {
     this.formatted = false;
     this.width = width;
     this.endX = this.x + width;
@@ -303,7 +303,7 @@ export class Stave extends Element {
     return this.options.spacingBetweenLinesPx;
   }
 
-  getBoundingBox(): BoundingBox {
+  override getBoundingBox(): BoundingBox {
     return new BoundingBox(this.x, this.y, this.width, this.getBottomY() - this.y);
   }
 
@@ -676,7 +676,7 @@ export class Stave extends Element {
   /**
    * All drawing functions below need the context to be set.
    */
-  draw(): void {
+  override draw(): void {
     const ctx = this.checkContext();
     this.setRendered();
 

--- a/src/stavebarline.ts
+++ b/src/stavebarline.ts
@@ -18,7 +18,7 @@ export enum BarlineType {
 }
 
 export class Barline extends StaveModifier {
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.Barline;
   }
 
@@ -129,7 +129,7 @@ export class Barline extends StaveModifier {
   }
 
   // Draw barlines
-  draw(): void {
+  override draw(): void {
     const stave = this.checkStave();
     const ctx = stave.checkContext();
     this.setRendered();

--- a/src/staveconnector.ts
+++ b/src/staveconnector.ts
@@ -55,7 +55,7 @@ export type StaveConnectorType =
 
 /** StaveConnector implements the connector lines between staves of a system. */
 export class StaveConnector extends Element {
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.StaveConnector;
   }
 
@@ -149,7 +149,7 @@ export class StaveConnector extends Element {
   }
 
   /** Set optional associated Text. */
-  setText(text: string, options: { shiftX?: number; shiftY?: number } = {}): this {
+  override setText(text: string, options: { shiftX?: number; shiftY?: number } = {}): this {
     const textElement = new Element('StaveConnector.text');
     textElement.setText(text);
     textElement.setXShift(options.shiftX ?? 0);
@@ -159,7 +159,7 @@ export class StaveConnector extends Element {
   }
 
   /** Render connector and associated text. */
-  draw(): void {
+  override draw(): void {
     const ctx = this.checkContext();
     this.setRendered();
 

--- a/src/stavehairpin.ts
+++ b/src/stavehairpin.ts
@@ -23,7 +23,7 @@ export interface StaveHairpinRenderOptions {
 }
 
 export class StaveHairpin extends Element {
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.StaveHairpin;
   }
 
@@ -187,7 +187,7 @@ export class StaveHairpin extends Element {
     ctx.closePath();
   }
 
-  draw(): void {
+  override draw(): void {
     this.checkContext();
     this.setRendered();
 

--- a/src/staveline.ts
+++ b/src/staveline.ts
@@ -49,7 +49,7 @@ function drawArrowHead(
 }
 
 export class StaveLine extends Element {
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.StaveLine;
   }
 
@@ -132,7 +132,7 @@ export class StaveLine extends Element {
   }
 
   // The the annotation for the `StaveLine`
-  setText(text: string): this {
+  override setText(text: string): this {
     this.text = text;
     return this;
   }
@@ -261,7 +261,7 @@ export class StaveLine extends Element {
   }
 
   // Renders the `StaveLine` on the context
-  draw(): void {
+  override draw(): void {
     const ctx = this.checkContext();
     this.setRendered();
 

--- a/src/stavemodifier.ts
+++ b/src/stavemodifier.ts
@@ -26,7 +26,7 @@ export enum StaveModifierPosition {
 }
 
 export class StaveModifier extends Element {
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.StaveModifier;
   }
 

--- a/src/stavenote.ts
+++ b/src/stavenote.ts
@@ -90,7 +90,7 @@ function centerRest(rest: StaveNoteFormatSettings, noteU: StaveNoteFormatSetting
 export class StaveNote extends StemmableNote {
   static DEBUG: boolean = false;
 
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.StaveNote;
   }
 
@@ -426,7 +426,7 @@ export class StaveNote extends StemmableNote {
     this.buildFlag();
   }
 
-  reset(): this {
+  override reset(): this {
     super.reset();
 
     // Save prior noteHead styles & reapply them after making new noteheads.
@@ -445,7 +445,7 @@ export class StaveNote extends StemmableNote {
     return this;
   }
 
-  setBeam(beam: Beam): this {
+  override setBeam(beam: Beam): this {
     this.beam = beam;
     this.calcNoteDisplacements();
     // Update stem extension if a beam is assigned.
@@ -456,7 +456,7 @@ export class StaveNote extends StemmableNote {
   }
 
   // Builds a `Stem` for the note
-  buildStem(): this {
+  override buildStem(): this {
     this.setStem(new Stem({ hide: this.isRest() }));
     return this;
   }
@@ -594,7 +594,7 @@ export class StaveNote extends StemmableNote {
   }
 
   // Get the `BoundingBox` for the entire note
-  getBoundingBox(): BoundingBox {
+  override getBoundingBox(): BoundingBox {
     const boundingBox = new BoundingBox(this.getAbsoluteX(), this.ys[0], 0, 0);
     this._noteHeads.forEach((notehead) => {
       boundingBox.mergeWith(notehead.getBoundingBox());
@@ -621,7 +621,7 @@ export class StaveNote extends StemmableNote {
 
   // Gets the line number of the bottom note in the chord.
   // If `isTopNote` is `true` then get the top note's line number instead
-  getLineNumber(isTopNote?: boolean): number {
+  override getLineNumber(isTopNote?: boolean): number {
     if (!this.keyProps.length) {
       throw new RuntimeError('NoKeyProps', "Can't get bottom note line, because note is not initialized properly.");
     }
@@ -644,7 +644,7 @@ export class StaveNote extends StemmableNote {
   /**
    * @returns true if this note is a type of rest. Rests don't have pitches, but take up space in the score.
    */
-  isRest(): boolean {
+  override isRest(): boolean {
     const val = this.glyphProps.codeHead;
     return val >= '\ue4e0' && val <= '\ue4ff';
   }
@@ -655,15 +655,15 @@ export class StaveNote extends StemmableNote {
   }
 
   // Determine if the `StaveNote` has a stem
-  hasStem(): boolean {
+  override hasStem(): boolean {
     return this.glyphProps.stem;
   }
 
-  hasFlag(): boolean {
+  override hasFlag(): boolean {
     return super.hasFlag() && !this.isRest();
   }
 
-  getStemX(): number {
+  override getStemX(): number {
     if (this.noteType === 'r') {
       return this.getCenterGlyphX();
     } else {
@@ -675,14 +675,14 @@ export class StaveNote extends StemmableNote {
 
   // Get the `y` coordinate for text placed on the top/bottom of a
   // note at a desired `textLine`
-  getYForTopText(textLine: number): number {
+  override getYForTopText(textLine: number): number {
     const extents = this.getStemExtents();
     return Math.min(
       this.checkStave().getYForTopText(textLine),
       extents.topY - this.renderOptions.annotationSpacing * (textLine + 1)
     );
   }
-  getYForBottomText(textLine: number): number {
+  override getYForBottomText(textLine: number): number {
     const extents = this.getStemExtents();
     return Math.max(
       this.checkStave().getYForTopText(textLine),
@@ -692,7 +692,7 @@ export class StaveNote extends StemmableNote {
 
   // Sets the current note to the provided `stave`. This applies
   // `y` values to the `NoteHeads`.
-  setStave(stave: Stave): this {
+  override setStave(stave: Stave): this {
     super.setStave(stave);
 
     const ys = this._noteHeads.map((notehead) => {
@@ -722,7 +722,7 @@ export class StaveNote extends StemmableNote {
   }
 
   // Get the starting `x` coordinate for a `StaveTie`
-  getTieRightX(): number {
+  override getTieRightX(): number {
     let tieStartX = this.getAbsoluteX();
     tieStartX += this.getGlyphWidth() + this.xShift + this.rightDisplacedHeadPx;
     if (this.modifierContext) tieStartX += this.modifierContext.getRightShift();
@@ -730,14 +730,14 @@ export class StaveNote extends StemmableNote {
   }
 
   // Get the ending `x` coordinate for a `StaveTie`
-  getTieLeftX(): number {
+  override getTieLeftX(): number {
     let tieEndX = this.getAbsoluteX();
     tieEndX += this.xShift - this.leftDisplacedHeadPx;
     return tieEndX;
   }
 
   // Get the stave line on which to place a rest
-  getLineForRest(): number {
+  override getLineForRest(): number {
     let restLine = this.keyProps[0].line;
     if (this.keyProps.length > 1) {
       const lastLine = this.keyProps[this.keyProps.length - 1].line;
@@ -751,7 +751,7 @@ export class StaveNote extends StemmableNote {
 
   // Get the default `x` and `y` coordinates for the provided `position`
   // and key `index`
-  getModifierStartXY(
+  override getModifierStartXY(
     position: number,
     index: number,
     options: { forceFlagRight?: boolean } = {}
@@ -820,7 +820,7 @@ export class StaveNote extends StemmableNote {
 
   // Sets the style of the complete StaveNote, including all keys
   // and the stem.
-  setStyle(style: ElementStyle): this {
+  override setStyle(style: ElementStyle): this {
     return super.setGroupStyle(style);
   }
 
@@ -849,7 +849,7 @@ export class StaveNote extends StemmableNote {
   }
 
   /** Get the glyph width. */
-  getGlyphWidth(): number {
+  override getGlyphWidth(): number {
     return this.noteHeads[0].getWidth();
   }
 
@@ -892,7 +892,7 @@ export class StaveNote extends StemmableNote {
   }
 
   // Pre-render formatting
-  preFormat(): void {
+  override preFormat(): void {
     if (this.preFormatted) return;
 
     let noteHeadPadding = 0;
@@ -1125,7 +1125,7 @@ export class StaveNote extends StemmableNote {
     });
   }
 
-  drawStem(stemOptions?: StemOptions): void {
+  override drawStem(stemOptions?: StemOptions): void {
     // GCR TODO: I can't find any context in which this is called with the stemStruct
     // argument in the codebase or tests. Nor can I find a case where super.drawStem
     // is called at all. Perhaps these should be removed?
@@ -1149,7 +1149,7 @@ export class StaveNote extends StemmableNote {
   /**
    * Override stemmablenote stem extension to adjust for distance from middle line.
    */
-  getStemExtension(): number {
+  override getStemExtension(): number {
     const superStemExtension = super.getStemExtension();
     if (!this.glyphProps.stem) {
       return superStemExtension;
@@ -1188,7 +1188,7 @@ export class StaveNote extends StemmableNote {
   }
 
   // Draws all the `StaveNote` parts. This is the main drawing method.
-  draw(): void {
+  override draw(): void {
     if (this.renderOptions.draw === false) return;
 
     if (this.ys.length === 0) {

--- a/src/staverepetition.ts
+++ b/src/staverepetition.ts
@@ -8,7 +8,7 @@ import { StaveModifier } from './stavemodifier';
 import { Category } from './typeguard';
 
 export class Repetition extends StaveModifier {
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.Repetition;
   }
 
@@ -30,8 +30,8 @@ export class Repetition extends StaveModifier {
 
   protected symbolType: number;
 
-  protected xShift: number;
-  protected yShift: number;
+  protected override xShift: number;
+  protected override yShift: number;
 
   constructor(type: number, x: number, yShift: number) {
     super();
@@ -52,7 +52,7 @@ export class Repetition extends StaveModifier {
     return this;
   }
 
-  draw(): void {
+  override draw(): void {
     const stave = this.checkStave();
     const x = stave.getModifierXShift(this.getPosition());
     this.setRendered();

--- a/src/stavesection.ts
+++ b/src/stavesection.ts
@@ -6,7 +6,7 @@ import { StaveModifier } from './stavemodifier';
 import { Category } from './typeguard';
 
 export class StaveSection extends StaveModifier {
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.StaveSection;
   }
 
@@ -27,7 +27,7 @@ export class StaveSection extends StaveModifier {
     return this;
   }
 
-  draw(): void {
+  override draw(): void {
     const stave = this.checkStave();
     const ctx = stave.checkContext();
     this.setRendered();

--- a/src/stavetempo.ts
+++ b/src/stavetempo.ts
@@ -43,7 +43,7 @@ export interface StaveTempoOptions {
 }
 
 export class StaveTempo extends StaveModifier {
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.StaveTempo;
   }
   protected tempo: StaveTempoOptions;
@@ -95,7 +95,7 @@ export class StaveTempo extends StaveModifier {
     return this;
   }
 
-  draw(): void {
+  override draw(): void {
     const stave = this.checkStave();
     const shiftX = stave.getModifierXShift(this.getPosition());
     const ctx = stave.checkContext();

--- a/src/stavetext.ts
+++ b/src/stavetext.ts
@@ -7,7 +7,7 @@ import { Category } from './typeguard';
 import { RuntimeError } from './util';
 
 export class StaveText extends StaveModifier {
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.StaveText;
   }
 
@@ -27,7 +27,7 @@ export class StaveText extends StaveModifier {
     this.justification = options.justification ?? TextNote.Justification.CENTER;
   }
 
-  draw(): void {
+  override draw(): void {
     const stave = this.checkStave();
     const ctx = stave.checkContext();
     this.setRendered();

--- a/src/stavetie.ts
+++ b/src/stavetie.ts
@@ -19,7 +19,7 @@ export interface TieNotes {
 }
 
 export class StaveTie extends Element {
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.StaveTie;
   }
 
@@ -277,7 +277,7 @@ export class StaveTie extends Element {
     }
   }
 
-  draw(): boolean {
+  override draw(): boolean {
     this.checkContext();
     this.setRendered();
     this.synchronizeIndexes();

--- a/src/stavevolta.ts
+++ b/src/stavevolta.ts
@@ -13,7 +13,7 @@ export enum VoltaType {
 }
 
 export class Volta extends StaveModifier {
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.Volta;
   }
 
@@ -31,7 +31,7 @@ export class Volta extends StaveModifier {
     this.text = label;
   }
 
-  draw(): void {
+  override draw(): void {
     const stave = this.checkStave();
     const x = stave.getModifierXShift(this.getPosition());
     const ctx = stave.checkContext();

--- a/src/stem.ts
+++ b/src/stem.ts
@@ -36,7 +36,7 @@ export class Stem extends Element {
   /** To enable logging for this class. Set `VexFlow.Stem.DEBUG` to `true`. */
   static DEBUG: boolean = false;
 
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.Stem;
   }
 
@@ -136,13 +136,13 @@ export class Stem extends Element {
   }
 
   // Gets the entire height for the stem
-  getHeight(): number {
+  override getHeight(): number {
     const yOffset = this.stemDirection === Stem.UP ? this.stemUpYOffset : this.stemDownYOffset;
     const unsignedHeight = this.yBottom - this.yTop + (Stem.HEIGHT - yOffset + this.stemExtension); // parentheses just for grouping.
     return unsignedHeight * this.stemDirection;
   }
 
-  getBoundingBox(): BoundingBox {
+  override getBoundingBox(): BoundingBox {
     throw new RuntimeError('NotImplemented', 'getBoundingBox() not implemented.');
   }
 
@@ -180,7 +180,7 @@ export class Stem extends Element {
   }
 
   // Render the stem onto the canvas
-  draw(): void {
+  override draw(): void {
     this.setRendered();
     if (this.hide) return;
     const ctx = this.checkContext();

--- a/src/stemmablenote.ts
+++ b/src/stemmablenote.ts
@@ -13,7 +13,7 @@ import { Category } from './typeguard';
 import { RuntimeError } from './util';
 
 export abstract class StemmableNote extends Note {
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.StemmableNote;
   }
 
@@ -129,7 +129,7 @@ export abstract class StemmableNote extends Note {
   }
 
   // Get/set the direction of the stem
-  getStemDirection(): number {
+  override getStemDirection(): number {
     if (!this.stemDirection) throw new RuntimeError('NoStem', 'No stem attached to this note.');
     return this.stemDirection;
   }
@@ -200,13 +200,13 @@ export abstract class StemmableNote extends Note {
   }
 
   // Get the top and bottom `y` values of the stem.
-  getStemExtents(): { topY: number; baseY: number } {
+  override getStemExtents(): { topY: number; baseY: number } {
     if (!this.stem) throw new RuntimeError('NoStem', 'No stem attached to this note.');
     return this.stem.getExtents();
   }
 
   /** Gets the `y` value for the top modifiers at a specific `textLine`. */
-  getYForTopText(textLine: number): number {
+  override getYForTopText(textLine: number): number {
     const stave = this.checkStave();
     if (this.hasStem()) {
       const extents = this.getStemExtents();
@@ -239,7 +239,7 @@ export abstract class StemmableNote extends Note {
   }
 
   /** Post formats the note. */
-  postFormat(): this {
+  override postFormat(): this {
     this.beam?.postFormat();
     this.postFormatted = true;
     return this;

--- a/src/stringnumber.ts
+++ b/src/stringnumber.ts
@@ -16,7 +16,7 @@ import { Category, isStaveNote, isStemmableNote } from './typeguard';
 import { RuntimeError } from './util';
 
 export class StringNumber extends Modifier {
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.StringNumber;
   }
 
@@ -132,7 +132,7 @@ export class StringNumber extends Modifier {
   protected stringNumber: string;
   protected xOffset: number;
   protected yOffset: number;
-  protected textLine: number;
+  protected override textLine: number;
   protected stemOffset: number;
   protected dashed: boolean;
   protected leg: number;
@@ -192,7 +192,7 @@ export class StringNumber extends Modifier {
     return this;
   }
 
-  draw(): void {
+  override draw(): void {
     const ctx = this.checkContext();
     const note = this.checkAttachedNote();
     this.setRendered();

--- a/src/strokes.ts
+++ b/src/strokes.ts
@@ -14,7 +14,7 @@ import { Category, isNote, isStaveNote, isTabNote } from './typeguard';
 import { RuntimeError } from './util';
 
 export class Stroke extends Modifier {
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.Stroke;
   }
 
@@ -93,7 +93,7 @@ export class Stroke extends Modifier {
     this.setWidth(10);
   }
 
-  getPosition(): number {
+  override getPosition(): number {
     return this.position;
   }
 
@@ -102,7 +102,7 @@ export class Stroke extends Modifier {
     return this;
   }
 
-  draw(): void {
+  override draw(): void {
     const ctx = this.checkContext();
     const note = this.checkAttachedNote();
     this.setRendered();

--- a/src/system.ts
+++ b/src/system.ts
@@ -67,7 +67,7 @@ export interface SystemOptions {
  * the system are formatted together.
  */
 export class System extends Element {
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.System;
   }
 
@@ -123,12 +123,12 @@ export class System extends Element {
   }
 
   /** Get origin X. */
-  getX(): number {
+  override getX(): number {
     return this.options.x;
   }
 
   /** Set origin X. */
-  setX(x: number): this {
+  override setX(x: number): this {
     this.options.x = x;
     this.partStaves.forEach((s) => {
       s.setX(x);
@@ -137,12 +137,12 @@ export class System extends Element {
   }
 
   /** Get origin y. */
-  getY(): number {
+  override getY(): number {
     return this.options.y;
   }
 
   /** Set origin y. */
-  setY(y: number): this {
+  override setY(y: number): this {
     this.options.y = y;
     this.partStaves.forEach((s) => {
       s.setY(y);
@@ -161,7 +161,7 @@ export class System extends Element {
   }
 
   /** Set associated context. */
-  setContext(context: RenderContext): this {
+  override setContext(context: RenderContext): this {
     super.setContext(context);
     this.factory.setContext(context);
     return this;
@@ -299,12 +299,12 @@ export class System extends Element {
   }
 
   /** Get the boundingBox. */
-  getBoundingBox(): BoundingBox {
+  override getBoundingBox(): BoundingBox {
     return new BoundingBox(this.options.x, this.options.y, this.options.width, (this.lastY ?? 0) - this.options.y);
   }
 
   /** Render the system. */
-  draw(): void {
+  override draw(): void {
     // Render debugging information, if requested.
     const ctx = this.checkContext();
     if (!this.formatter || !this.startX || !this.lastY || !this.debugNoteMetricsYs) {

--- a/src/tabnote.ts
+++ b/src/tabnote.ts
@@ -125,7 +125,7 @@ function getPartialStemLines(stemY: number, unusedStrings: number[][], stave: St
 }
 
 export class TabNote extends StemmableNote {
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.TabNote;
   }
 
@@ -185,7 +185,7 @@ export class TabNote extends StemmableNote {
     return this.positions.map((x) => x.str).reduce((a, b) => (a < b ? a : b));
   };
 
-  reset(): this {
+  override reset(): this {
     super.reset();
     if (this.stave) this.setStave(this.stave);
     return this;
@@ -200,13 +200,13 @@ export class TabNote extends StemmableNote {
   }
 
   // Determine if the note has a stem
-  hasStem(): boolean {
+  override hasStem(): boolean {
     if (this.renderOptions.drawStem) return true;
     return false;
   }
 
   // Get the default stem extension for the note
-  getStemExtension(): number {
+  override getStemExtension(): number {
     if (this.stemExtensionOverride !== undefined) {
       return this.stemExtensionOverride;
     }
@@ -243,7 +243,7 @@ export class TabNote extends StemmableNote {
   }
 
   // Set the `stave` to the note
-  setStave(stave: Stave): this {
+  override setStave(stave: Stave): this {
     super.setStave(stave);
     const ctx = stave.getContext();
     this.setContext(ctx);
@@ -268,7 +268,7 @@ export class TabNote extends StemmableNote {
 
   // Get the default `x` and `y` coordinates for a modifier at a specific
   // `position` at a fret position `index`
-  getModifierStartXY(position: number, index: number): { x: number; y: number } {
+  override getModifierStartXY(position: number, index: number): { x: number; y: number } {
     if (!this.preFormatted) {
       throw new RuntimeError('UnformattedNote', "Can't call GetModifierStartXY on an unformatted note");
     }
@@ -294,12 +294,12 @@ export class TabNote extends StemmableNote {
   }
 
   // Get the default line for rest
-  getLineForRest(): number {
+  override getLineForRest(): number {
     return Number(this.positions[0].str);
   }
 
   // Pre-render formatting
-  preFormat(): void {
+  override preFormat(): void {
     if (this.preFormatted) return;
     if (this.modifierContext) this.modifierContext.preFormat();
     // width is already set during init()
@@ -307,7 +307,7 @@ export class TabNote extends StemmableNote {
   }
 
   // Get the x position for the stem
-  getStemX(): number {
+  override getStemX(): number {
     return this.getCenterGlyphX();
   }
 
@@ -325,7 +325,7 @@ export class TabNote extends StemmableNote {
   }
 
   // Get the stem extents for the tabnote
-  getStemExtents(): { topY: number; baseY: number } {
+  override getStemExtents(): { topY: number; baseY: number } {
     return this.checkStem().getExtents();
   }
 
@@ -416,7 +416,7 @@ export class TabNote extends StemmableNote {
   }
 
   // The main rendering function for the entire note.
-  draw(): void {
+  override draw(): void {
     const ctx = this.checkContext();
 
     if (this.ys.length === 0) {

--- a/src/tabslide.ts
+++ b/src/tabslide.ts
@@ -11,7 +11,7 @@ import { Category } from './typeguard';
 import { RuntimeError } from './util';
 
 export class TabSlide extends TabTie {
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.TabSlide;
   }
 
@@ -79,7 +79,13 @@ export class TabSlide extends TabTie {
    * @param params.firstX is specified in pixels.
    * @param params.lastX is specified in pixels.
    */
-  renderTie(params: { direction: number; firstX: number; lastX: number; lastYs: number[]; firstYs: number[] }): void {
+  override renderTie(params: {
+    direction: number;
+    firstX: number;
+    lastX: number;
+    lastYs: number[];
+    firstYs: number[];
+  }): void {
     if (params.firstYs.length === 0 || params.lastYs.length === 0) {
       throw new RuntimeError('BadArguments', 'No Y-values to render');
     }

--- a/src/tabstave.ts
+++ b/src/tabstave.ts
@@ -4,7 +4,7 @@ import { Stave, StaveOptions } from './stave';
 import { Category } from './typeguard';
 
 export class TabStave extends Stave {
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.TabStave;
   }
 
@@ -19,7 +19,7 @@ export class TabStave extends Stave {
     super(x, y, width, tabOptions);
   }
 
-  getYForGlyphs(): number {
+  override getYForGlyphs(): number {
     return this.getYForLine(2.5);
   }
 

--- a/src/tabtie.ts
+++ b/src/tabtie.ts
@@ -9,7 +9,7 @@ import { StaveTie, TieNotes } from './stavetie';
 import { Category } from './typeguard';
 
 export class TabTie extends StaveTie {
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.TabTie;
   }
 

--- a/src/textbracket.ts
+++ b/src/textbracket.ts
@@ -36,7 +36,7 @@ export enum TextBracketPosition {
 export class TextBracket extends Element {
   static DEBUG: boolean = false;
 
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.TextBracket;
   }
 
@@ -106,7 +106,7 @@ export class TextBracket extends Element {
    * @param ctx
    * @returns this
    */
-  applyStyle(ctx: RenderContext): this {
+  override applyStyle(ctx: RenderContext): this {
     this.textElement.setFont(this.fontInfo);
     // We called this.resetFont() in the constructor, so we know this.textFont is available.
     const { family, size, weight, style } = this.fontInfo;
@@ -137,7 +137,7 @@ export class TextBracket extends Element {
   }
 
   // Draw the octave bracket on the rendering context
-  draw(): void {
+  override draw(): void {
     const ctx = this.checkContext();
     this.setRendered();
 

--- a/src/textdynamics.ts
+++ b/src/textdynamics.ts
@@ -23,7 +23,7 @@ export class TextDynamics extends Note {
   /** To enable logging for this class. Set `VexFlow.TextDynamics.DEBUG` to `true`. */
   static DEBUG: boolean = false;
 
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.TextDynamics;
   }
 
@@ -69,7 +69,7 @@ export class TextDynamics extends Note {
   }
 
   /** Preformat the dynamics text. */
-  preFormat(): this {
+  override preFormat(): this {
     // length of this.glyphs must be <=
     // length of this.sequence, so if we're formatted before
     // create new glyphs.
@@ -89,7 +89,7 @@ export class TextDynamics extends Note {
   }
 
   /** Draw the dynamics text on the rendering context. */
-  draw(): void {
+  override draw(): void {
     this.setRendered();
     const x = this.getAbsoluteX();
     const y = this.checkStave().getYForLine(this.line + -3);

--- a/src/textnote.ts
+++ b/src/textnote.ts
@@ -31,7 +31,7 @@ export interface TextNoteStruct extends NoteStruct {
  * Examples of this would be such as dynamics, lyrics, chord changes, etc.
  */
 export class TextNote extends Note {
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.TextNote;
   }
 
@@ -118,7 +118,7 @@ export class TextNote extends Note {
   }
 
   /** Pre-render formatting. */
-  preFormat(): void {
+  override preFormat(): void {
     if (this.preFormatted) return;
     const tickContext = this.checkTickContext(`Can't preformat without a TickContext.`);
 
@@ -137,7 +137,7 @@ export class TextNote extends Note {
    * Renders the TextNote.
    * `TextNote` has to be assigned to a `Stave` before rendering by means of `setStave`.
    */
-  draw(): void {
+  override draw(): void {
     const ctx = this.checkContext();
     const stave = this.checkStave();
     const tickContext = this.checkTickContext(`Can't draw without a TickContext.`);

--- a/src/tickable.ts
+++ b/src/tickable.ts
@@ -33,7 +33,7 @@ export interface FormatterMetrics {
  * has a duration, i.e., Tickables occupy space in the musical rendering dimension.
  */
 export abstract class Tickable extends Element {
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.Tickable;
   }
 
@@ -119,7 +119,7 @@ export abstract class Tickable extends Element {
   }
 
   /** Get width of note. Used by the formatter for positioning. */
-  getWidth(): number {
+  override getWidth(): number {
     if (!this._preFormatted) {
       throw new RuntimeError('UnformattedNote', "Can't call GetWidth on an unformatted note.");
     }
@@ -128,7 +128,7 @@ export abstract class Tickable extends Element {
   }
 
   /** Get `x` position of this tick context. */
-  getX(): number {
+  override getX(): number {
     const tickContext = this.checkTickContext(`Can't getX() without a TickContext.`);
     return tickContext.getX() + this.xShift;
   }

--- a/src/timesignature.ts
+++ b/src/timesignature.ts
@@ -37,7 +37,7 @@ const assertIsValidTimeSig = (timeSpec: string) => {
  * such as "3/4(6/8)" or "2/4+5/8".
  */
 export class TimeSignature extends StaveModifier {
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.TimeSignature;
   }
 
@@ -203,7 +203,7 @@ export class TimeSignature extends StaveModifier {
    * Draw the time signature on a Stave using its RenderContext.  Both setStave
    * and setContext must already be run.
    */
-  draw(): void {
+  override draw(): void {
     const stave = this.checkStave();
     const ctx = stave.checkContext();
     this.setRendered();
@@ -237,7 +237,7 @@ export class TimeSignature extends StaveModifier {
 
   // gets combined bounding box of time sig
   // NOTE: should be called after drawAt initializes top/botRenderY to get proper position
-  getBoundingBox(): BoundingBox {
+  override getBoundingBox(): BoundingBox {
     if (this.isNumeric) {
       // these always return boxes so no need to handle case where one/both are null/undefined
       const topBoundingBox = this.topText.getBoundingBox();

--- a/src/timesignote.ts
+++ b/src/timesignote.ts
@@ -7,7 +7,7 @@ import { TimeSignature } from './timesignature';
 import { Category } from './typeguard';
 
 export class TimeSigNote extends Note {
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.TimeSigNote;
   }
 
@@ -25,17 +25,17 @@ export class TimeSigNote extends Note {
 
   /* Overridden to ignore */
   // eslint-disable-next-line
-  addToModifierContext(mc: ModifierContext): this {
+  override addToModifierContext(mc: ModifierContext): this {
     // DO NOTHING.
     return this;
   }
 
-  preFormat(): this {
+  override preFormat(): this {
     this.preFormatted = true;
     return this;
   }
 
-  draw(): void {
+  override draw(): void {
     const stave = this.checkStave();
     const ctx = this.checkContext();
     this.setRendered();

--- a/src/tremolo.ts
+++ b/src/tremolo.ts
@@ -10,7 +10,7 @@ import { Category } from './typeguard';
 
 /** Tremolo implements tremolo notation. */
 export class Tremolo extends Modifier {
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.Tremolo;
   }
 
@@ -28,7 +28,7 @@ export class Tremolo extends Modifier {
   }
 
   /** Draw the tremolo on the rendering context. */
-  draw(): void {
+  override draw(): void {
     const ctx = this.checkContext();
     const note = this.checkAttachedNote();
     this.setRendered();

--- a/src/tuplet.ts
+++ b/src/tuplet.ts
@@ -76,7 +76,7 @@ export const enum TupletLocation {
 }
 
 export class Tuplet extends Element {
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.Tuplet;
   }
 
@@ -310,7 +310,7 @@ export class Tuplet extends Element {
     return yPosition + nestedTupletYOffset + yOffset;
   }
 
-  draw(): void {
+  override draw(): void {
     const { location, bracketed, textYOffset, suffix } = this.options;
     const bracketPadding = Metrics.get('Tuplet.bracketPadding');
     const extraSpacing = Metrics.get('Tuplet.suffix.extraSpacing');

--- a/src/vibrato.ts
+++ b/src/vibrato.ts
@@ -15,7 +15,7 @@ export interface VibratoRenderOptions {
 
 /** `Vibrato` implements diverse vibratos. */
 export class Vibrato extends Modifier {
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.Vibrato;
   }
 
@@ -89,7 +89,7 @@ export class Vibrato extends Modifier {
   }
 
   /** Draw the vibrato on the rendering context. */
-  draw(): void {
+  override draw(): void {
     const ctx = this.checkContext();
     const note = this.checkAttachedNote();
     this.setRendered();

--- a/src/vibratobracket.ts
+++ b/src/vibratobracket.ts
@@ -18,7 +18,7 @@ export class VibratoBracket extends Element {
   /** To enable logging for this class. Set `VexFlow.VibratoBracket.DEBUG` to `true`. */
   static DEBUG: boolean = false;
 
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.VibratoBracket;
   }
 
@@ -55,7 +55,7 @@ export class VibratoBracket extends Element {
   }
 
   /** Draw the vibrato bracket on the rendering context. */
-  draw(): void {
+  override draw(): void {
     const ctx = this.checkContext();
     this.setRendered();
     const y: number =

--- a/src/voice.ts
+++ b/src/voice.ts
@@ -28,7 +28,7 @@ export enum VoiceMode {
  * `Voice` is mainly a container object to group `Tickables` for formatting.
  */
 export class Voice extends Element {
-  static get CATEGORY(): string {
+  static override get CATEGORY(): string {
     return Category.Voice;
   }
 
@@ -152,7 +152,7 @@ export class Voice extends Element {
   }
 
   /** Get the bounding box for the voice. */
-  getBoundingBox(): BoundingBox {
+  override getBoundingBox(): BoundingBox {
     const boundingBox = this.tickables[0].getBoundingBox();
     for (let i = 1; i < this.tickables.length; ++i) {
       const tickable = this.tickables[i];
@@ -284,7 +284,7 @@ export class Voice extends Element {
    * This method also calculates the voice's boundingBox while drawing
    * the notes. Note the similarities with this.getBoundingBox().
    */
-  draw(context: RenderContext = this.checkContext(), stave?: Stave): void {
+  override draw(context: RenderContext = this.checkContext(), stave?: Stave): void {
     stave = stave ?? this.stave;
     this.setRendered();
     for (let i = 0; i < this.tickables.length; ++i) {

--- a/tests/mocks.ts
+++ b/tests/mocks.ts
@@ -11,25 +11,25 @@ import { TickContext } from '../src/tickcontext';
 import { Voice } from '../src/voice';
 
 class MockTickable extends Tickable {
-  tickContext?: TickContext;
-  ticks: Fraction = new Fraction(1, 1);
-  voice?: Voice;
+  override tickContext?: TickContext;
+  override ticks: Fraction = new Fraction(1, 1);
+  override voice?: Voice;
   stave?: Stave;
-  ignoreTicks: boolean = false;
+  override ignoreTicks: boolean = false;
 
   init(): void {
     // DO NOTHING.
   }
 
-  getX(): number {
+  override getX(): number {
     return this.tickContext!.getX();
   }
 
-  getIntrinsicTicks(): number {
+  override getIntrinsicTicks(): number {
     return this.ticks.value();
   }
 
-  getTicks(): Fraction {
+  override getTicks(): Fraction {
     return this.ticks;
   }
 
@@ -52,16 +52,16 @@ class MockTickable extends Tickable {
     };
   }
 
-  getWidth(): number {
+  override getWidth(): number {
     return this.width;
   }
 
-  setWidth(w: number): this {
+  override setWidth(w: number): this {
     this.width = w;
     return this;
   }
 
-  setVoice(v: Voice): this {
+  override setVoice(v: Voice): this {
     this.voice = v;
     return this;
   }
@@ -75,26 +75,26 @@ class MockTickable extends Tickable {
     return this.stave;
   }
 
-  setTickContext(tc: TickContext): this {
+  override setTickContext(tc: TickContext): this {
     this.tickContext = tc;
     return this;
   }
 
-  setIgnoreTicks(flag: boolean): this {
+  override setIgnoreTicks(flag: boolean): this {
     this.ignoreTicks = flag;
     return this;
   }
 
-  shouldIgnoreTicks(): boolean {
+  override shouldIgnoreTicks(): boolean {
     return this.ignoreTicks;
   }
 
-  preFormat(): void {
+  override preFormat(): void {
     // DO NOTHING.
   }
 
   // eslint-disable-next-line
-  draw(...args: any[]): void {
+  override draw(...args: any[]): void {
     // DO NOTHING.
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,10 +11,23 @@
     "skipLibCheck": true /* Skip type checking of declaration files. */,
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */,
     "moduleResolution": "node",
-    "lib": ["dom", "es2020"],
-    "removeComments": false
-    // "noImplicitOverride": true, /* Introduce in the future for more type safety. Will cause >= 217 errors due to lack of "override" keyword. */
+    "lib": [
+      "dom",
+      "es2020"
+    ],
+    "removeComments": false,
+    "noImplicitOverride": true, /* Require explicit `override` keyword on all class members that override a base-class member. */
   },
-  "include": ["./src", "./entry", "./tests"],
-  "exclude": ["node_modules/**/*", "tools/fonts/legacy", "releases", "reference", "build"]
+  "include": [
+    "./src",
+    "./entry",
+    "./tests"
+  ],
+  "exclude": [
+    "node_modules/**/*",
+    "tools/fonts/legacy",
+    "releases",
+    "reference",
+    "build"
+  ]
 }


### PR DESCRIPTION
Hey all,

I noticed that noImplicitOverride (https://www.typescriptlang.org/tsconfig/#noImplicitOverride) was commented out in the project's tsconfig.json with a note about wanting it to be added in the future. Well, maybe the future is now! 

The non tsconfig modified files are just adding `override` wherever the ts compiler was telling me there was an error with the new rule. 