### PR TITLE
Fix positioned articulation origins

### DIFF
--- a/src/element.ts
+++ b/src/element.ts
@@ -671,14 +671,17 @@ export class Element {
 
   setOriginX(x: number): void {
     const bbox = this.getBoundingBox();
-    const originX = Math.abs((bbox.getX() - this.xShift) / bbox.getW());
+    // getBoundingBox() is expressed in rendered coordinates. Remove both the
+    // element position and its current shift so repeated origin updates remain
+    // relative to the glyph's own bounds.
+    const originX = Math.abs((bbox.getX() - this.x - this.xShift) / bbox.getW());
     const xShift = (x - originX) * bbox.getW();
     this.xShift = -xShift;
   }
 
   setOriginY(y: number): void {
     const bbox = this.getBoundingBox();
-    const originY = Math.abs((bbox.getY() - this.yShift) / bbox.getH());
+    const originY = Math.abs((bbox.getY() - this.y - this.yShift) / bbox.getH());
     const yShift = (y - originY) * bbox.getH();
     this.yShift = -yShift;
   }

--- a/tests/articulation_tests.ts
+++ b/tests/articulation_tests.ts
@@ -28,6 +28,7 @@ const ArticulationTests = {
     run('Bounding Box', verticalPlacement, { drawBoundingBox: true });
     run('Vertical Placement', verticalPlacement, { drawBoundingBox: false });
     run('Vertical Placement (Glyph codes)', verticalPlacement2);
+    run('Origin remains stable after positioning', originRemainsStable);
     run('Staccato/Staccatissimo', drawArticulations, { sym1: 'a.', sym2: 'av' });
     run('Accent/Tenuto', drawArticulations, { sym1: 'a>', sym2: 'a-' });
     run('Marcato/L.H. Pizzicato', drawArticulations, { sym1: 'a^', sym2: 'a+' });
@@ -41,6 +42,27 @@ const ArticulationTests = {
     run('TabNote Articulation', tabNotes, { sym1: 'a.', sym2: 'a.' });
   },
 };
+
+function originRemainsStable(options: TestOptions): void {
+  const articulation = new Articulation('a.');
+  articulation.setOrigin(0.5, 1);
+  const initialXShift = articulation.getXShift();
+  const initialYShift = articulation.getYShift();
+
+  articulation.setX(240).setY(160);
+  articulation.setOrigin(0.5, 1);
+
+  options.assert.strictEqual(
+    articulation.getXShift(),
+    initialXShift,
+    'The glyph origin does not absorb the previous rendered x coordinate.'
+  );
+  options.assert.strictEqual(
+    articulation.getYShift(),
+    initialYShift,
+    'The glyph origin does not absorb the previous rendered y coordinate.'
+  );
+}
 
 // Helper function for creating StaveNotes.
 function drawArticulations(options: TestOptions): void {


### PR DESCRIPTION
## Summary
This fixes positioned articulations that drift to the wrong notehead/stem origin after the VexFlow 5 changes around notehead and modifier positioning.

## Validation
- `npm run lint`
- `PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome-stable npm test`
