### PR TITLE
fix: align stems to X noteheads using SMuFL anchors

### DIFF
--- a/src/stavenote.ts
+++ b/src/stavenote.ts
@@ -703,7 +703,7 @@ export class StaveNote extends StemmableNote {
     this.setYs(ys);
 
     if (this.stem) {
-      const { yTop, yBottom } = this.getNoteHeadBounds();
+      const { yTop, yBottom } = this.getStemYBounds();
       this.stem.setYBounds(yTop, yBottom);
     }
 
@@ -932,6 +932,29 @@ export class StaveNote extends StemmableNote {
    * @property {number} highestNonDisplacedLine
    * @property {number} lowestNonDisplacedLine
    */
+
+  /**
+   * Get Y bounds for the stem, adjusted for SMuFL stem anchor offsets defined in
+   * Tables.noteHeadStemYOffsets. This ensures stems attach at the correct point
+   * on the notehead (e.g. the arm tip of an X notehead) rather than the center.
+   */
+  protected getStemYBounds(): { yTop: number; yBottom: number } {
+    const anchorKey = this.stemDirection === Stem.UP ? 'up' : 'down';
+    let yTop = +Infinity;
+    let yBottom = -Infinity;
+    this._noteHeads.forEach((nh) => {
+      const offset = Tables.noteHeadStemYOffsets[nh.text];
+      const anchor = offset ? offset[anchorKey] : 0;
+      const y = nh.getY() - anchor * Tables.STAVE_LINE_DISTANCE;
+      yTop = Math.min(y, yTop);
+      yBottom = Math.max(y, yBottom);
+    });
+    if (!isFinite(yTop) || !isFinite(yBottom)) {
+      const bounds = this.getNoteHeadBounds();
+      return { yTop: bounds.yTop, yBottom: bounds.yBottom };
+    }
+    return { yTop, yBottom };
+  }
 
   /**
    * Get the staff line and y value for the highest & lowest noteheads

--- a/src/tables.ts
+++ b/src/tables.ts
@@ -424,6 +424,16 @@ export class Tables {
   static SLASH_NOTEHEAD_WIDTH = 15;
   static STAVE_LINE_DISTANCE = 10;
 
+  /**
+   * SMuFL stem anchor Y offsets for noteheads, in staff spaces (positive = above notehead center).
+   * Sourced from Bravura metadata `glyphsWithAnchors`: `stemUpSE[1]` (up) and `stemDownNW[1]` (down).
+   * Used to position the stem base at the correct SMuFL attachment point rather than the notehead center.
+   */
+  static readonly noteHeadStemYOffsets: Record<string, { up: number; down: number }> = {
+    [Glyphs.noteheadXBlack]: { up: 0.444, down: -0.44 },
+    [Glyphs.noteheadXHalf]: { up: 0.412, down: -0.412 },
+  };
+
   // HACK:
   // Since text origins are positioned at the baseline, we must
   // compensate for the ascender of the text. Of course, 1 staff space is


### PR DESCRIPTION
Use SMuFL stemUpSE and stemDownNW anchors from Bravura metadata to calculate correct stem Y bounds for X noteheads. This ensures stems attach at the arm tips rather than the vertical center of the notehead.

Fixes #314

Verification Results

Unit Tests: Verified locally on macOS. All 1,860 automated tests passed (0 failures).

Visual Regression: Strictly additive change. Logic only triggers for "x" noteheads; all other glyphs use original logic (zero unintended deltas).

Live Demo: [https://chrispaul.info/vexflow/demo-issue314.html](https://chrispaul.info/vexflow/demo-issue314.html)

edit: updated with "verification results"