### PR TITLE
Expose finalized notation geometry

### DIFF
--- a/src/articulation.ts
+++ b/src/articulation.ts
@@ -2,6 +2,7 @@
 // @author Larry Kuhns.
 // MIT License
 
+import { BoundingBox } from './boundingbox';
 import { Builder } from './easyscore';
 import { Glyphs } from './glyphs';
 import { Modifier } from './modifier';
@@ -19,6 +20,15 @@ export interface ArticulationStruct {
   aboveCode?: string;
   belowCode?: string;
   betweenLines: boolean;
+}
+
+export interface ArticulationLayout {
+  x: number;
+  y: number;
+  boundingBox: BoundingBox;
+  position: number;
+  index: number;
+  outwardShift: number;
 }
 
 // eslint-disable-next-line
@@ -180,6 +190,8 @@ export class Articulation extends Modifier {
   protected articulation: ArticulationStruct;
 
   protected heightShift = 0;
+  protected outwardShift = 0;
+  protected layoutResult?: ArticulationLayout;
   /**
    * FIXME:
    * Most of the complex formatting logic (ie: snapping to space) is
@@ -322,30 +334,61 @@ export class Articulation extends Modifier {
       this.articulation.code ||
       Glyphs.null;
     this.text = code;
+    this.layoutResult = undefined;
   }
 
   /** Set if articulation should be rendered between lines. */
   setBetweenLines(betweenLines = true): this {
     this.articulation.betweenLines = betweenLines;
+    this.layoutResult = undefined;
     return this;
   }
 
-  /** Render articulation in position next to note. */
-  override draw(): void {
-    const ctx = this.checkContext();
-    const note = this.checkAttachedNote();
-    this.setRendered();
+  /**
+   * Move the articulation away from the staff by an absolute number of pixels.
+   * Reapplying the same value is idempotent; callers never have to undo an old
+   * relative y-shift before recalculating slur clearance.
+   */
+  setOutwardShift(outwardShift: number): this {
+    if (!Number.isFinite(outwardShift) || outwardShift < 0) {
+      throw new RuntimeError('BadArguments', 'Articulation outward shift must be a finite non-negative number.');
+    }
+    this.outwardShift = outwardShift;
+    this.layoutResult = undefined;
+    return this;
+  }
 
+  getOutwardShift(): number {
+    return this.outwardShift;
+  }
+
+  /**
+   * Calculate final articulation geometry after note and beam formatting.
+   *
+   * This method is safe to call repeatedly. It derives x/y and origin from the
+   * current note geometry and the absolute outward shift instead of applying
+   * incremental changes to a previous render.
+   */
+  layout(): ArticulationLayout {
+    const note = this.checkAttachedNote();
     const index = this.checkIndex();
     const { position, textLine } = this;
     const canSitBetweenLines = this.articulation.betweenLines;
+
+    if (isStemmableNote(note)) {
+      note.getBeam()?.postFormat();
+    }
 
     const stave = note.checkStave();
     const staffSpace = stave.getSpacingBetweenLines();
     const isTab = isTabNote(note);
 
-    // Articulations are centered over/under the note head.
-    const { x } = note.getModifierStartXY(position, index);
+    // Articulations are centered over/under the selected note head, including
+    // displaced chord heads. Non-StaveNote types retain their native anchor.
+    let { x } = note.getModifierStartXY(position, index);
+    if (isStaveNote(note)) {
+      x = note.getSelectedNoteHeadBounds(index).centerX;
+    }
     const shouldSitOutsideStaff = !canSitBetweenLines || isTab;
 
     const initialOffset = getInitialOffset(note, position);
@@ -375,9 +418,43 @@ export class Articulation extends Modifier {
       y += Math.abs(snappedLine - articLine) * staffSpace * offsetDirection;
     }
 
+    y += this.outwardShift * (position === ABOVE ? -1 : 1);
+
     L(`Rendering articulation at (x: ${x}, y: ${y})`);
     this.x = x;
     this.y = y;
+    this.layoutResult = {
+      x,
+      y,
+      boundingBox: this.getBoundingBox().clone(),
+      position,
+      index,
+      outwardShift: this.outwardShift,
+    };
+    return this.getLayout();
+  }
+
+  /** Return a defensive copy of the most recently calculated geometry. */
+  getLayout(): ArticulationLayout {
+    if (!this.layoutResult) {
+      return this.layout();
+    }
+    return {
+      ...this.layoutResult,
+      boundingBox: this.layoutResult.boundingBox.clone(),
+    };
+  }
+
+  /** Render the already calculated articulation geometry. */
+  override draw(): void {
+    const ctx = this.checkContext();
+    // Legacy direct-draw clients may not run a formatter or the owning
+    // StaveNote layout. Keep that route functional, while normal formatted
+    // notes arrive here with final geometry.
+    if (!this.layoutResult) {
+      this.layout();
+    }
+    this.setRendered();
     this.renderText(ctx, 0, 0);
   }
 }

--- a/src/articulation.ts
+++ b/src/articulation.ts
@@ -375,10 +375,6 @@ export class Articulation extends Modifier {
     const { position, textLine } = this;
     const canSitBetweenLines = this.articulation.betweenLines;
 
-    if (isStemmableNote(note)) {
-      note.getBeam()?.postFormat();
-    }
-
     const stave = note.checkStave();
     const staffSpace = stave.getSpacingBetweenLines();
     const isTab = isTabNote(note);

--- a/src/beam.ts
+++ b/src/beam.ts
@@ -43,6 +43,12 @@ export const BEAM_BOTH = 'B';
 
 export type PartialBeamDirection = typeof BEAM_LEFT | typeof BEAM_RIGHT | typeof BEAM_BOTH;
 
+/** Final beam geometry in render-context pixels, shared by drawing and collision layout. */
+export interface BeamRenderPolygon {
+  points: [{ x: number; y: number }, { x: number; y: number }, { x: number; y: number }, { x: number; y: number }];
+  duration: string;
+}
+
 /** `Beams` span over a set of `StemmableNotes`. */
 export class Beam extends Element {
   static override get CATEGORY(): string {
@@ -918,16 +924,18 @@ export class Beam extends Element {
     }, this);
   }
 
-  // Render the beam lines
-  protected drawBeamLines(ctx: RenderContext): void {
+  /** Return the finalized beam polygons using exactly the geometry consumed by draw(). */
+  getRenderedBeamPolygons(): BeamRenderPolygon[] {
+    if (!this.postFormatted) {
+      this.postFormat();
+    }
     const validBeamDurations = ['4', '8', '16', '32', '64', '128', '256', '512', '1024'];
-
     const firstNote = this.notes[0];
     let beamY = this.getBeamYToDraw();
     const firstStemX = firstNote.getStemX();
     const beamThickness = this.renderOptions.beamWidth * this._stemDirection;
+    const polygons: BeamRenderPolygon[] = [];
 
-    // Draw the beams.
     for (let i = 0; i < validBeamDurations.length; ++i) {
       const duration = validBeamDurations[i];
       const beamLines = this.getBeamLines(duration);
@@ -938,22 +946,37 @@ export class Beam extends Element {
 
         const startBeamY = this.getSlopeY(startBeamX, firstStemX, beamY, this.slope);
         const lastBeamX = beamLine.end;
-        if (lastBeamX) {
+        if (lastBeamX !== undefined) {
           const lastBeamY = this.getSlopeY(lastBeamX, firstStemX, beamY, this.slope);
-
-          ctx.beginPath();
-          ctx.moveTo(startBeamX, startBeamY);
-          ctx.lineTo(startBeamX, startBeamY + beamThickness);
-          ctx.lineTo(lastBeamX + 1, lastBeamY + beamThickness);
-          ctx.lineTo(lastBeamX + 1, lastBeamY);
-          ctx.closePath();
-          ctx.fill();
+          polygons.push({
+            duration,
+            points: [
+              { x: startBeamX, y: startBeamY },
+              { x: startBeamX, y: startBeamY + beamThickness },
+              { x: lastBeamX + 1, y: lastBeamY + beamThickness },
+              { x: lastBeamX + 1, y: lastBeamY },
+            ],
+          });
         } else {
           throw new RuntimeError('NoLastBeamX', 'lastBeamX undefined.');
         }
       }
 
       beamY += beamThickness * 1.5;
+    }
+    return polygons;
+  }
+
+  // Render the beam lines
+  protected drawBeamLines(ctx: RenderContext): void {
+    for (const polygon of this.getRenderedBeamPolygons()) {
+      ctx.beginPath();
+      ctx.moveTo(polygon.points[0].x, polygon.points[0].y);
+      for (let index = 1; index < polygon.points.length; index++) {
+        ctx.lineTo(polygon.points[index].x, polygon.points[index].y);
+      }
+      ctx.closePath();
+      ctx.fill();
     }
   }
 

--- a/src/element.ts
+++ b/src/element.ts
@@ -671,14 +671,17 @@ export class Element {
 
   setOriginX(x: number): void {
     const bbox = this.getBoundingBox();
-    const originX = Math.abs((bbox.getX() - this.xShift) / bbox.getW());
+    // getBoundingBox() is expressed in rendered coordinates. Remove both the
+    // element position and its current shift so repeated origin updates remain
+    // relative to the glyph's own bounds.
+    const originX = Math.abs((bbox.getX() - this.x - this.xShift) / bbox.getW());
     const xShift = (x - originX) * bbox.getW();
     this.xShift = -xShift;
   }
 
   setOriginY(y: number): void {
     const bbox = this.getBoundingBox();
-    const originY = Math.abs((bbox.getY() - this.yShift) / bbox.getH());
+    const originY = Math.abs((bbox.getY() - this.y - this.yShift) / bbox.getH());
     const yShift = (y - originY) * bbox.getH();
     this.yShift = -yShift;
   }

--- a/src/modifiercontext.ts
+++ b/src/modifiercontext.ts
@@ -171,7 +171,10 @@ export class ModifierContext {
     if (this.postFormatted) return;
     L('Postformatting ModifierContext');
 
-    // If post-formatting is required for an element, add more lines below.
+    // Finalize beams and stems. Articulation geometry is calculated by the
+    // owning layout once the notes have their final staves and beam extents;
+    // draw() retains a legacy fallback for direct clients.
     StaveNote.postFormat(this.getMembers(Category.StaveNote) as Note[]);
+    this.postFormatted = true;
   }
 }

--- a/src/notehead.ts
+++ b/src/notehead.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2023-present VexFlow contributors: https://github.com/vexflow/vexflow/graphs/contributors
 // MIT License
 
+import { BoundingBox } from './boundingbox';
 import { ElementStyle } from './element';
 import { Note, NoteStruct } from './note';
 import { Stave } from './stave';
@@ -120,11 +121,30 @@ export class NoteHead extends Note {
     // to its tick context
     const x = !this.preFormatted ? this.x : super.getAbsoluteX();
 
-    // For a more natural displaced notehead, we adjust the displacement amount
-    // by half the stem width in order to maintain a slight overlap with the stem
-    const displacementStemAdjustment = Stem.WIDTH / 2;
+    return this.getRenderedX(x);
+  }
 
-    return x + (this.displaced ? (this.width - displacementStemAdjustment) * this.stemDirection : 0);
+  /**
+   * Return the rendered x coordinate for a notehead whose parent chord begins
+   * at `baseX`. Unlike `getAbsoluteX()`, this does not depend on or mutate the
+   * notehead's current draw state, so layout clients can query displaced chord
+   * heads before drawing.
+   */
+  getRenderedX(baseX: number): number {
+    // For a more natural displaced notehead, we adjust the displacement amount
+    // by half the stem width in order to maintain a slight overlap with the stem.
+    const displacementStemAdjustment = Stem.WIDTH / 2;
+    return baseX + (this.displaced ? (this.width - displacementStemAdjustment) * this.stemDirection : 0);
+  }
+
+  /**
+   * Return the exact glyph bounding box at the supplied parent-note x
+   * coordinate without changing the notehead's stored position.
+   */
+  getBoundingBoxAt(baseX: number): BoundingBox {
+    const boundingBox = super.getBoundingBox().clone();
+    boundingBox.setX(this.getRenderedX(baseX) + this.xShift);
+    return boundingBox;
   }
 
   /** Set notehead to a provided `stave`. */

--- a/src/stavenote.ts
+++ b/src/stavenote.ts
@@ -37,6 +37,19 @@ export interface StaveNoteHeadBounds {
   lowestNonDisplacedLine: number;
 }
 
+export interface StaveNoteSelectedNoteHeadBounds {
+  index: number;
+  boundingBox: BoundingBox;
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+  centerX: number;
+  centerY: number;
+  line: number;
+  displaced: boolean;
+}
+
 export interface StaveNoteFormatSettings {
   line: number;
   maxLine: number;
@@ -1030,6 +1043,46 @@ export class StaveNote extends StemmableNote {
     return this._noteHeads.slice();
   }
 
+  /**
+   * Return the exact pre-draw bounds for one selected head in a chord.
+   *
+   * The regular note bounding box includes stems, flags and modifiers. Slurs,
+   * ties and articulation layout instead need the glyph bounds for the exact
+   * MusicXML pitch they attach to, including VexFlow's chord-head displacement.
+   */
+  getNoteHeadBoundingBox(index: number): BoundingBox {
+    const noteHead = this._noteHeads[index];
+    if (!noteHead) {
+      throw new RuntimeError('BadArguments', `No notehead exists at index ${index}.`);
+    }
+    return noteHead.getBoundingBoxAt(this.getNoteHeadBeginX());
+  }
+
+  /** Return a serializable description of one selected notehead's geometry. */
+  getSelectedNoteHeadBounds(index: number): StaveNoteSelectedNoteHeadBounds {
+    const noteHead = this._noteHeads[index];
+    if (!noteHead) {
+      throw new RuntimeError('BadArguments', `No notehead exists at index ${index}.`);
+    }
+    const boundingBox = this.getNoteHeadBoundingBox(index);
+    const left = boundingBox.getX();
+    const top = boundingBox.getY();
+    const right = left + boundingBox.getW();
+    const bottom = top + boundingBox.getH();
+    return {
+      index,
+      boundingBox,
+      left,
+      right,
+      top,
+      bottom,
+      centerX: (left + right) / 2,
+      centerY: (top + bottom) / 2,
+      line: noteHead.getLine(),
+      displaced: noteHead.isDisplaced(),
+    };
+  }
+
   // Draw the ledger lines between the stave and the highest/lowest keys
   drawLedgerLines(): void {
     const stave = this.checkStave();
@@ -1148,6 +1201,27 @@ export class StaveNote extends StemmableNote {
     });
   }
 
+  /**
+   * Finalize notehead, stem, beam, and articulation geometry without drawing.
+   * Safe to call repeatedly after horizontal formatting or stave changes.
+   */
+  layoutArticulations(): void {
+    const xBegin = this.getNoteHeadBeginX();
+    this._noteHeads.forEach((notehead) => notehead.setX(xBegin));
+
+    if (this.stem) {
+      const stemX = this.getStemX();
+      this.stem.setNoteHeadXBounds(stemX, stemX);
+    }
+    this.beam?.postFormat();
+
+    for (const modifier of this.modifiers) {
+      if (modifier.getCategory() === Category.Articulation) {
+        (modifier as Modifier & { layout(): unknown }).layout();
+      }
+    }
+  }
+
   override drawStem(stemOptions?: StemOptions): void {
     // GCR TODO: I can't find any context in which this is called with the stemStruct
     // argument in the codebase or tests. Nor can I find a case where super.drawStem
@@ -1222,11 +1296,8 @@ export class StaveNote extends StemmableNote {
     const xBegin = this.getNoteHeadBeginX();
     const shouldRenderStem = this.hasStem() && !this.beam;
 
-    // Format note head x positions
     this._noteHeads.forEach((notehead) => notehead.setX(xBegin));
-
     if (this.stem) {
-      // Format stem x positions
       const stemX = this.getStemX();
       this.stem.setNoteHeadXBounds(stemX, stemX);
     }

--- a/src/stavenote.ts
+++ b/src/stavenote.ts
@@ -1206,6 +1206,11 @@ export class StaveNote extends StemmableNote {
    * Safe to call repeatedly after horizontal formatting or stave changes.
    */
   layoutArticulations(): void {
+    const articulations = this.modifiers.filter((modifier) => modifier.getCategory() === Category.Articulation);
+    if (articulations.length === 0) {
+      return;
+    }
+
     const xBegin = this.getNoteHeadBeginX();
     this._noteHeads.forEach((notehead) => notehead.setX(xBegin));
 
@@ -1215,10 +1220,8 @@ export class StaveNote extends StemmableNote {
     }
     this.beam?.postFormat();
 
-    for (const modifier of this.modifiers) {
-      if (modifier.getCategory() === Category.Articulation) {
-        (modifier as Modifier & { layout(): unknown }).layout();
-      }
+    for (const modifier of articulations) {
+      (modifier as Modifier & { layout(): unknown }).layout();
     }
   }
 

--- a/src/stavetie.ts
+++ b/src/stavetie.ts
@@ -18,6 +18,14 @@ export interface TieNotes {
   lastIndexes?: number[];
 }
 
+/** Final quadratic outlines in render-context pixels, shared by drawing and collision layout. */
+export interface TieRenderCurve {
+  start: { x: number; y: number };
+  topControl: { x: number; y: number };
+  end: { x: number; y: number };
+  bottomControl: { x: number; y: number };
+}
+
 export class StaveTie extends Element {
   static override get CATEGORY(): string {
     return Category.StaveTie;
@@ -134,49 +142,66 @@ export class StaveTie extends Element {
     }
 
     const ctx = this.checkContext();
-    let cp1 = this.renderOptions.cp1;
-    let cp2 = this.renderOptions.cp2;
-
-    if (Math.abs(params.lastX - params.firstX) < this.renderOptions.shortTieCutoff) {
-      // do not get super exaggerated curves for very short ties
-      cp1 = this.renderOptions.cp1Short;
-      cp2 = this.renderOptions.cp2Short;
-    }
-
-    const firstXShift = this.renderOptions.firstXShift;
-    const lastXShift = this.renderOptions.lastXShift;
-    const yShift = this.renderOptions.yShift * params.direction;
-
-    // setNotes(...) verified that firstIndexes and lastIndexes are not undefined.
-    // As a result, we use the ! non-null assertion operator here.
-
-    const firstIndexes = this.notes.firstIndexes!;
-
-    const lastIndexes = this.notes.lastIndexes!;
     const clsAttribute = this.getAttribute('class');
     ctx.openGroup('stavetie' + (clsAttribute ? ' ' + clsAttribute : ''), this.getAttribute('id'));
-    for (let i = 0; i < firstIndexes.length; ++i) {
-      const cpX = (params.lastX + lastXShift + (params.firstX + firstXShift)) / 2;
-      // firstY and lastY are specified in pixels.
-      const firstY = params.firstYs[firstIndexes[i]] + yShift;
-      const lastY = params.lastYs[lastIndexes[i]] + yShift;
-
-      if (isNaN(firstY) || isNaN(lastY)) {
-        throw new RuntimeError('BadArguments', 'Bad indexes for tie rendering.');
-      }
-
-      const topControlPointY = (firstY + lastY) / 2 + cp1 * params.direction;
-      const bottomControlPointY = (firstY + lastY) / 2 + cp2 * params.direction;
-
+    for (const curve of this.calculateRenderedTieCurves(params)) {
       ctx.beginPath();
-      ctx.moveTo(params.firstX + firstXShift, firstY);
-      ctx.quadraticCurveTo(cpX, topControlPointY, params.lastX + lastXShift, lastY);
-      ctx.quadraticCurveTo(cpX, bottomControlPointY, params.firstX + firstXShift, firstY);
+      ctx.moveTo(curve.start.x, curve.start.y);
+      ctx.quadraticCurveTo(curve.topControl.x, curve.topControl.y, curve.end.x, curve.end.y);
+      ctx.quadraticCurveTo(curve.bottomControl.x, curve.bottomControl.y, curve.start.x, curve.start.y);
       ctx.closePath();
       ctx.fill();
     }
     this.drawPointerRect();
     ctx.closeGroup();
+  }
+
+  private calculateRenderedTieCurves(params: {
+    direction: number;
+    firstX: number;
+    lastX: number;
+    lastYs: number[];
+    firstYs: number[];
+  }): TieRenderCurve[] {
+    let cp1 = this.renderOptions.cp1;
+    let cp2 = this.renderOptions.cp2;
+    if (Math.abs(params.lastX - params.firstX) < this.renderOptions.shortTieCutoff) {
+      cp1 = this.renderOptions.cp1Short;
+      cp2 = this.renderOptions.cp2Short;
+    }
+    const firstX = params.firstX + this.renderOptions.firstXShift;
+    const lastX = params.lastX + this.renderOptions.lastXShift;
+    const cpX = (lastX + firstX) / 2;
+    const yShift = this.renderOptions.yShift * params.direction;
+    const curves: TieRenderCurve[] = [];
+    const firstIndexes = this.notes.firstIndexes!;
+    const lastIndexes = this.notes.lastIndexes!;
+    for (let index = 0; index < firstIndexes.length; index++) {
+      const firstY = params.firstYs[firstIndexes[index]] + yShift;
+      const lastY = params.lastYs[lastIndexes[index]] + yShift;
+      if (isNaN(firstY) || isNaN(lastY)) {
+        throw new RuntimeError('BadArguments', 'Bad indexes for tie rendering.');
+      }
+      curves.push({
+        start: { x: firstX, y: firstY },
+        topControl: { x: cpX, y: (firstY + lastY) / 2 + cp1 * params.direction },
+        end: { x: lastX, y: lastY },
+        bottomControl: { x: cpX, y: (firstY + lastY) / 2 + cp2 * params.direction },
+      });
+    }
+    return curves;
+  }
+
+  /** Return the finalized tie outlines using exactly the geometry consumed by draw(). */
+  getRenderedTieCurves(): TieRenderCurve[] {
+    this.synchronizeIndexes();
+    return this.calculateRenderedTieCurves({
+      firstX: this.getFirstX(),
+      lastX: this.getLastX(),
+      firstYs: this.getFirstYs(),
+      lastYs: this.getLastYs(),
+      direction: this.getDirection(),
+    });
   }
 
   /**

--- a/tests/articulation_tests.ts
+++ b/tests/articulation_tests.ts
@@ -6,7 +6,7 @@
 import { VexFlow } from '../src/vexflow';
 import { TestOptions, VexFlowTests } from './vexflow_test_helpers';
 
-import { Articulation } from '../src/articulation';
+import { Articulation, ArticulationLayout } from '../src/articulation';
 import { Beam } from '../src/beam';
 import { Formatter } from '../src/formatter';
 import { Glyphs } from '../src/glyphs';
@@ -29,6 +29,9 @@ const ArticulationTests = {
     run('Vertical Placement', verticalPlacement, { drawBoundingBox: false });
     run('Vertical Placement (Glyph codes)', verticalPlacement2);
     run('Origin remains stable after positioning', originRemainsStable);
+    run('Pre-draw selected notehead layout', selectedNoteheadPreDrawLayout);
+    run('Final beam geometry precedes articulation layout', finalBeamGeometryLayout);
+    run('Outward displacement is absolute and idempotent', absoluteOutwardDisplacement);
     run('Staccato/Staccatissimo', drawArticulations, { sym1: 'a.', sym2: 'av' });
     run('Accent/Tenuto', drawArticulations, { sym1: 'a>', sym2: 'a-' });
     run('Marcato/L.H. Pizzicato', drawArticulations, { sym1: 'a^', sym2: 'a+' });
@@ -61,6 +64,94 @@ function originRemainsStable(options: TestOptions): void {
     articulation.getYShift(),
     initialYShift,
     'The glyph origin does not absorb the previous rendered y coordinate.'
+  );
+}
+
+function formatNotesToStave(stave: Stave, notes: StaveNote[], beats: number): void {
+  const voice = new Voice({ numBeats: beats, beatValue: 8 }).addTickables(notes);
+  new Formatter().joinVoices([voice]).formatToStave([voice], stave, { stave });
+}
+
+function assertClose(options: TestOptions, actual: number, expected: number, message: string): void {
+  options.assert.ok(Math.abs(actual - expected) <= 0.001, `${message}: expected ${expected}, got ${actual}`);
+}
+
+function selectedNoteheadPreDrawLayout(options: TestOptions, contextBuilder: ContextBuilder): void {
+  const ctx = contextBuilder(options.elementId, 420, 180);
+  const stave = new Stave(10, 40, 400).setContext(ctx);
+  const articulation = new Articulation('a.').setPosition(ModifierPosition.ABOVE);
+  const note = new StaveNote({
+    keys: ['b/4', 'c/5'],
+    duration: '8',
+    stemDirection: Stem.UP,
+  }).addModifier(articulation, 1);
+
+  formatNotesToStave(stave, [note], 1);
+
+  const selectedHead = note.getSelectedNoteHeadBounds(1);
+  note.layoutArticulations();
+  const firstLayout = articulation.getLayout();
+  const secondLayout = articulation.layout();
+  options.assert.ok(selectedHead.displaced, 'the selected upper chord head is displaced');
+  assertClose(
+    options,
+    firstLayout.x,
+    selectedHead.centerX,
+    'articulation is centered on the selected displaced notehead'
+  );
+  assertClose(options, secondLayout.x, firstLayout.x, 'repeated pre-draw layout keeps x stable');
+  assertClose(options, secondLayout.y, firstLayout.y, 'repeated pre-draw layout keeps y stable');
+
+  articulation.setContext(ctx);
+  articulation.draw();
+  const afterDraw = articulation.getLayout();
+  assertClose(options, afterDraw.x, firstLayout.x, 'draw consumes the calculated x without changing it');
+  assertClose(options, afterDraw.y, firstLayout.y, 'draw consumes the calculated y without changing it');
+}
+
+function finalBeamGeometryLayout(options: TestOptions, contextBuilder: ContextBuilder): void {
+  const ctx = contextBuilder(options.elementId, 420, 180);
+  const stave = new Stave(10, 40, 400).setContext(ctx);
+  const articulation = new Articulation('a>').setPosition(ModifierPosition.ABOVE);
+  const notes = [
+    new StaveNote({ keys: ['c/5'], duration: '8', stemDirection: Stem.UP }).addModifier(articulation, 0),
+    new StaveNote({ keys: ['g/5'], duration: '8', stemDirection: Stem.UP }),
+  ];
+  const beam = new Beam(notes);
+
+  formatNotesToStave(stave, notes, 2);
+
+  const firstLayout: ArticulationLayout = articulation.getLayout();
+  const firstStemTip = notes[0].getStemExtents().topY;
+  options.assert.ok(beam.postFormatted, 'beam geometry is finalized by formatter post-format');
+  options.assert.ok(firstLayout.y < firstStemTip, 'stem-side articulation clears the final beamed stem tip');
+
+  beam.postFormat();
+  const secondLayout = articulation.layout();
+  assertClose(options, secondLayout.x, firstLayout.x, 're-finalizing the beam does not move articulation x');
+  assertClose(options, secondLayout.y, firstLayout.y, 're-finalizing the beam does not move articulation y');
+}
+
+function absoluteOutwardDisplacement(options: TestOptions, contextBuilder: ContextBuilder): void {
+  const ctx = contextBuilder(options.elementId, 420, 180);
+  const stave = new Stave(10, 40, 400).setContext(ctx);
+  const articulation = new Articulation('a-').setPosition(ModifierPosition.ABOVE);
+  const note = new StaveNote({ keys: ['c/5'], duration: '8', stemDirection: Stem.DOWN }).addModifier(articulation, 0);
+
+  formatNotesToStave(stave, [note], 1);
+  const baseline = articulation.getLayout();
+  articulation.setOutwardShift(12);
+  const shifted = articulation.layout();
+  articulation.setOutwardShift(12);
+  const repeated = articulation.layout();
+
+  assertClose(options, shifted.y, baseline.y - 12, 'above articulation moves outward by the requested amount');
+  assertClose(options, repeated.y, shifted.y, 'reapplying the same outward shift does not accumulate');
+  assertClose(
+    options,
+    repeated.boundingBox.getY(),
+    shifted.boundingBox.getY(),
+    'the final articulation bounds remain stable'
   );
 }
 

--- a/tests/articulation_tests.ts
+++ b/tests/articulation_tests.ts
@@ -31,6 +31,7 @@ const ArticulationTests = {
     run('Origin remains stable after positioning', originRemainsStable);
     run('Pre-draw selected notehead layout', selectedNoteheadPreDrawLayout);
     run('Final beam geometry precedes articulation layout', finalBeamGeometryLayout);
+    run('Notes without articulations leave beam geometry alone', noArticulationLayoutIsNoop);
     run('Outward displacement is absolute and idempotent', absoluteOutwardDisplacement);
     run('Staccato/Staccatissimo', drawArticulations, { sym1: 'a.', sym2: 'av' });
     run('Accent/Tenuto', drawArticulations, { sym1: 'a>', sym2: 'a-' });
@@ -130,6 +131,27 @@ function finalBeamGeometryLayout(options: TestOptions, contextBuilder: ContextBu
   const secondLayout = articulation.layout();
   assertClose(options, secondLayout.x, firstLayout.x, 're-finalizing the beam does not move articulation x');
   assertClose(options, secondLayout.y, firstLayout.y, 're-finalizing the beam does not move articulation y');
+}
+
+function noArticulationLayoutIsNoop(options: TestOptions, contextBuilder: ContextBuilder): void {
+  const ctx = contextBuilder(options.elementId, 420, 180);
+  const stave = new Stave(10, 40, 400).setContext(ctx);
+  const notes = [
+    new StaveNote({ keys: ['c/5'], duration: '8', stemDirection: Stem.UP }),
+    new StaveNote({ keys: ['g/5'], duration: '8', stemDirection: Stem.UP }),
+  ];
+  const beam = new Beam(notes);
+  formatNotesToStave(stave, notes, 2);
+
+  let postFormatCalls = 0;
+  const originalPostFormat = beam.postFormat.bind(beam);
+  beam.postFormat = (): void => {
+    postFormatCalls++;
+    originalPostFormat();
+  };
+
+  notes[0].layoutArticulations();
+  options.assert.strictEqual(postFormatCalls, 0, 'a note without articulations does not re-finalize its beam');
 }
 
 function absoluteOutwardDisplacement(options: TestOptions, contextBuilder: ContextBuilder): void {

--- a/tests/articulation_tests.ts
+++ b/tests/articulation_tests.ts
@@ -28,6 +28,7 @@ const ArticulationTests = {
     run('Bounding Box', verticalPlacement, { drawBoundingBox: true });
     run('Vertical Placement', verticalPlacement, { drawBoundingBox: false });
     run('Vertical Placement (Glyph codes)', verticalPlacement2);
+    run('Origin remains stable after positioning', originRemainsStable);
     run('Staccato/Staccatissimo', drawArticulations, { sym1: 'a.', sym2: 'av' });
     run('Accent/Tenuto', drawArticulations, { sym1: 'a>', sym2: 'a-' });
     run('Marcato/L.H. Pizzicato', drawArticulations, { sym1: 'a^', sym2: 'a+' });
@@ -41,6 +42,27 @@ const ArticulationTests = {
     run('TabNote Articulation', tabNotes, { sym1: 'a.', sym2: 'a.' });
   },
 };
+
+function originRemainsStable(options: TestOptions): void {
+  const articulation = new Articulation('a.');
+  articulation.setOrigin(0.5, 1);
+  const initialXShift = articulation.getXShift();
+  const initialYShift = articulation.getYShift();
+
+  articulation.setX(240).setY(160);
+  articulation.setOrigin(0.5, 1);
+
+  options.assert.strictEqual(
+    articulation.getXShift(),
+    initialXShift,
+    'The glyph origin does not absorb the previous rendered x coordinate.'
+  );
+  options.assert.strictEqual(
+    articulation.getYShift(),
+    initialYShift,
+    'The glyph origin does not absorb the previous rendered y coordinate.'
+  );
+}
 
 // Helper function for creating StaveNotes.
 function drawArticulations(options: TestOptions): void {

--- a/tests/beam_tests.ts
+++ b/tests/beam_tests.ts
@@ -70,7 +70,23 @@ function simple(options: TestOptions): void {
 
   f.Formatter().joinVoices([voice]).formatToStave([voice], stave);
 
+  const renderedBeam = voice
+    .getTickables()
+    .find((tickable) => (tickable as StemmableNote).getBeam?.()) as StemmableNote;
+  const vfBeam = renderedBeam.getBeam();
+  const polygonsBeforeDraw = vfBeam?.getRenderedBeamPolygons();
+  options.assert.ok(
+    polygonsBeforeDraw && polygonsBeforeDraw.length > 0,
+    'Finalized beam polygons are available before draw'
+  );
+
   f.draw();
+
+  options.assert.deepEqual(
+    vfBeam?.getRenderedBeamPolygons(),
+    polygonsBeforeDraw,
+    'Beam drawing consumes the same finalized polygons'
+  );
 
   options.assert.ok(true, 'Simple Test');
 }

--- a/tests/stavetie_tests.ts
+++ b/tests/stavetie_tests.ts
@@ -156,7 +156,16 @@ function tieAlgorithms(options: TestOptions): void {
     options: { direction: Stem.DOWN },
   });
   factory.Formatter().joinVoices([voice]).formatToStave([voice], stave);
+  const tieCurvesBeforeDraw = tie1.getRenderedTieCurves();
+  options.assert.equal(tieCurvesBeforeDraw.length, 1);
+  options.assert.equal(tieCurvesBeforeDraw[0].start.x, tie1.getFirstX());
+  options.assert.equal(tieCurvesBeforeDraw[0].end.x, tie1.getLastX());
   factory.draw();
+  options.assert.deepEqual(
+    tie1.getRenderedTieCurves(),
+    tieCurvesBeforeDraw,
+    'Tie drawing consumes the same finalized curves'
+  );
   options.assert.equal(tie1.getDirection(), Stem.UP);
   options.assert.equal(tie2.getDirection(), Stem.DOWN);
   options.assert.ok(tie1.getFirstX() < tie1.getLastX());


### PR DESCRIPTION
## Summary

- expose exact selected-notehead bounds before drawing
- calculate articulation geometry idempotently after final beam/stem layout
- support absolute outward articulation displacement without rerender drift
- expose the same finalized beam polygons and tie curves consumed by drawing

These APIs let notation-layout clients perform collision detection against the geometry VexFlow will actually render, rather than approximating whole-note bounding boxes or duplicating draw-time calculations.

## Dependency

This branch is stacked on #322 because stable articulation bounding boxes require the positioned-origin correction. Once #322 merges, this PR can be rebased onto `main` and will contain only the three finalized-geometry commits.

## Validation

- VexFlow lint under Node 24
- VexFlow browser QUnit suite under Node 24
- 1,880 tests passed, including repeated-layout, final-beam, selected-head, beam-polygon, and tie-curve coverage
