### PR TITLE
Add source-scoped formatter layout padding

### DIFF
--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -503,6 +503,24 @@ export class Formatter {
     return this.minTotalWidth;
   }
 
+  /**
+   * Return the exact portion of the minimum width contributed by layout-only
+   * TickContext padding. Call after preCalculateMinTotalWidth() or format().
+   *
+   * Consumers can use this to keep hard engraving clearances separate from
+   * elastic rhythmic spacing.
+   */
+  getMinTotalWidthLayoutPadding(): number {
+    if (!this.hasMinTotalWidth) {
+      throw new RuntimeError(
+        'NoMinTotalWidth',
+        "Call 'preCalculateMinTotalWidth' or 'preFormat' before calling 'getMinTotalWidthLayoutPadding'"
+      );
+    }
+
+    return this.tickContexts?.array.reduce((width, context) => width + context.getLayoutPaddingWidth(), 0) ?? 0;
+  }
+
   /** Calculate the resolution multiplier for `voices`, which is the
    * least common multiple of all the voices' getResolutionMultiplier() results. */
   static getResolutionMultiplier(voices: Voice[]): number {

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -764,6 +764,22 @@ export class Formatter {
                 maxNegativeShiftPx = Math.min(maxNegativeShiftPx, insideLeftEdge - insideRightEdge);
               });
 
