### PR TITLE
Key signatures new syntax fix

### DIFF
--- a/src/stave.ts
+++ b/src/stave.ts
@@ -476,7 +476,7 @@ export class Stave extends Element {
    *
    * Example:
    * `stave.addKeySignature('Db');`
-   * @param keySpec new key specification `[A-G][b|#]?` or `[flats|sharps]_[1-14]?`
+   * @param keySpec new key specification `[A-G][b|#]?` or `[flats|sharps]_[0-14]?`
    * @param cancelKeySpec
    * @param position
    * @returns

--- a/src/tables.ts
+++ b/src/tables.ts
@@ -57,7 +57,7 @@ const generateKeySignatures = (): KeySignatures => {
 
   for (let i = 1; i <= 14; i++) {
     keySignatures[`flats_${i}`] = { accidental: 'b', num: i };
-    keySignatures[`sharps_${i}`] = { accidental: 'b', num: i };
+    keySignatures[`sharps_${i}`] = { accidental: '#', num: i };
   }
 
   keySignatures['flats_0'] = { num: 0 };


### PR DESCRIPTION
This PR addresses a bug introduced in [PR 263](https://github.com/vexflow/vexflow/pull/263). 

While trying to use this new implementation, I noticed that a typo prevented to use key signatures with flat with the new syntax. 

This PR now corrects it. I also updated the documentation to more accurately reflect the possibilities of the implementation.