### PR TITLE
Add ponyfill for `structuredClone` to support Safari versions older than 15.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "vexflow",
       "version": "5.1.0",
       "license": "MIT",
+      "dependencies": {
+        "structured-clone-es": "^1.0.0"
+      },
       "devDependencies": {
         "@eslint/compat": "^1.2.9",
         "@eslint/eslintrc": "^3.3.1",
@@ -9247,6 +9250,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/structured-clone-es": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/structured-clone-es/-/structured-clone-es-1.0.0.tgz",
+      "integrity": "sha512-FL8EeKFFyNQv5cMnXI31CIMCsFarSVI2bF0U0ImeNE3g/F1IvJQyqzOXxPBRXiwQfyBTlbNe88jh1jFW0O/jiQ==",
+      "license": "ISC"
     },
     "node_modules/supports-color": {
       "version": "8.1.1",

--- a/package.json
+++ b/package.json
@@ -133,5 +133,8 @@
     "piano",
     "guitar",
     "tablature"
-  ]
+  ],
+  "dependencies": {
+    "structured-clone-es": "^1.0.0"
+  }
 }

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -2,6 +2,7 @@
 
 import { ElementStyle } from './element';
 import { FontInfo } from './font';
+import { structuredClone } from './util';
 
 export class Metrics {
   protected static cacheStyle = new Map<string, ElementStyle>();

--- a/src/svgcontext.ts
+++ b/src/svgcontext.ts
@@ -7,7 +7,7 @@ import { Font, FontInfo, FontStyle, FontWeight } from './font';
 import { Metrics } from './metrics';
 import { RenderContext, TextMeasure } from './rendercontext';
 import { Tables } from './tables';
-import { normalizeAngle, prefix, RuntimeError } from './util';
+import { normalizeAngle, prefix, RuntimeError, structuredClone } from './util';
 
 export type Attributes = {
   [name: string]: string | number | undefined;

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,6 @@
 // Copyright (c) 2023-present VexFlow contributors: https://github.com/vexflow/vexflow/graphs/contributors
 // MIT License
+export { structuredClone } from 'structured-clone-es'
 
 // Note: Keep this module free of imports to reduce the chance of circular dependencies.
 


### PR DESCRIPTION

- Resolves #306

This pull request provides a polyfill for [`structuredClone`](https://developer.mozilla.org/en-US/docs/Web/API/Window/structuredClone), which is not available in Safari versions older than 15.4 (release date ⁨2022-03-14⁩). 

> ..Unlike Chrome, Edge, and Firefox, Safari doesn't auto-update on [macOS]

Here are the places it's being used.

```sh
$ cd vexflow/src
$ grep -rn structuredClone
svgcontext.ts:576:      state: structuredClone(this.state),
svgcontext.ts:577:      attributes: structuredClone(this.attributes),
svgcontext.ts:586:      this.state = structuredClone(state.state);
svgcontext.ts:587:      this.attributes = structuredClone(state.attributes);
metrics.ts:31:    return structuredClone(font);
metrics.ts:47:    return structuredClone(style);
```

For context, below text copied from [this comment](https://github.com/vexflow/vexflow/issues/306#issuecomment-3418775407).

---

..I looked into a good polyfill for `structuredClone`. This library is the most popular in terms of GitHub and NPM activity.

- https://github.com/ungap/structured-clone

But there's an ES Module wrapper that looks more convenient.

> As @ungap/structured-clone use `.js` for both CJS and ESM, making the ESM version not working in Node.js. This package re-bundles it, ships TypeScript definitions, and adds ESM support for Node.js.

- https://github.com/antfu/structured-clone-es

It's by a reputable author, so the NPM package [`structured-clone-es`](https://www.npmjs.com/package/structured-clone-es) is likely trustworthy as a dependency.

I also confirmed that it's a "[ponyfill](https://github.com/sindresorhus/ponyfill)". It does not modify any globals, instead exporting a standalone method that defers to the global if it exists.

> Unlike [polyfills](https://en.wikipedia.org/wiki/Polyfill_%28programming%29), ponyfills don't pretend to be the native API. They offer the same functionality through explicit imports and usage, keeping your code predictable and side-effect free.

I also checked if the library is small enough to copy & paste into `util.ts`, but it's a few files with fairly involved logic. Probably an acceptable trade-off to add it as an external dependency. I noticed so far Vexflow has _zero_ non-dev dependency which is nice.