+              // Preserve the full shared-column boundary established by TickContext.preFormat().
+              // The per-voice checks above protect drawable noteheads and modifiers, but layout-only
+              // padding may originate from a different tickable in either shared context. Without
+              // this adjacent-context bound, softmax justification can reclaim that clearance.
+              const contextMetrics = context.getMetrics();
+              const prevContextMetrics = prevContext.getMetrics();
+              if (contextMetrics.layoutPaddingLeftPx > 0 || prevContextMetrics.layoutPaddingRightPx > 0) {
+                const adjacentInsideLeftEdge = context.getX() - contextMetrics.totalLeftPx;
+                const adjacentInsideRightEdge =
+                  prevContext.getX() + prevContextMetrics.notePx + prevContextMetrics.totalRightPx;
+                maxNegativeShiftPx = Math.min(
+                  maxNegativeShiftPx,
+                  Math.max(0, adjacentInsideLeftEdge - adjacentInsideRightEdge)
+                );
+              }
+
               // Don't shift further left than the notehead of the last context. Actually, stay at most 5% to the right
               // so that two different tick contexts don't align across staves.
               maxNegativeShiftPx = Math.min(

--- a/src/note.ts
+++ b/src/note.ts
@@ -40,6 +40,10 @@ export interface NoteMetrics {
   glyphWidth?: number;
   /** The width of the note head only. */
   notePx: number;
+  /** Layout-only clearance before the rhythmic column. */
+  layoutPaddingLeftPx: number;
+  /** Layout-only clearance after the rhythmic column. */
+  layoutPaddingRightPx: number;
   /** Start `X` for left modifiers. */
   modLeftPx: number;
   /** Start `X` for right modifiers. */
@@ -258,6 +262,8 @@ export abstract class Note extends Tickable {
     strokePx: number;
   };
   protected duration: string;
+  protected layoutPaddingLeftPx: number;
+  protected layoutPaddingRightPx: number;
   protected leftDisplacedHeadPx: number;
   protected rightDisplacedHeadPx: number;
   protected noteType: string;
@@ -317,6 +323,8 @@ export abstract class Note extends Tickable {
 
     // Positioning variables
     this.width = 0; // Width in pixels calculated after preFormat
+    this.layoutPaddingLeftPx = 0;
+    this.layoutPaddingRightPx = 0;
     this.leftDisplacedHeadPx = 0; // Extra room on left for displaced note head
     this.rightDisplacedHeadPx = 0; // Extra room on right for displaced note head
     this.xShift = 0; // X shift from tick context X
@@ -619,6 +627,8 @@ export abstract class Note extends Tickable {
       width,
       glyphWidth,
       notePx,
+      layoutPaddingLeftPx: this.layoutPaddingLeftPx,
+      layoutPaddingRightPx: this.layoutPaddingRightPx,
 
       // Modifier spacing.
       modLeftPx,
@@ -628,6 +638,29 @@ export abstract class Note extends Tickable {
       leftDisplacedHeadPx: this.leftDisplacedHeadPx,
       rightDisplacedHeadPx: this.rightDisplacedHeadPx,
       glyphPx: 0,
+    };
+  }
+
+  /**
+   * Add directional clearance used only by the formatter.
+   *
+   * Layout padding contributes to the shared rhythmic column's extents, but is
+   * deliberately excluded from this note's drawable width and bounding box.
+   */
+  setLayoutPadding(leftPx: number, rightPx: number): this {
+    if (!Number.isFinite(leftPx) || leftPx < 0 || !Number.isFinite(rightPx) || rightPx < 0) {
+      throw new RuntimeError('BadArgument', 'Layout padding must contain finite non-negative values.');
+    }
+    this.layoutPaddingLeftPx = leftPx;
+    this.layoutPaddingRightPx = rightPx;
+    this.preFormatted = false;
+    return this;
+  }
+
+  getLayoutPadding(): { leftPx: number; rightPx: number } {
+    return {
+      leftPx: this.layoutPaddingLeftPx,
+      rightPx: this.layoutPaddingRightPx,
     };
   }
 

--- a/src/note.ts
+++ b/src/note.ts
@@ -264,6 +264,9 @@ export abstract class Note extends Tickable {
   protected duration: string;
   protected layoutPaddingLeftPx: number;
   protected layoutPaddingRightPx: number;
+  protected legacyLayoutPaddingLeftPx: number;
+  protected legacyLayoutPaddingRightPx: number;
+  protected readonly layoutPaddingBySource: Map<string, { leftPx: number; rightPx: number }>;
   protected leftDisplacedHeadPx: number;
   protected rightDisplacedHeadPx: number;
   protected noteType: string;
@@ -325,6 +328,9 @@ export abstract class Note extends Tickable {
     this.width = 0; // Width in pixels calculated after preFormat
     this.layoutPaddingLeftPx = 0;
     this.layoutPaddingRightPx = 0;
+    this.legacyLayoutPaddingLeftPx = 0;
+    this.legacyLayoutPaddingRightPx = 0;
+    this.layoutPaddingBySource = new Map();
     this.leftDisplacedHeadPx = 0; // Extra room on left for displaced note head
     this.rightDisplacedHeadPx = 0; // Extra room on right for displaced note head
     this.xShift = 0; // X shift from tick context X
@@ -646,15 +652,65 @@ export abstract class Note extends Tickable {
    *
    * Layout padding contributes to the shared rhythmic column's extents, but is
    * deliberately excluded from this note's drawable width and bounding box.
+   *
+   * This compatibility setter controls the note's unnamed padding requirement.
+   * Named requirements set with `setLayoutPaddingForSource()` are retained and
+   * combined with it using the maximum requirement in each direction.
    */
   setLayoutPadding(leftPx: number, rightPx: number): this {
+    this.validateLayoutPadding(leftPx, rightPx);
+    this.legacyLayoutPaddingLeftPx = leftPx;
+    this.legacyLayoutPaddingRightPx = rightPx;
+    this.recalculateLayoutPadding();
+    return this;
+  }
+
+  /**
+   * Set a named directional layout requirement.
+   *
+   * Independent sources combine by taking the maximum left and right
+   * requirement. Re-setting a source replaces its previous requirement.
+   */
+  setLayoutPaddingForSource(source: string, leftPx: number, rightPx: number): this {
+    this.validateLayoutPaddingSource(source);
+    this.validateLayoutPadding(leftPx, rightPx);
+    this.layoutPaddingBySource.set(source, { leftPx, rightPx });
+    this.recalculateLayoutPadding();
+    return this;
+  }
+
+  /** Remove a named directional layout requirement. */
+  clearLayoutPaddingForSource(source: string): this {
+    this.validateLayoutPaddingSource(source);
+    if (this.layoutPaddingBySource.delete(source)) {
+      this.recalculateLayoutPadding();
+    }
+    return this;
+  }
+
+  protected validateLayoutPadding(leftPx: number, rightPx: number): void {
     if (!Number.isFinite(leftPx) || leftPx < 0 || !Number.isFinite(rightPx) || rightPx < 0) {
       throw new RuntimeError('BadArgument', 'Layout padding must contain finite non-negative values.');
     }
+  }
+
+  protected validateLayoutPaddingSource(source: string): void {
+    if (typeof source !== 'string' || source.length === 0) {
+      throw new RuntimeError('BadArgument', 'Layout padding source must be a non-empty string.');
+    }
+  }
+
+  protected recalculateLayoutPadding(): void {
+    let leftPx = this.legacyLayoutPaddingLeftPx;
+    let rightPx = this.legacyLayoutPaddingRightPx;
+    this.layoutPaddingBySource.forEach((padding) => {
+      leftPx = Math.max(leftPx, padding.leftPx);
+      rightPx = Math.max(rightPx, padding.rightPx);
+    });
     this.layoutPaddingLeftPx = leftPx;
     this.layoutPaddingRightPx = rightPx;
     this.preFormatted = false;
-    return this;
+    this.tickContext?.invalidatePreFormat();
   }
 
   getLayoutPadding(): { leftPx: number; rightPx: number } {

--- a/src/tickcontext.ts
+++ b/src/tickcontext.ts
@@ -39,6 +39,8 @@ export class TickContext {
   protected xOffset: number;
   protected notePx: number;
   protected glyphPx: number;
+  protected layoutPaddingLeftPx: number;
+  protected layoutPaddingRightPx: number;
   protected leftDisplacedHeadPx: number;
   protected rightDisplacedHeadPx: number;
   protected modLeftPx: number;
@@ -84,6 +86,8 @@ export class TickContext {
     // Formatting metrics
     this.notePx = 0; // width of widest note in this context
     this.glyphPx = 0; // width of glyph (note head)
+    this.layoutPaddingLeftPx = 0;
+    this.layoutPaddingRightPx = 0;
     this.leftDisplacedHeadPx = 0; // Extra left pixels for displaced notes
     this.rightDisplacedHeadPx = 0; // Extra right pixels for displaced notes
     this.modLeftPx = 0; // Left modifier pixels
@@ -186,6 +190,8 @@ export class TickContext {
       width,
       glyphPx,
       notePx,
+      layoutPaddingLeftPx,
+      layoutPaddingRightPx,
       leftDisplacedHeadPx,
       rightDisplacedHeadPx,
       modLeftPx,
@@ -197,6 +203,8 @@ export class TickContext {
       width, // Width of largest tickable in context
       glyphPx, // Width of largest glyph (note head)
       notePx, // Width of notehead + stem
+      layoutPaddingLeftPx,
+      layoutPaddingRightPx,
       leftDisplacedHeadPx, // Left modifiers
       rightDisplacedHeadPx, // Right modifiers
       modLeftPx,
@@ -262,13 +270,23 @@ export class TickContext {
       // Maintain the widest note head
       this.glyphPx = Math.max(this.glyphPx, metrics.glyphWidth ?? 0);
 
+      // Maintain layout-only clearance requested by any tickable in this shared column.
+      this.layoutPaddingLeftPx = Math.max(this.layoutPaddingLeftPx, metrics.layoutPaddingLeftPx);
+      this.layoutPaddingRightPx = Math.max(this.layoutPaddingRightPx, metrics.layoutPaddingRightPx);
+
       // Total modifier shift
       this.modLeftPx = Math.max(this.modLeftPx, metrics.modLeftPx);
       this.modRightPx = Math.max(this.modRightPx, metrics.modRightPx);
 
       // Total shift
-      this.totalLeftPx = Math.max(this.totalLeftPx, metrics.modLeftPx + metrics.leftDisplacedHeadPx);
-      this.totalRightPx = Math.max(this.totalRightPx, metrics.modRightPx + metrics.rightDisplacedHeadPx);
+      this.totalLeftPx = Math.max(
+        this.totalLeftPx,
+        metrics.layoutPaddingLeftPx + metrics.modLeftPx + metrics.leftDisplacedHeadPx
+      );
+      this.totalRightPx = Math.max(
+        this.totalRightPx,
+        metrics.layoutPaddingRightPx + metrics.modRightPx + metrics.rightDisplacedHeadPx
+      );
 
       // Recalculate the tick context total width
       this.width = this.notePx + this.totalLeftPx + this.totalRightPx;

--- a/src/tickcontext.ts
+++ b/src/tickcontext.ts
@@ -18,6 +18,21 @@ export interface TickContextOptions {
   tickID: number;
 }
 
+interface LayoutPaddingTickable {
+  getLayoutPadding(): { leftPx: number; rightPx: number };
+  setLayoutPaddingForSource(source: string, leftPx: number, rightPx: number): unknown;
+  clearLayoutPaddingForSource(source: string): unknown;
+}
+
+function isLayoutPaddingTickable(tickable: Tickable): tickable is Tickable & LayoutPaddingTickable {
+  const candidate = tickable as Tickable & Partial<LayoutPaddingTickable>;
+  return (
+    typeof candidate.getLayoutPadding === 'function' &&
+    typeof candidate.setLayoutPaddingForSource === 'function' &&
+    typeof candidate.clearLayoutPaddingForSource === 'function'
+  );
+}
+
 /**
  * TickContext formats abstract tickable objects, such as notes, chords, tabs, etc.
  *
@@ -45,6 +60,8 @@ export class TickContext {
   protected rightDisplacedHeadPx: number;
   protected modLeftPx: number;
   protected modRightPx: number;
+  protected totalLeftPxWithoutLayoutPadding: number;
+  protected totalRightPxWithoutLayoutPadding: number;
   protected totalLeftPx: number;
   protected totalRightPx: number;
   protected maxTickable?: Tickable;
@@ -92,6 +109,8 @@ export class TickContext {
     this.rightDisplacedHeadPx = 0; // Extra right pixels for displaced notes
     this.modLeftPx = 0; // Left modifier pixels
     this.modRightPx = 0; // Right modifier pixels
+    this.totalLeftPxWithoutLayoutPadding = 0;
+    this.totalRightPxWithoutLayoutPadding = 0;
     this.totalLeftPx = 0; // Total left pixels
     this.totalRightPx = 0; // Total right pixels
     this.tContexts = []; // Parent array of tick contexts
@@ -184,6 +203,37 @@ export class TickContext {
     return this.tickables.filter((tickable) => tickable.isCenterAligned());
   }
 
+  /**
+   * Add a named amount of effective clearance to both sides of this shared
+   * rhythmic column.
+   *
+   * The source is first removed from every layout-capable tickable. Its new
+   * requirement is then based on each tickable's remaining effective padding,
+   * which makes reapplication idempotent. Applying the delta to every voice
+   * also prevents another voice's wider modifier from masking the clearance.
+   */
+  applyLayoutPaddingForSource(source: string, leftDeltaPx: number, rightDeltaPx: number): this {
+    this.validateLayoutPaddingSource(source);
+    this.validateLayoutPaddingDelta(leftDeltaPx, rightDeltaPx);
+
+    const layoutTickables = this.tickables.filter(isLayoutPaddingTickable);
+    layoutTickables.forEach((tickable) => tickable.clearLayoutPaddingForSource(source));
+    layoutTickables.forEach((tickable) => {
+      const baseline = tickable.getLayoutPadding();
+      tickable.setLayoutPaddingForSource(source, baseline.leftPx + leftDeltaPx, baseline.rightPx + rightDeltaPx);
+    });
+    this.invalidatePreFormat();
+    return this;
+  }
+
+  /** Remove a named effective-context clearance from every capable tickable. */
+  clearLayoutPaddingForSource(source: string): this {
+    this.validateLayoutPaddingSource(source);
+    this.tickables.filter(isLayoutPaddingTickable).forEach((tickable) => tickable.clearLayoutPaddingForSource(source));
+    this.invalidatePreFormat();
+    return this;
+  }
+
   /** Gets widths context, note and left/right modifiers for formatting. */
   getMetrics(): TickContextMetrics {
     const {
@@ -214,13 +264,27 @@ export class TickContext {
     };
   }
 
+  /**
+   * Return the exact amount by which layout-only padding increased this
+   * context's minimum width. This excludes clearance already supplied by
+   * drawable modifiers or displaced noteheads.
+   */
+  getLayoutPaddingWidth(): number {
+    return (
+      this.totalLeftPx -
+      this.totalLeftPxWithoutLayoutPadding +
+      this.totalRightPx -
+      this.totalRightPxWithoutLayoutPadding
+    );
+  }
+
   getCurrentTick(): Fraction {
     return this.currentTick;
   }
 
   setCurrentTick(tick: Fraction): void {
     this.currentTick = tick;
-    this.preFormatted = false;
+    this.invalidatePreFormat();
   }
 
   addTickable(tickable: Tickable, voiceIndex?: number): this {
@@ -248,13 +312,14 @@ export class TickContext {
     tickable.setTickContext(this);
     this.tickables.push(tickable);
     this.tickablesByVoice[voiceIndex ?? 0] = tickable;
-    this.preFormatted = false;
+    this.invalidatePreFormat();
     return this;
   }
 
   preFormat(): this {
     if (this.preFormatted) return this;
 
+    this.resetPreFormatGeometry();
     for (let i = 0; i < this.tickables.length; ++i) {
       const tickable = this.tickables[i];
       tickable.preFormat();
@@ -279,6 +344,14 @@ export class TickContext {
       this.modRightPx = Math.max(this.modRightPx, metrics.modRightPx);
 
       // Total shift
+      this.totalLeftPxWithoutLayoutPadding = Math.max(
+        this.totalLeftPxWithoutLayoutPadding,
+        metrics.modLeftPx + metrics.leftDisplacedHeadPx
+      );
+      this.totalRightPxWithoutLayoutPadding = Math.max(
+        this.totalRightPxWithoutLayoutPadding,
+        metrics.modRightPx + metrics.rightDisplacedHeadPx
+      );
       this.totalLeftPx = Math.max(
         this.totalLeftPx,
         metrics.layoutPaddingLeftPx + metrics.modLeftPx + metrics.leftDisplacedHeadPx
@@ -292,7 +365,46 @@ export class TickContext {
       this.width = this.notePx + this.totalLeftPx + this.totalRightPx;
     }
 
+    this.preFormatted = true;
     return this;
+  }
+
+  /**
+   * Invalidate cached pre-format geometry. The next `preFormat()` starts from
+   * zeroed aggregates, so removing or reducing padding can shrink the context.
+   */
+  invalidatePreFormat(): this {
+    this.preFormatted = false;
+    this.postFormatted = false;
+    return this;
+  }
+
+  protected resetPreFormatGeometry(): void {
+    this.notePx = 0;
+    this.glyphPx = 0;
+    this.layoutPaddingLeftPx = 0;
+    this.layoutPaddingRightPx = 0;
+    this.leftDisplacedHeadPx = 0;
+    this.rightDisplacedHeadPx = 0;
+    this.modLeftPx = 0;
+    this.modRightPx = 0;
+    this.totalLeftPxWithoutLayoutPadding = 0;
+    this.totalRightPxWithoutLayoutPadding = 0;
+    this.totalLeftPx = 0;
+    this.totalRightPx = 0;
+    this.width = 0;
+  }
+
+  protected validateLayoutPaddingSource(source: string): void {
+    if (typeof source !== 'string' || source.length === 0) {
+      throw new RuntimeError('BadArgument', 'Layout padding source must be a non-empty string.');
+    }
+  }
+
+  protected validateLayoutPaddingDelta(leftDeltaPx: number, rightDeltaPx: number): void {
+    if (!Number.isFinite(leftDeltaPx) || leftDeltaPx < 0 || !Number.isFinite(rightDeltaPx) || rightDeltaPx < 0) {
+      throw new RuntimeError('BadArgument', 'Layout padding delta must contain finite non-negative values.');
+    }
   }
 
   postFormat(): this {

--- a/tests/mocks.ts
+++ b/tests/mocks.ts
@@ -44,6 +44,8 @@ class MockTickable extends Tickable {
       width: 0,
       glyphWidth: 0,
       notePx: this.width,
+      layoutPaddingLeftPx: 0,
+      layoutPaddingRightPx: 0,
       modLeftPx: 0,
       modRightPx: 0,
       leftDisplacedHeadPx: 0,

--- a/tests/stavenote_tests.ts
+++ b/tests/stavenote_tests.ts
@@ -397,6 +397,29 @@ function directionalLayoutPadding(assert: Assert): void {
     baselineBoundingBox.getW(),
     'layout-only padding does not widen the drawable bounding box'
   );
+
+  const notes = [
+    new StaveNote({ keys: ['c/4'], duration: 'q' }).setStave(stave).setLayoutPadding(0, 120),
+    new StaveNote({ keys: ['d/4'], duration: 'q' }).setStave(stave),
+    new StaveNote({ keys: ['e/4'], duration: 'q' }).setStave(stave),
+    new StaveNote({ keys: ['f/4'], duration: 'q' }).setStave(stave),
+  ];
+  const voice = new Voice({ numBeats: 4, beatValue: 4 }).addTickables(notes);
+  const formatter = new Formatter().joinVoices([voice]);
+  const minimumWidth = formatter.preCalculateMinTotalWidth([voice]);
+  formatter.format([voice], minimumWidth);
+  const justifiedContexts = formatter.getTickContexts()!.array;
+  const firstJustifiedMetrics = justifiedContexts[0].getMetrics();
+  const secondJustifiedMetrics = justifiedContexts[1].getMetrics();
+  const finalGap =
+    justifiedContexts[1].getX() -
+    secondJustifiedMetrics.totalLeftPx -
+    (justifiedContexts[0].getX() + firstJustifiedMetrics.notePx + firstJustifiedMetrics.totalRightPx);
+
+  assert.ok(
+    finalGap >= -0.001,
+    `softmax justification preserves layout-only clearance (final gap ${finalGap.toFixed(3)}px)`
+  );
 }
 
 function drawBasic(options: TestOptions, contextBuilder: ContextBuilder): void {

--- a/tests/stavenote_tests.ts
+++ b/tests/stavenote_tests.ts
@@ -43,6 +43,7 @@ const StaveNoteTests = {
     QUnit.test('Width', width);
     QUnit.test('TickContext', tickContext);
     QUnit.test('Directional layout padding', directionalLayoutPadding);
+    QUnit.test('Named layout padding', namedLayoutPadding);
 
     const run = VexFlowTests.runTests;
     run('StaveNote Draw - Treble', drawBasic, { clef: 'treble', octaveShift: 0, restKey: 'r/4' });
@@ -420,6 +421,91 @@ function directionalLayoutPadding(assert: Assert): void {
     finalGap >= -0.001,
     `softmax justification preserves layout-only clearance (final gap ${finalGap.toFixed(3)}px)`
   );
+
+  const modifierBaseline = new StaveNote({ keys: ['c/4'], duration: 'q' }).setStave(stave);
+  modifierBaseline.addModifier(new Accidental('b'), 0);
+  const baselineVoice = new Voice({ numBeats: 1, beatValue: 4 }).addTickable(modifierBaseline);
+  const baselineFormatter = new Formatter().joinVoices([baselineVoice]);
+  const baselineWidth = baselineFormatter.preCalculateMinTotalWidth([baselineVoice]);
+
+  const paddedWithModifier = new StaveNote({ keys: ['c/4'], duration: 'q' }).setStave(stave).setLayoutPadding(40, 25);
+  paddedWithModifier.addModifier(new Accidental('b'), 0);
+  const paddedVoice = new Voice({ numBeats: 1, beatValue: 4 }).addTickable(paddedWithModifier);
+  const paddedFormatter = new Formatter().joinVoices([paddedVoice]);
+  const paddedWidth = paddedFormatter.preCalculateMinTotalWidth([paddedVoice]);
+  const hardPaddingWidth = paddedFormatter.getMinTotalWidthLayoutPadding();
+
+  assert.equal(
+    paddedWidth - baselineWidth,
+    hardPaddingWidth,
+    'formatter reports the exact hard-padding contribution beyond drawable modifiers'
+  );
+}
+
+function namedLayoutPadding(assert: Assert): void {
+  const stave = new Stave(10, 10, 400);
+  const note = new StaveNote({ keys: ['c/4'], duration: 'q' }).setStave(stave).setLayoutPadding(4, 5);
+
+  note.setLayoutPaddingForSource('lyrics', 12, 3);
+  note.setLayoutPaddingForSource('rests', 7, 14);
+  assert.deepEqual(
+    note.getLayoutPadding(),
+    { leftPx: 12, rightPx: 14 },
+    'independent named sources and legacy padding combine by directional maximum'
+  );
+
+  note.clearLayoutPaddingForSource('lyrics');
+  assert.deepEqual(
+    note.getLayoutPadding(),
+    { leftPx: 7, rightPx: 14 },
+    'clearing one source restores the remaining named requirements'
+  );
+  note.clearLayoutPaddingForSource('rests');
+  assert.deepEqual(
+    note.getLayoutPadding(),
+    { leftPx: 4, rightPx: 5 },
+    'clearing every named source restores the compatibility-setter baseline'
+  );
+
+  const modified = new StaveNote({ keys: ['d/4'], duration: 'q' }).setStave(stave);
+  modified.addModifier(new Accidental('b'), 0);
+  modified.addToModifierContext(new ModifierContext());
+  const unmodified = new StaveNote({ keys: ['e/4'], duration: 'q' }).setStave(stave);
+  unmodified.addToModifierContext(new ModifierContext());
+  const context = new TickContext().addTickable(modified, 0).addTickable(unmodified, 1).preFormat();
+  const baseline = context.getMetrics();
+
+  context.applyLayoutPaddingForSource('constraint', 6, 9).preFormat();
+  const firstApplication = context.getMetrics();
+  assert.equal(
+    firstApplication.totalLeftPx - baseline.totalLeftPx,
+    6,
+    'effective-context left clearance is not masked by a modifier in another voice'
+  );
+  assert.equal(
+    firstApplication.totalRightPx - baseline.totalRightPx,
+    9,
+    'effective-context right clearance is added to the complete shared column'
+  );
+
+  context.applyLayoutPaddingForSource('constraint', 6, 9).preFormat();
+  assert.deepEqual(context.getMetrics(), firstApplication, 'reapplying the same named context clearance is idempotent');
+
+  context.applyLayoutPaddingForSource('constraint', 2, 3).preFormat();
+  const reduced = context.getMetrics();
+  assert.equal(
+    reduced.totalLeftPx - baseline.totalLeftPx,
+    2,
+    'reapplying a smaller left clearance recomputes and shrinks context geometry'
+  );
+  assert.equal(
+    reduced.totalRightPx - baseline.totalRightPx,
+    3,
+    'reapplying a smaller right clearance recomputes and shrinks context geometry'
+  );
+
+  context.clearLayoutPaddingForSource('constraint').preFormat();
+  assert.deepEqual(context.getMetrics(), baseline, 'clearing context clearance restores baseline geometry');
 }
 
 function drawBasic(options: TestOptions, contextBuilder: ContextBuilder): void {

--- a/tests/stavenote_tests.ts
+++ b/tests/stavenote_tests.ts
@@ -28,6 +28,7 @@ import { Stem } from '../src/stem';
 import { StringNumber } from '../src/stringnumber';
 import { Stroke } from '../src/strokes';
 import { TickContext } from '../src/tickcontext';
+import { Voice } from '../src/voice';
 
 const StaveNoteTests = {
   Start(): void {
@@ -41,6 +42,7 @@ const StaveNoteTests = {
     QUnit.test('StaveLine', staveLine);
     QUnit.test('Width', width);
     QUnit.test('TickContext', tickContext);
+    QUnit.test('Directional layout padding', directionalLayoutPadding);
 
     const run = VexFlowTests.runTests;
     run('StaveNote Draw - Treble', drawBasic, { clef: 'treble', octaveShift: 0, restKey: 'r/4' });
@@ -338,6 +340,63 @@ function tickContext(assert: Assert): void {
   new TickContext().addTickable(note).preFormat().setX(10).setPadding(0);
 
   assert.expect(0);
+}
+
+function directionalLayoutPadding(assert: Assert): void {
+  const stave = new Stave(10, 10, 400);
+  const createPair = (leftPx = 0, rightPx = 0) => {
+    const first = new StaveNote({ keys: ['c/4'], duration: 'q' }).setStave(stave).setLayoutPadding(leftPx, rightPx);
+    const second = new StaveNote({ keys: ['d/4'], duration: 'q' }).setStave(stave);
+    const voice = new Voice({ numBeats: 2, beatValue: 4 }).addTickables([first, second]);
+    const formatter = new Formatter().joinVoices([voice]).format([voice], 0);
+    const contexts = formatter.getTickContexts()!.array;
+    return {
+      first,
+      firstContext: contexts[0],
+      secondContext: contexts[1],
+    };
+  };
+
+  const baseline = createPair();
+  const padded = createPair(7, 13);
+  const baselineMetrics = baseline.firstContext.getMetrics();
+  const paddedMetrics = padded.firstContext.getMetrics();
+
+  assert.equal(
+    paddedMetrics.totalLeftPx - baselineMetrics.totalLeftPx,
+    7,
+    'left layout padding contributes to the shared tick context'
+  );
+  assert.equal(
+    paddedMetrics.totalRightPx - baselineMetrics.totalRightPx,
+    13,
+    'right layout padding contributes to the shared tick context'
+  );
+  assert.equal(
+    padded.secondContext.getX() - baseline.secondContext.getX(),
+    20,
+    'directional padding advances the following rhythmic column'
+  );
+  assert.equal(
+    padded.first.getMetrics().width,
+    baseline.first.getMetrics().width,
+    'layout-only padding does not change the drawable note width'
+  );
+
+  baseline.firstContext.setX(100);
+  padded.firstContext.setX(100);
+  const baselineBoundingBox = baseline.first.getBoundingBox();
+  const paddedBoundingBox = padded.first.getBoundingBox();
+  assert.equal(
+    paddedBoundingBox.getX(),
+    baselineBoundingBox.getX(),
+    'layout-only padding does not shift the drawable bounding box'
+  );
+  assert.equal(
+    paddedBoundingBox.getW(),
+    baselineBoundingBox.getW(),
+    'layout-only padding does not widen the drawable bounding box'
+  );
 }
 
 function drawBasic(options: TestOptions, contextBuilder: ContextBuilder): void {


### PR DESCRIPTION
## Summary

- add directional, source-scoped layout padding to notes and tick contexts
- preserve hard minimum distances during formatter justification
- allow a caller to replace or remove its own padding without disturbing other constraints
- leave existing score layout unchanged when no external padding is supplied

This gives notation consumers a typed way to express collision clearances without folding hard constraints into rhythmic spacing or repeatedly accumulating padding across rerenders.

## Validation

- `npm run lint` under Node 24
- `PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome-stable npm test` under Node 24
- 1,862 QUnit tests passed
