### PR TITLE
Fix svg group: Include class attribute

### DIFF
--- a/src/annotation.ts
+++ b/src/annotation.ts
@@ -224,7 +224,8 @@ export class Annotation extends Modifier {
     const start = note.getModifierStartXY(ModifierPosition.ABOVE, this.index);
 
     this.setRendered();
-    ctx.openGroup('annotation', this.getAttribute('id'));
+    const clsAttribute = this.getAttribute('class');
+    ctx.openGroup('annotation' + (clsAttribute ? ' ' + clsAttribute : ''), this.getAttribute('id'));
 
     const textWidth = this.getWidth();
     const textHeight = Font.convertSizeToPixelValue(this.fontInfo.size);

--- a/src/beam.ts
+++ b/src/beam.ts
@@ -991,7 +991,8 @@ export class Beam extends Element {
       this.postFormat();
     }
 
-    ctx.openGroup('beam', this.getAttribute('id'));
+    const clsAttribute = this.getAttribute('class');
+    ctx.openGroup('beam' + (clsAttribute ? ' ' + clsAttribute : ''), this.getAttribute('id'));
     this.drawStems(ctx);
     this.drawBeamLines(ctx);
     this.drawPointerRect();

--- a/src/chordsymbol.ts
+++ b/src/chordsymbol.ts
@@ -403,7 +403,8 @@ export class ChordSymbol extends Modifier {
     const note = this.checkAttachedNote() as StemmableNote;
     this.setRendered();
 
-    ctx.openGroup('chordsymbol', this.getAttribute('id'));
+    const clsAttribute = this.getAttribute('class');
+    ctx.openGroup('chordsymbol' + (clsAttribute ? ' ' + clsAttribute : ''), this.getAttribute('id'));
 
     const start = note.getModifierStartXY(Modifier.Position.ABOVE, this.index);
     ctx.setFont(this.fontInfo);

--- a/src/clef.ts
+++ b/src/clef.ts
@@ -153,7 +153,8 @@ export class Clef extends StaveModifier {
     const ctx = stave.checkContext();
     this.setRendered();
 
-    ctx.openGroup('clef', this.getAttribute('id'));
+    const clsAttribute = this.getAttribute('class');
+    ctx.openGroup('clef' + (clsAttribute ? ' ' + clsAttribute : ''), this.getAttribute('id'));
 
     this.y = stave.getYForLine(this.line);
     this.renderText(ctx, 0, 0);

--- a/src/flag.ts
+++ b/src/flag.ts
@@ -26,7 +26,8 @@ export class Flag extends Element {
   override draw(): void {
     const ctx = this.checkContext();
     this.setRendered();
-    ctx.openGroup('flag', this.getAttribute('id'));
+    const clsAttribute = this.getAttribute('class');
+    ctx.openGroup('flag' + (clsAttribute ? ' ' + clsAttribute : ''), this.getAttribute('id'));
 
     L("Drawing flag '", this.text, "' at", this.x, this.y);
     this.renderText(ctx, 0, 0);

--- a/src/glyphnote.ts
+++ b/src/glyphnote.ts
@@ -56,7 +56,8 @@ export class GlyphNote extends Note {
     const stave = this.checkStave();
     const ctx = stave.checkContext();
     this.setRendered();
-    ctx.openGroup('glyphNote', this.getAttribute('id'));
+    const clsAttribute = this.getAttribute('class');
+    ctx.openGroup('glyphNote' + (clsAttribute ? ' ' + clsAttribute : ''), this.getAttribute('id'));
 
     this.x = this.isCenterAligned() ? this.getAbsoluteX() - this.getWidth() / 2 : this.getAbsoluteX();
     this.y = stave.getYForLine(this.options.line);

--- a/src/keysignature.ts
+++ b/src/keysignature.ts
@@ -294,7 +294,8 @@ export class KeySignature extends StaveModifier {
     if (!this.formatted) this.format();
     this.setRendered();
 
-    ctx.openGroup('keysignature', this.getAttribute('id'));
+    const clsAttribute = this.getAttribute('class');
+    ctx.openGroup('keysignature' + (clsAttribute ? ' ' + clsAttribute : ''), this.getAttribute('id'));
     for (let i = 0; i < this.children.length; i++) {
       const glyph = this.children[i];
       glyph.renderText(ctx, this.x, 0);

--- a/src/notehead.ts
+++ b/src/notehead.ts
@@ -151,7 +151,8 @@ export class NoteHead extends Note {
   override draw(): void {
     const ctx = this.checkContext();
     this.setRendered();
-    ctx.openGroup('notehead', this.getAttribute('id'));
+    const clsAttribute = this.getAttribute('class');
+    ctx.openGroup('notehead' + (clsAttribute ? ' ' + clsAttribute : ''), this.getAttribute('id'));
 
     L("Drawing note head '", this.noteType, this.duration, "' at", this.x, this.y);
     this.x = this.getAbsoluteX();

--- a/src/ornament.ts
+++ b/src/ornament.ts
@@ -225,7 +225,8 @@ export class Ornament extends Modifier {
 
     const stave = note.checkStave();
 
-    ctx.openGroup('ornament', this.getAttribute('id'));
+    const clsAttribute = this.getAttribute('class');
+    ctx.openGroup('ornament' + (clsAttribute ? ' ' + clsAttribute : ''), this.getAttribute('id'));
 
     // Get initial coordinates for the modifier position
     const start = note.getModifierStartXY(this.position, this.index);

--- a/src/stave.ts
+++ b/src/stave.ts
@@ -680,7 +680,8 @@ export class Stave extends Element {
     const ctx = this.checkContext();
     this.setRendered();
 
-    ctx.openGroup('stave', this.getAttribute('id'));
+    const clsAttribute = this.getAttribute('class');
+    ctx.openGroup('stave' + (clsAttribute ? ' ' + clsAttribute : ''), this.getAttribute('id'));
     if (!this.formatted) this.format();
 
     const numLines = this.options.numLines;

--- a/src/stavebarline.ts
+++ b/src/stavebarline.ts
@@ -134,7 +134,8 @@ export class Barline extends StaveModifier {
     const ctx = stave.checkContext();
     this.setRendered();
 
-    ctx.openGroup('stavebarline', this.getAttribute('id'));
+    const clsAttribute = this.getAttribute('class');
+    ctx.openGroup('stavebarline' + (clsAttribute ? ' ' + clsAttribute : ''), this.getAttribute('id'));
     switch (this.type) {
       case BarlineType.SINGLE:
         this.drawVerticalBar(stave, this.x, false);

--- a/src/stavenote.ts
+++ b/src/stavenote.ts
@@ -1211,7 +1211,8 @@ export class StaveNote extends StemmableNote {
     L('Rendering ', this.isChord() ? 'chord :' : 'note :', this.keys);
 
     // Apply the overall style -- may be contradicted by local settings:
-    ctx.openGroup('stavenote', this.getAttribute('id'));
+    const clsAttribute = this.getAttribute('class');
+    ctx.openGroup('stavenote' + (clsAttribute ? ' ' + clsAttribute : ''), this.getAttribute('id'));
     this.drawLedgerLines();
     if (shouldRenderStem) this.drawStem();
     this.drawNoteHeads();

--- a/src/stavetie.ts
+++ b/src/stavetie.ts
@@ -153,7 +153,8 @@ export class StaveTie extends Element {
     const firstIndexes = this.notes.firstIndexes!;
 
     const lastIndexes = this.notes.lastIndexes!;
-    ctx.openGroup('stavetie', this.getAttribute('id'));
+    const clsAttribute = this.getAttribute('class');
+    ctx.openGroup('stavetie' + (clsAttribute ? ' ' + clsAttribute : ''), this.getAttribute('id'));
     for (let i = 0; i < firstIndexes.length; ++i) {
       const cpX = (params.lastX + lastXShift + (params.firstX + firstXShift)) / 2;
       // firstY and lastY are specified in pixels.

--- a/src/stem.ts
+++ b/src/stem.ts
@@ -210,7 +210,8 @@ export class Stem extends Element {
     const stemletYOffset = this.isStemlet ? stemHeight - this.stemletHeight * this.stemDirection : 0;
 
     // Draw the stem
-    ctx.openGroup('stem', this.getAttribute('id'));
+    const clsAttribute = this.getAttribute('class');
+    ctx.openGroup('stem' + (clsAttribute ? ' ' + clsAttribute : ''), this.getAttribute('id'));
     ctx.beginPath();
     ctx.setLineWidth(Stem.WIDTH);
     ctx.moveTo(stemX, stemY - stemletYOffset + yBaseOffset);

--- a/src/tabnote.ts
+++ b/src/tabnote.ts
@@ -426,7 +426,8 @@ export class TabNote extends StemmableNote {
     this.setRendered();
     const renderStem = this.beam === undefined && this.renderOptions.drawStem;
 
-    ctx.openGroup('tabnote', this.getAttribute('id'));
+    const clsAttribute = this.getAttribute('class');
+    ctx.openGroup('tabnote' + (clsAttribute ? ' ' + clsAttribute : ''), this.getAttribute('id'));
     this.drawPositions();
     this.drawStemThrough();
 

--- a/src/timesignature.ts
+++ b/src/timesignature.ts
@@ -207,7 +207,8 @@ export class TimeSignature extends StaveModifier {
     const stave = this.checkStave();
     const ctx = stave.checkContext();
     this.setRendered();
-    ctx.openGroup('timesignature', this.getAttribute('id'));
+    const clsAttribute = this.getAttribute('class');
+    ctx.openGroup('timesignature' + (clsAttribute ? ' ' + clsAttribute : ''), this.getAttribute('id'));
     this.drawAt(ctx, stave, this.x);
     this.drawPointerRect();
     ctx.closeGroup();

--- a/src/timesignote.ts
+++ b/src/timesignote.ts
@@ -40,7 +40,8 @@ export class TimeSigNote extends Note {
     const ctx = this.checkContext();
     this.setRendered();
 
-    ctx.openGroup('timesignote', this.getAttribute('id'));
+    const clsAttribute = this.getAttribute('class');
+    ctx.openGroup('timesignote' + (clsAttribute ? ' ' + clsAttribute : ''), this.getAttribute('id'));
     this.timeSig.drawAt(ctx, stave, this.getAbsoluteX());
     this.drawPointerRect();
     ctx.closeGroup();

--- a/src/tuplet.ts
+++ b/src/tuplet.ts
@@ -367,7 +367,8 @@ export class Tuplet extends Element {
       yPos + this.textElement.getHeight() / 2 + (location === Tuplet.LOCATION_TOP ? -1 : 1) * textYOffset;
 
     // start grouping
-    ctx.openGroup('tuplet', this.getAttribute('id'));
+    const clsAttribute = this.getAttribute('class');
+    ctx.openGroup('tuplet' + (clsAttribute ? ' ' + clsAttribute : ''), this.getAttribute('id'));
 
     // draw bracket if the tuplet is not beamed
     if (bracketed) {


### PR DESCRIPTION
Originally from @rednebmas, but on the old repo: https://github.com/0xfe/vexflow/pull/1656

Actually use the `class` attribute on drawable elements. Currently we can set it with `Element.addClass()` but it is totally ignored at rendering.
The idea is, for instance, to be able to colorize some notes or ease the interactivity with some `Elements`.