### PR TITLE
new getNestedTupletCount algorithm

### DIFF
--- a/src/tuplet.ts
+++ b/src/tuplet.ts
@@ -228,23 +228,23 @@ export class Tuplet extends Element {
   // offset for this tuplet:
   getNestedTupletCount(): number {
     const { location } = this.options;
-    const firstNote = this.notes[0];
-    let maxTupletCount = countTuplets(firstNote, location);
-    let minTupletCount = countTuplets(firstNote, location);
 
-    // Count the tuplets that are on the same side (above/below)
-    // as this tuplet:
-    function countTuplets(note: Note, location: number) {
-      return note.getTupletStack().filter((tuplet) => tuplet.options.location === location).length;
+    let maxOffset = 0;
+    for (const note of this.notes) {
+      // Find the array of tuplets that note belongs to
+      const stack = note
+        .getTupletStack()
+        // Count the tuplets that are on the same side (above/below) as this tuplet.
+        .filter((tuplet) => tuplet.options.location === location);
+
+      // Find where “this” appears in that filtered stack
+      const index = stack.indexOf(this);
+      if (index >= 0 && index > maxOffset) {
+        maxOffset = index;
+      }
     }
 
-    this.notes.forEach((note) => {
-      const tupletCount = countTuplets(note, location);
-      maxTupletCount = tupletCount > maxTupletCount ? tupletCount : maxTupletCount;
-      minTupletCount = tupletCount < minTupletCount ? tupletCount : minTupletCount;
-    });
-
-    return maxTupletCount - minTupletCount;
+    return maxOffset;
   }
 
   // determine the y position of the tuplet:

--- a/tests/tuplet_tests.ts
+++ b/tests/tuplet_tests.ts
@@ -568,18 +568,18 @@ function nested(options: TestOptions): void {
   });
 
   f.Tuplet({
-    notes: notes.slice(0, 7),
-    options: {
-      notesOccupied: 2,
-      numNotes: 3,
-    },
-  });
-
-  f.Tuplet({
     notes: notes.slice(2, 7),
     options: {
       notesOccupied: 4,
       numNotes: 5,
+    },
+  });
+
+  f.Tuplet({
+    notes: notes.slice(0, 7),
+    options: {
+      notesOccupied: 2,
+      numNotes: 3,
     },
   });
 
@@ -614,17 +614,6 @@ function single(options: TestOptions): void {
     notes: notes.slice(1, 4),
   });
 
-  // big quartuplet
-  f.Tuplet({
-    notes: notes.slice(0, -1),
-    options: {
-      numNotes: 4,
-      notesOccupied: 3,
-      ratioed: true,
-      bracketed: true,
-    },
-  });
-
   // first singleton
   f.Tuplet({
     notes: notes.slice(0, 1),
@@ -650,6 +639,17 @@ function single(options: TestOptions): void {
     options: {
       numNotes: 3,
       notesOccupied: 2,
+      ratioed: true,
+      bracketed: true,
+    },
+  });
+
+  // big quartuplet
+  f.Tuplet({
+    notes: notes.slice(0, -1),
+    options: {
+      numNotes: 4,
+      notesOccupied: 3,
       ratioed: true,
       bracketed: true,
     },

--- a/tests/tuplet_tests.ts
+++ b/tests/tuplet_tests.ts
@@ -27,6 +27,7 @@ const TupletTests = {
     run('Mixed Stem Direction Tuplet', mixedTop);
     run('Mixed Stem Direction Bottom Tuplet', mixedBottom);
     run('Nested Tuplets', nested);
+    run('Nested Tuplets Only Tuplet Children', nestedChildren);
     run('Single Tuplets', single);
   },
 };
@@ -591,6 +592,60 @@ function nested(options: TestOptions): void {
   f.draw();
 
   options.assert.ok(true, 'Nested Tuplets');
+}
+
+function nestedChildren(options: TestOptions): void {
+  const f = VexFlowTests.makeFactory(options);
+  const stave = f.Stave({ x: 10, y: 10 }).addTimeSignature('4/4');
+
+  const notes = [
+    // Big triplet 1:
+    { keys: ['b/4'], duration: '4' },
+    { keys: ['a/4'], duration: '4' },
+    { keys: ['c/4'], duration: '4' },
+    { keys: ['g/4'], duration: '8' },
+    { keys: ['a/4'], duration: '8' },
+    { keys: ['f/4'], duration: '8' },
+  ]
+    .map(setStemUp)
+    .map(f.StaveNote.bind(f));
+
+  f.Beam({
+    notes: notes.slice(3),
+  });
+
+  f.Tuplet({
+    notes: notes.slice(0, 3),
+    options: {
+      notesOccupied: 2,
+      numNotes: 3,
+    },
+  });
+
+  f.Tuplet({
+    notes: notes.slice(3),
+    options: {
+      notesOccupied: 2,
+      numNotes: 3,
+    },
+  });
+
+  f.Tuplet({
+    notes: notes.slice(),
+    options: {
+      notesOccupied: 4,
+      numNotes: 3,
+    },
+  });
+
+  // 4/4 time
+  const voice = f.Voice().setStrict(true).addTickables(notes);
+
+  new Formatter().joinVoices([voice]).formatToStave([voice], stave);
+
+  f.draw();
+
+  options.assert.ok(true, 'Nested Tuplets Only Tuplet Children');
 }
 
 function single(options: TestOptions): void {


### PR DESCRIPTION
Closes #297 

Uses new algorithm for `getNestedTupletCount()`. Added test case handles when all the children are tuplets. Current test case Nested Tuplets already handles the other scenario where at least one child is not a tuplet.

Added commit to change the render order of the tuplets in nested tuplet and simple tuplet tests to be in line with how they would normally be found in music notation. 