### PR TITLE
Refine grace-note slur geometry

### DIFF
--- a/src/articulation.ts
+++ b/src/articulation.ts
@@ -2,6 +2,7 @@
 // @author Larry Kuhns.
 // MIT License
 
+import { BoundingBox } from './boundingbox';
 import { Builder } from './easyscore';
 import { Glyphs } from './glyphs';
 import { Modifier } from './modifier';
@@ -19,6 +20,15 @@ export interface ArticulationStruct {
   aboveCode?: string;
   belowCode?: string;
   betweenLines: boolean;
+}
+
+export interface ArticulationLayout {
+  x: number;
+  y: number;
+  boundingBox: BoundingBox;
+  position: number;
+  index: number;
+  outwardShift: number;
 }
 
 // eslint-disable-next-line
@@ -180,6 +190,8 @@ export class Articulation extends Modifier {
   protected articulation: ArticulationStruct;
 
   protected heightShift = 0;
+  protected outwardShift = 0;
+  protected layoutResult?: ArticulationLayout;
   /**
    * FIXME:
    * Most of the complex formatting logic (ie: snapping to space) is
@@ -322,30 +334,61 @@ export class Articulation extends Modifier {
       this.articulation.code ||
       Glyphs.null;
     this.text = code;
+    this.layoutResult = undefined;
   }
 
   /** Set if articulation should be rendered between lines. */
   setBetweenLines(betweenLines = true): this {
     this.articulation.betweenLines = betweenLines;
+    this.layoutResult = undefined;
     return this;
   }
 
-  /** Render articulation in position next to note. */
-  override draw(): void {
-    const ctx = this.checkContext();
-    const note = this.checkAttachedNote();
-    this.setRendered();
+  /**
+   * Move the articulation away from the staff by an absolute number of pixels.
+   * Reapplying the same value is idempotent; callers never have to undo an old
+   * relative y-shift before recalculating slur clearance.
+   */
+  setOutwardShift(outwardShift: number): this {
+    if (!Number.isFinite(outwardShift) || outwardShift < 0) {
+      throw new RuntimeError('BadArguments', 'Articulation outward shift must be a finite non-negative number.');
+    }
+    this.outwardShift = outwardShift;
+    this.layoutResult = undefined;
+    return this;
+  }
 
+  getOutwardShift(): number {
+    return this.outwardShift;
+  }
+
+  /**
+   * Calculate final articulation geometry after note and beam formatting.
+   *
+   * This method is safe to call repeatedly. It derives x/y and origin from the
+   * current note geometry and the absolute outward shift instead of applying
+   * incremental changes to a previous render.
+   */
+  layout(): ArticulationLayout {
+    const note = this.checkAttachedNote();
     const index = this.checkIndex();
     const { position, textLine } = this;
     const canSitBetweenLines = this.articulation.betweenLines;
+
+    if (isStemmableNote(note)) {
+      note.getBeam()?.postFormat();
+    }
 
     const stave = note.checkStave();
     const staffSpace = stave.getSpacingBetweenLines();
     const isTab = isTabNote(note);
 
-    // Articulations are centered over/under the note head.
-    const { x } = note.getModifierStartXY(position, index);
+    // Articulations are centered over/under the selected note head, including
+    // displaced chord heads. Non-StaveNote types retain their native anchor.
+    let { x } = note.getModifierStartXY(position, index);
+    if (isStaveNote(note)) {
+      x = note.getSelectedNoteHeadBounds(index).centerX;
+    }
     const shouldSitOutsideStaff = !canSitBetweenLines || isTab;
 
     const initialOffset = getInitialOffset(note, position);
@@ -375,9 +418,43 @@ export class Articulation extends Modifier {
       y += Math.abs(snappedLine - articLine) * staffSpace * offsetDirection;
     }
 
+    y += this.outwardShift * (position === ABOVE ? -1 : 1);
+
     L(`Rendering articulation at (x: ${x}, y: ${y})`);
     this.x = x;
     this.y = y;
+    this.layoutResult = {
+      x,
+      y,
+      boundingBox: this.getBoundingBox().clone(),
+      position,
+      index,
+      outwardShift: this.outwardShift,
+    };
+    return this.getLayout();
+  }
+
+  /** Return a defensive copy of the most recently calculated geometry. */
+  getLayout(): ArticulationLayout {
+    if (!this.layoutResult) {
+      return this.layout();
+    }
+    return {
+      ...this.layoutResult,
+      boundingBox: this.layoutResult.boundingBox.clone(),
+    };
+  }
+
+  /** Render the already calculated articulation geometry. */
+  override draw(): void {
+    const ctx = this.checkContext();
+    // Legacy direct-draw clients may not run a formatter or the owning
+    // StaveNote layout. Keep that route functional, while normal formatted
+    // notes arrive here with final geometry.
+    if (!this.layoutResult) {
+      this.layout();
+    }
+    this.setRendered();
     this.renderText(ctx, 0, 0);
   }
 }

--- a/src/articulation.ts
+++ b/src/articulation.ts
@@ -379,11 +379,18 @@ export class Articulation extends Modifier {
     const staffSpace = stave.getSpacingBetweenLines();
     const isTab = isTabNote(note);
 
-    // Articulations are centered over/under the selected note head, including
-    // displaced chord heads. Non-StaveNote types retain their native anchor.
+    // Keep articulations on the optical centre of the owning chord. In
+    // particular, an articulation encoded on one displaced head of an
+    // adjacent-second chord still belongs to the chord as a whole. Neither the
+    // selected head nor VexFlow's undisplaced-head column is the visual centre.
     let { x } = note.getModifierStartXY(position, index);
     if (isStaveNote(note)) {
-      x = note.getSelectedNoteHeadBounds(index).centerX;
+      const noteheadBounds = note.noteHeads.map((_notehead, noteheadIndex) =>
+        note.getSelectedNoteHeadBounds(noteheadIndex)
+      );
+      const left = Math.min(...noteheadBounds.map((bounds) => bounds.left));
+      const right = Math.max(...noteheadBounds.map((bounds) => bounds.right));
+      x = (left + right) / 2;
     }
     const shouldSitOutsideStaff = !canSitBetweenLines || isTab;
 

--- a/src/articulation.ts
+++ b/src/articulation.ts
@@ -375,10 +375,6 @@ export class Articulation extends Modifier {
     const { position, textLine } = this;
     const canSitBetweenLines = this.articulation.betweenLines;
 
-    if (isStemmableNote(note)) {
-      note.getBeam()?.postFormat();
-    }
-
     const stave = note.checkStave();
     const staffSpace = stave.getSpacingBetweenLines();
     const isTab = isTabNote(note);

--- a/src/beam.ts
+++ b/src/beam.ts
@@ -43,6 +43,12 @@ export const BEAM_BOTH = 'B';
 
 export type PartialBeamDirection = typeof BEAM_LEFT | typeof BEAM_RIGHT | typeof BEAM_BOTH;
 
+/** Final beam geometry in render-context pixels, shared by drawing and collision layout. */
+export interface BeamRenderPolygon {
+  points: [{ x: number; y: number }, { x: number; y: number }, { x: number; y: number }, { x: number; y: number }];
+  duration: string;
+}
+
 /** `Beams` span over a set of `StemmableNotes`. */
 export class Beam extends Element {
   static override get CATEGORY(): string {
@@ -918,16 +924,18 @@ export class Beam extends Element {
     }, this);
   }
 
-  // Render the beam lines
-  protected drawBeamLines(ctx: RenderContext): void {
+  /** Return the finalized beam polygons using exactly the geometry consumed by draw(). */
+  getRenderedBeamPolygons(): BeamRenderPolygon[] {
+    if (!this.postFormatted) {
+      this.postFormat();
+    }
     const validBeamDurations = ['4', '8', '16', '32', '64', '128', '256', '512', '1024'];
-
     const firstNote = this.notes[0];
     let beamY = this.getBeamYToDraw();
     const firstStemX = firstNote.getStemX();
     const beamThickness = this.renderOptions.beamWidth * this._stemDirection;
+    const polygons: BeamRenderPolygon[] = [];
 
-    // Draw the beams.
     for (let i = 0; i < validBeamDurations.length; ++i) {
       const duration = validBeamDurations[i];
       const beamLines = this.getBeamLines(duration);
@@ -938,22 +946,37 @@ export class Beam extends Element {
 
         const startBeamY = this.getSlopeY(startBeamX, firstStemX, beamY, this.slope);
         const lastBeamX = beamLine.end;
-        if (lastBeamX) {
+        if (lastBeamX !== undefined) {
           const lastBeamY = this.getSlopeY(lastBeamX, firstStemX, beamY, this.slope);
-
-          ctx.beginPath();
-          ctx.moveTo(startBeamX, startBeamY);
-          ctx.lineTo(startBeamX, startBeamY + beamThickness);
-          ctx.lineTo(lastBeamX + 1, lastBeamY + beamThickness);
-          ctx.lineTo(lastBeamX + 1, lastBeamY);
-          ctx.closePath();
-          ctx.fill();
+          polygons.push({
+            duration,
+            points: [
+              { x: startBeamX, y: startBeamY },
+              { x: startBeamX, y: startBeamY + beamThickness },
+              { x: lastBeamX + 1, y: lastBeamY + beamThickness },
+              { x: lastBeamX + 1, y: lastBeamY },
+            ],
+          });
         } else {
           throw new RuntimeError('NoLastBeamX', 'lastBeamX undefined.');
         }
       }
 
       beamY += beamThickness * 1.5;
+    }
+    return polygons;
+  }
+
+  // Render the beam lines
+  protected drawBeamLines(ctx: RenderContext): void {
+    for (const polygon of this.getRenderedBeamPolygons()) {
+      ctx.beginPath();
+      ctx.moveTo(polygon.points[0].x, polygon.points[0].y);
+      for (let index = 1; index < polygon.points.length; index++) {
+        ctx.lineTo(polygon.points[index].x, polygon.points[index].y);
+      }
+      ctx.closePath();
+      ctx.fill();
     }
   }
 

--- a/src/element.ts
+++ b/src/element.ts
@@ -671,14 +671,17 @@ export class Element {
 
   setOriginX(x: number): void {
     const bbox = this.getBoundingBox();
-    const originX = Math.abs((bbox.getX() - this.xShift) / bbox.getW());
+    // getBoundingBox() is expressed in rendered coordinates. Remove both the
+    // element position and its current shift so repeated origin updates remain
+    // relative to the glyph's own bounds.
+    const originX = Math.abs((bbox.getX() - this.x - this.xShift) / bbox.getW());
     const xShift = (x - originX) * bbox.getW();
     this.xShift = -xShift;
   }
 
   setOriginY(y: number): void {
     const bbox = this.getBoundingBox();
-    const originY = Math.abs((bbox.getY() - this.yShift) / bbox.getH());
+    const originY = Math.abs((bbox.getY() - this.y - this.yShift) / bbox.getH());
     const yShift = (y - originY) * bbox.getH();
     this.yShift = -yShift;
   }

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -319,8 +319,8 @@ export class Factory {
     return note;
   }
 
-  GraceNoteGroup(params: { notes: StemmableNote[]; slur?: boolean }): GraceNoteGroup {
-    const group = new GraceNoteGroup(params.notes, params.slur);
+  GraceNoteGroup(params: { notes: StemmableNote[]; slur?: boolean; slurStartIndex?: number }): GraceNoteGroup {
+    const group = new GraceNoteGroup(params.notes, params.slur, params.slurStartIndex);
     group.setContext(this.context);
     return group;
   }

--- a/src/gracenotegroup.ts
+++ b/src/gracenotegroup.ts
@@ -12,7 +12,7 @@ import { ModifierContextState } from './modifiercontext';
 import { Note } from './note';
 import { RenderContext } from './rendercontext';
 import { StaveNote } from './stavenote';
-import { StaveTie } from './stavetie';
+import { StaveTie, TieRenderCurve } from './stavetie';
 import { StemmableNote } from './stemmablenote';
 import { Tables } from './tables';
 import { TabTie } from './tabtie';
@@ -24,6 +24,44 @@ import { Voice } from './voice';
 // eslint-disable-next-line
 function L(...args: any) {
   if (GraceNoteGroup.DEBUG) log('VexFlow.GraceNoteGroup', args);
+}
+
+export interface GraceNoteSlurBounds {
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+}
+
+export interface GraceNoteSlurLayout {
+  curves: TieRenderCurve[];
+  direction: number;
+  startNotehead: GraceNoteSlurBounds;
+  endNotehead: GraceNoteSlurBounds;
+  intersectedEndpointIds: ('start-notehead' | 'end-notehead')[];
+}
+
+function pointInsideBounds(point: { x: number; y: number }, bounds: GraceNoteSlurBounds): boolean {
+  const epsilon = 0.01;
+  return (
+    point.x > bounds.left + epsilon &&
+    point.x < bounds.right - epsilon &&
+    point.y > bounds.top + epsilon &&
+    point.y < bounds.bottom - epsilon
+  );
+}
+
+function quadraticPoint(
+  start: { x: number; y: number },
+  control: { x: number; y: number },
+  end: { x: number; y: number },
+  t: number
+): { x: number; y: number } {
+  const oneMinusT = 1 - t;
+  return {
+    x: oneMinusT * oneMinusT * start.x + 2 * oneMinusT * t * control.x + t * t * end.x,
+    y: oneMinusT * oneMinusT * start.y + 2 * oneMinusT * t * control.y + t * t * end.y,
+  };
 }
 
 /** GraceNoteGroup is used to format and render grace notes. */
@@ -165,6 +203,67 @@ export class GraceNoteGroup extends Modifier {
     return this.graceNotes;
   }
 
+  /** Return the finalized grace slur, once the group has been laid out. */
+  getSlur(): StaveTie | TabTie | undefined {
+    return this.slur;
+  }
+
+  /**
+   * Return the exact grace-slur outlines consumed by drawing.
+   *
+   * Grace slurs are drawn directly by GraceNoteGroup. Exposing that final
+   * geometry lets callers perform collision diagnostics without reconstructing
+   * a curve from rendered output.
+   */
+  getRenderedSlurCurves(): TieRenderCurve[] {
+    return this.slur instanceof StaveTie ? this.slur.getRenderedTieCurves() : [];
+  }
+
+  /** Return finalized grace-slur geometry and objective endpoint collisions. */
+  getSlurLayout(): GraceNoteSlurLayout | undefined {
+    if (!(this.slur instanceof StaveTie)) return undefined;
+    const notes = this.slur.getNotes();
+    if (!(notes.firstNote instanceof StaveNote) || !(notes.lastNote instanceof StaveNote)) return undefined;
+
+    const startIndex = notes.firstIndexes?.[0] ?? 0;
+    const endIndex = notes.lastIndexes?.[0] ?? 0;
+    const start = notes.firstNote.getSelectedNoteHeadBounds(startIndex);
+    const end = notes.lastNote.getSelectedNoteHeadBounds(endIndex);
+    const startNotehead: GraceNoteSlurBounds = {
+      left: start.left,
+      right: start.right,
+      top: start.top,
+      bottom: start.bottom,
+    };
+    const endNotehead: GraceNoteSlurBounds = {
+      left: end.left,
+      right: end.right,
+      top: end.top,
+      bottom: end.bottom,
+    };
+    const curves = this.getRenderedSlurCurves();
+    const intersectedEndpointIds: ('start-notehead' | 'end-notehead')[] = [];
+    for (const [id, bounds] of [
+      ['start-notehead', startNotehead],
+      ['end-notehead', endNotehead],
+    ] as const) {
+      const intersects = curves.some((curve) => {
+        for (let sample = 1; sample < 24; sample++) {
+          const t = sample / 24;
+          if (
+            pointInsideBounds(quadraticPoint(curve.start, curve.topControl, curve.end, t), bounds) ||
+            pointInsideBounds(quadraticPoint(curve.start, curve.bottomControl, curve.end, t), bounds)
+          ) {
+            return true;
+          }
+        }
+        return false;
+      });
+      if (intersects) intersectedEndpointIds.push(id);
+    }
+    return { curves, direction: this.slur.getDirection(), startNotehead, endNotehead, intersectedEndpointIds };
+  }
+
   override draw(): void {
     const ctx: RenderContext = this.checkContext();
     const note = this.checkAttachedNote();
@@ -184,12 +283,30 @@ export class GraceNoteGroup extends Modifier {
       const isStavenote = isStaveNote(note);
       const TieClass = isStavenote ? StaveTie : TabTie;
 
+      // A grace slur follows musical order: the final grace note (the one
+      // nearest the beat) into the main note. Reversing these endpoints makes
+      // the curve run from the main note's far edge to the first grace note's
+      // far edge, crossing the noteheads it is supposed to connect.
       this.slur = new TieClass({
-        lastNote: this.graceNotes[0],
-        firstNote: note,
+        firstNote: this.graceNotes[this.graceNotes.length - 1],
+        lastNote: note,
         firstIndexes: [0],
         lastIndexes: [0],
       });
+
+      if (this.slur instanceof StaveTie && isStavenote) {
+        const nearestGrace = this.graceNotes[this.graceNotes.length - 1];
+        const graceY = nearestGrace.getYs()[0];
+        const mainY = note.getYs()[0];
+        if (Math.abs(mainY - graceY) >= 2 * Tables.STAVE_LINE_DISTANCE) {
+          // On a large leap, following the main note's stem can put the slur
+          // inside the interval and make its diagonal cross a connected head.
+          // Route it around the outside of the leap: above when the grace note
+          // is higher, below when it is lower. Close grace gestures retain the
+          // conventional stem-derived placement.
+          this.slur.setDirection(graceY < mainY ? -1 : 1);
+        }
+      }
 
       this.slur.renderOptions.cp2 = 12;
       this.slur.renderOptions.yShift = (isStavenote ? 7 : 5) + this.renderOptions.slurYShift;

--- a/src/gracenotegroup.ts
+++ b/src/gracenotegroup.ts
@@ -356,11 +356,11 @@ export class GraceNoteGroup extends Modifier {
           // must remain visibly above the intervening beam. For a quadratic
           // curve, the midpoint travels only halfway towards its control
           // point, so double both the endpoint delta and desired clearance.
-          // This keeps the visible inner edge 1.2 staff-spaces outside the
+          // This keeps the visible inner edge 0.6 staff-spaces outside the
           // higher endpoint even when the gesture is diagonal.
           const renderedStartY = graceY + yShift + this.slur.renderOptions.firstYShift;
           const renderedEndY = mainY + yShift + this.slur.renderOptions.lastYShift;
-          const controlHeight = Math.abs(renderedEndY - renderedStartY) + 2.4 * Tables.STAVE_LINE_DISTANCE;
+          const controlHeight = Math.abs(renderedEndY - renderedStartY) + 1.2 * Tables.STAVE_LINE_DISTANCE;
           this.slur.renderOptions.cp1 = controlHeight;
           this.slur.renderOptions.cp2 = controlHeight + 4;
         }

--- a/src/gracenotegroup.ts
+++ b/src/gracenotegroup.ts
@@ -7,6 +7,7 @@
 
 import { Beam } from './beam';
 import { Formatter } from './formatter';
+import { Metrics } from './metrics';
 import { Modifier } from './modifier';
 import { ModifierContextState } from './modifiercontext';
 import { Note } from './note';
@@ -64,6 +65,19 @@ function quadraticPoint(
     x: oneMinusT * oneMinusT * start.x + 2 * oneMinusT * t * control.x + t * t * end.x,
     y: oneMinusT * oneMinusT * start.y + 2 * oneMinusT * t * control.y + t * t * end.y,
   };
+}
+
+function curveIntersectsBounds(curve: TieRenderCurve, bounds: GraceNoteSlurBounds): boolean {
+  for (let sample = 1; sample < 24; sample++) {
+    const t = sample / 24;
+    if (
+      pointInsideBounds(quadraticPoint(curve.start, curve.topControl, curve.end, t), bounds) ||
+      pointInsideBounds(quadraticPoint(curve.start, curve.bottomControl, curve.end, t), bounds)
+    ) {
+      return true;
+    }
+  }
+  return false;
 }
 
 /** GraceNoteGroup is used to format and render grace notes. */
@@ -132,9 +146,13 @@ export class GraceNoteGroup extends Modifier {
     for (let i = 0; i < groupList.length; ++i) {
       const gracenoteGroup = groupList[i].gracenoteGroup;
       formatWidth = gracenoteGroup.getWidth() + groupList[i].spacing;
-      gracenoteGroup.setSpacingFromNextModifier(
-        groupShift - Math.min(formatWidth, groupShift) + StaveNote.minNoteheadPadding
-      );
+      const note = gracenoteGroup.getNote();
+      const parentAccidentals = note.getModifiersByType(Category.Accidental);
+      const noteheadPadding =
+        parentAccidentals.length && gracenoteGroup.showSlur
+          ? Metrics.get('Accidental.noteheadAccidentalPadding')
+          : StaveNote.minNoteheadPadding;
+      gracenoteGroup.setSpacingFromNextModifier(groupShift - Math.min(formatWidth, groupShift) + noteheadPadding);
     }
 
     if (right) state.rightShift += groupShift;
@@ -152,7 +170,7 @@ export class GraceNoteGroup extends Modifier {
 
     this.showSlur = showSlur;
     this.slur = undefined;
-    this.slurStartIndex = Math.max(0, Math.min(slurStartIndex ?? graceNotes.length - 1, graceNotes.length - 1));
+    this.slurStartIndex = Math.max(0, Math.min(slurStartIndex ?? 0, graceNotes.length - 1));
 
     this.voice = new Voice({
       numBeats: 4,
@@ -209,6 +227,48 @@ export class GraceNoteGroup extends Modifier {
     return this.graceNotes;
   }
 
+  private getNoteHeadSpan(note: StaveNote): GraceNoteSlurBounds {
+    const bounds = note.noteHeads.map((noteHead) => noteHead.getBoundingBoxAt(note.getNoteHeadBeginX()));
+    const left = Math.min(...bounds.map((bound) => bound.getX()));
+    const right = Math.max(...bounds.map((bound) => bound.getX() + bound.getW()));
+    const top = Math.min(...bounds.map((bound) => bound.getY()));
+    const bottom = Math.max(...bounds.map((bound) => bound.getY() + bound.getH()));
+    return { left, right, top, bottom };
+  }
+
+  private getAccidentalBounds(note: StaveNote): GraceNoteSlurBounds[] {
+    return note.getModifiersByType(Category.Accidental).map((accidental) => {
+      const index = accidental.getIndex() ?? 0;
+      const start = note.getModifierStartXY(accidental.getPosition(), index);
+      const metrics = accidental.getTextMetrics();
+      const left = start.x - accidental.getWidth() + accidental.getXShift();
+      const top = start.y - metrics.actualBoundingBoxAscent + accidental.getYShift();
+      return {
+        left,
+        right: left + accidental.getWidth(),
+        top,
+        bottom: top + metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent,
+      };
+    });
+  }
+
+  private clearSlurFromAccidentals(note: StaveNote): void {
+    if (!(this.slur instanceof StaveTie)) return;
+
+    const accidentalBounds = this.getAccidentalBounds(note);
+    if (accidentalBounds.length === 0) return;
+
+    const baseCp1 = this.slur.renderOptions.cp1;
+    const baseCp2 = this.slur.renderOptions.cp2;
+    const clearanceStep = Tables.STAVE_LINE_DISTANCE;
+    for (let step = 0; step <= 8; step++) {
+      this.slur.renderOptions.cp1 = baseCp1 + step * clearanceStep;
+      this.slur.renderOptions.cp2 = baseCp2 + step * clearanceStep;
+      const curves = this.slur.getRenderedTieCurves();
+      if (!curves.some((curve) => accidentalBounds.some((bounds) => curveIntersectsBounds(curve, bounds)))) return;
+    }
+  }
+
   /** Return the finalized grace slur, once the group has been laid out. */
   getSlur(): StaveTie | TabTie | undefined {
     return this.slur;
@@ -234,7 +294,9 @@ export class GraceNoteGroup extends Modifier {
     const startIndex = notes.firstIndexes?.[0] ?? 0;
     const endIndex = notes.lastIndexes?.[0] ?? 0;
     const start = notes.firstNote.getSelectedNoteHeadBounds(startIndex);
-    const end = notes.lastNote.getSelectedNoteHeadBounds(endIndex);
+    const end = notes.lastNote.isChord()
+      ? this.getNoteHeadSpan(notes.lastNote)
+      : notes.lastNote.getSelectedNoteHeadBounds(endIndex);
     const startNotehead: GraceNoteSlurBounds = {
       left: start.left,
       right: start.right,
@@ -253,18 +315,7 @@ export class GraceNoteGroup extends Modifier {
       ['start-notehead', startNotehead],
       ['end-notehead', endNotehead],
     ] as const) {
-      const intersects = curves.some((curve) => {
-        for (let sample = 1; sample < 24; sample++) {
-          const t = sample / 24;
-          if (
-            pointInsideBounds(quadraticPoint(curve.start, curve.topControl, curve.end, t), bounds) ||
-            pointInsideBounds(quadraticPoint(curve.start, curve.bottomControl, curve.end, t), bounds)
-          ) {
-            return true;
-          }
-        }
-        return false;
-      });
+      const intersects = curves.some((curve) => curveIntersectsBounds(curve, bounds));
       if (intersects) intersectedEndpointIds.push(id);
     }
     return {
@@ -278,6 +329,26 @@ export class GraceNoteGroup extends Modifier {
     };
   }
 
+  private compactGraceNotesAgainstAccidentals(note: Note): void {
+    if (!this.showSlur || !isStaveNote(note) || this.position !== Modifier.Position.LEFT) return;
+
+    const accidentalBounds = this.getAccidentalBounds(note);
+    if (accidentalBounds.length === 0) return;
+
+    const graceNote = this.getGraceNotes().at(-1);
+    if (!graceNote) return;
+
+    const padding = Metrics.get('Accidental.noteheadAccidentalPadding');
+    const desiredRight = Math.min(...accidentalBounds.map((bounds) => bounds.left)) - padding;
+    const shift = desiredRight - graceNote.getTieRightX();
+    if (Math.abs(shift) < 0.001) return;
+
+    this.getGraceNotes().forEach((note) => {
+      const tickContext = note.getTickContext();
+      tickContext.setXOffset(tickContext.getXOffset() + shift);
+    });
+  }
+
   override draw(): void {
     const ctx: RenderContext = this.checkContext();
     const note = this.checkAttachedNote();
@@ -286,6 +357,7 @@ export class GraceNoteGroup extends Modifier {
     L('Drawing grace note group for:', note);
 
     this.alignSubNotesWithNote(this.getGraceNotes(), note, this.position); // Modifier function
+    this.compactGraceNotesAgainstAccidentals(note);
 
     // Draw grace notes.
     this.graceNotes.forEach((graceNote) => graceNote.setContext(ctx).drawWithStyle());
@@ -347,8 +419,8 @@ export class GraceNoteGroup extends Modifier {
         attachStemTip('start', slurStartNote, this.slur.getFirstX(), graceY + yShift);
         attachStemTip('end', note, this.slur.getLastX(), mainY + yShift);
         if (this.slurEndAttachment === 'notehead') {
-          const mainNotehead = note.getSelectedNoteHeadBounds(0);
-          this.slur.renderOptions.lastXShift = mainNotehead.centerX - this.slur.getLastX();
+          const mainNotehead = this.getNoteHeadSpan(note);
+          this.slur.renderOptions.lastXShift = (mainNotehead.left + mainNotehead.right) / 2 - this.slur.getLastX();
           this.slurEndAttachment = 'notehead-center';
         }
         if (this.slurStartIndex < this.graceNotes.length - 1) {
@@ -366,6 +438,7 @@ export class GraceNoteGroup extends Modifier {
         }
       }
       if (this.slurStartIndex >= this.graceNotes.length - 1) this.slur.renderOptions.cp2 = 12;
+      if (this.slur instanceof StaveTie && isStavenote) this.clearSlurFromAccidentals(note);
       this.slur.setContext(ctx).drawWithStyle();
     }
   }

--- a/src/gracenotegroup.ts
+++ b/src/gracenotegroup.ts
@@ -36,6 +36,8 @@ export interface GraceNoteSlurBounds {
 export interface GraceNoteSlurLayout {
   curves: TieRenderCurve[];
   direction: number;
+  startAttachment: 'notehead' | 'stem-tip';
+  endAttachment: 'notehead' | 'stem-tip';
   startNotehead: GraceNoteSlurBounds;
   endNotehead: GraceNoteSlurBounds;
   intersectedEndpointIds: ('start-notehead' | 'end-notehead')[];
@@ -80,6 +82,9 @@ export class GraceNoteGroup extends Modifier {
   protected formatter?: Formatter;
   public renderOptions: { slurYShift: number };
   protected slur?: StaveTie | TabTie;
+  protected slurStartIndex: number;
+  protected slurStartAttachment: 'notehead' | 'stem-tip' = 'notehead';
+  protected slurEndAttachment: 'notehead' | 'stem-tip' = 'notehead';
   protected beams: Beam[];
 
   /** Arranges groups inside a `ModifierContext`. */
@@ -138,7 +143,7 @@ export class GraceNoteGroup extends Modifier {
   }
 
   //** `GraceNoteGroup` inherits from `Modifier` and is placed inside a `ModifierContext`. */
-  constructor(graceNotes: StemmableNote[], showSlur?: boolean) {
+  constructor(graceNotes: StemmableNote[], showSlur?: boolean, slurStartIndex?: number) {
     super();
 
     this.position = Modifier.Position.LEFT;
@@ -147,6 +152,7 @@ export class GraceNoteGroup extends Modifier {
 
     this.showSlur = showSlur;
     this.slur = undefined;
+    this.slurStartIndex = Math.max(0, Math.min(slurStartIndex ?? graceNotes.length - 1, graceNotes.length - 1));
 
     this.voice = new Voice({
       numBeats: 4,
@@ -261,7 +267,15 @@ export class GraceNoteGroup extends Modifier {
       });
       if (intersects) intersectedEndpointIds.push(id);
     }
-    return { curves, direction: this.slur.getDirection(), startNotehead, endNotehead, intersectedEndpointIds };
+    return {
+      curves,
+      direction: this.slur.getDirection(),
+      startAttachment: this.slurStartAttachment,
+      endAttachment: this.slurEndAttachment,
+      startNotehead,
+      endNotehead,
+      intersectedEndpointIds,
+    };
   }
 
   override draw(): void {
@@ -280,23 +294,25 @@ export class GraceNoteGroup extends Modifier {
 
     if (this.showSlur) {
       // Create and draw slur.
+      this.slurStartAttachment = 'notehead';
+      this.slurEndAttachment = 'notehead';
       const isStavenote = isStaveNote(note);
       const TieClass = isStavenote ? StaveTie : TabTie;
 
-      // A grace slur follows musical order: the final grace note (the one
-      // nearest the beat) into the main note. Reversing these endpoints makes
-      // the curve run from the main note's far edge to the first grace note's
-      // far edge, crossing the noteheads it is supposed to connect.
+      // A grace slur follows musical order from its source-selected grace note
+      // into the main note. Callers without source detail retain the historical
+      // nearest-grace default.
+      const slurStartNote = this.graceNotes[this.slurStartIndex];
       this.slur = new TieClass({
-        firstNote: this.graceNotes[this.graceNotes.length - 1],
+        firstNote: slurStartNote,
         lastNote: note,
         firstIndexes: [0],
         lastIndexes: [0],
       });
+      this.slur.renderOptions.yShift = (isStavenote ? 7 : 5) + this.renderOptions.slurYShift;
 
       if (this.slur instanceof StaveTie && isStavenote) {
-        const nearestGrace = this.graceNotes[this.graceNotes.length - 1];
-        const graceY = nearestGrace.getYs()[0];
+        const graceY = slurStartNote.getYs()[0];
         const mainY = note.getYs()[0];
         if (Math.abs(mainY - graceY) >= 2 * Tables.STAVE_LINE_DISTANCE) {
           // On a large leap, following the main note's stem can put the slur
@@ -306,10 +322,43 @@ export class GraceNoteGroup extends Modifier {
           // conventional stem-derived placement.
           this.slur.setDirection(graceY < mainY ? -1 : 1);
         }
-      }
 
-      this.slur.renderOptions.cp2 = 12;
-      this.slur.renderOptions.yShift = (isStavenote ? 7 : 5) + this.renderOptions.slurYShift;
+        const direction = this.slur.getDirection();
+        const attachStemTip = (
+          endpoint: 'start' | 'end',
+          endpointNote: StemmableNote,
+          defaultX: number,
+          defaultY: number
+        ): void => {
+          if (!endpointNote.hasStem() || endpointNote.getStemDirection() !== -direction) return;
+          const stemX = endpointNote.getStemX();
+          const stemTipY = endpointNote.getStemExtents().topY;
+          if (endpoint === 'start') {
+            this.slur!.renderOptions.firstXShift = stemX - defaultX;
+            this.slur!.renderOptions.firstYShift = stemTipY - defaultY;
+            this.slurStartAttachment = 'stem-tip';
+          } else {
+            this.slur!.renderOptions.lastXShift = stemX - defaultX;
+            this.slur!.renderOptions.lastYShift = stemTipY - defaultY;
+            this.slurEndAttachment = 'stem-tip';
+          }
+        };
+        const yShift = this.slur.renderOptions.yShift * direction;
+        attachStemTip('start', slurStartNote, this.slur.getFirstX(), graceY + yShift);
+        attachStemTip('end', note, this.slur.getLastX(), mainY + yShift);
+        if (this.slurStartIndex < this.graceNotes.length - 1) {
+          // A multi-note grace slur starts at the first source grace stem and
+          // must remain visibly above the intervening beam. Derive the control
+          // height from the endpoints so a diagonal gesture still clears the
+          // higher endpoint (and therefore the beam) by 0.8 staff-space.
+          const renderedStartY = graceY + yShift + this.slur.renderOptions.firstYShift;
+          const renderedEndY = mainY + yShift + this.slur.renderOptions.lastYShift;
+          const controlHeight = Math.abs(renderedEndY - renderedStartY) / 2 + 0.8 * Tables.STAVE_LINE_DISTANCE;
+          this.slur.renderOptions.cp1 = controlHeight;
+          this.slur.renderOptions.cp2 = controlHeight + 4;
+        }
+      }
+      if (this.slurStartIndex >= this.graceNotes.length - 1) this.slur.renderOptions.cp2 = 12;
       this.slur.setContext(ctx).drawWithStyle();
     }
   }

--- a/src/gracenotegroup.ts
+++ b/src/gracenotegroup.ts
@@ -36,8 +36,8 @@ export interface GraceNoteSlurBounds {
 export interface GraceNoteSlurLayout {
   curves: TieRenderCurve[];
   direction: number;
-  startAttachment: 'notehead' | 'stem-tip';
-  endAttachment: 'notehead' | 'stem-tip';
+  startAttachment: 'notehead' | 'notehead-center' | 'stem-tip';
+  endAttachment: 'notehead' | 'notehead-center' | 'stem-tip';
   startNotehead: GraceNoteSlurBounds;
   endNotehead: GraceNoteSlurBounds;
   intersectedEndpointIds: ('start-notehead' | 'end-notehead')[];
@@ -83,8 +83,8 @@ export class GraceNoteGroup extends Modifier {
   public renderOptions: { slurYShift: number };
   protected slur?: StaveTie | TabTie;
   protected slurStartIndex: number;
-  protected slurStartAttachment: 'notehead' | 'stem-tip' = 'notehead';
-  protected slurEndAttachment: 'notehead' | 'stem-tip' = 'notehead';
+  protected slurStartAttachment: 'notehead' | 'notehead-center' | 'stem-tip' = 'notehead';
+  protected slurEndAttachment: 'notehead' | 'notehead-center' | 'stem-tip' = 'notehead';
   protected beams: Beam[];
 
   /** Arranges groups inside a `ModifierContext`. */
@@ -346,14 +346,21 @@ export class GraceNoteGroup extends Modifier {
         const yShift = this.slur.renderOptions.yShift * direction;
         attachStemTip('start', slurStartNote, this.slur.getFirstX(), graceY + yShift);
         attachStemTip('end', note, this.slur.getLastX(), mainY + yShift);
+        if (this.slurEndAttachment === 'notehead') {
+          const mainNotehead = note.getSelectedNoteHeadBounds(0);
+          this.slur.renderOptions.lastXShift = mainNotehead.centerX - this.slur.getLastX();
+          this.slurEndAttachment = 'notehead-center';
+        }
         if (this.slurStartIndex < this.graceNotes.length - 1) {
           // A multi-note grace slur starts at the first source grace stem and
-          // must remain visibly above the intervening beam. Derive the control
-          // height from the endpoints so a diagonal gesture still clears the
-          // higher endpoint (and therefore the beam) by 0.8 staff-space.
+          // must remain visibly above the intervening beam. For a quadratic
+          // curve, the midpoint travels only halfway towards its control
+          // point, so double both the endpoint delta and desired clearance.
+          // This keeps the visible inner edge 1.2 staff-spaces outside the
+          // higher endpoint even when the gesture is diagonal.
           const renderedStartY = graceY + yShift + this.slur.renderOptions.firstYShift;
           const renderedEndY = mainY + yShift + this.slur.renderOptions.lastYShift;
-          const controlHeight = Math.abs(renderedEndY - renderedStartY) / 2 + 0.8 * Tables.STAVE_LINE_DISTANCE;
+          const controlHeight = Math.abs(renderedEndY - renderedStartY) + 2.4 * Tables.STAVE_LINE_DISTANCE;
           this.slur.renderOptions.cp1 = controlHeight;
           this.slur.renderOptions.cp2 = controlHeight + 4;
         }

--- a/src/gracenotegroup.ts
+++ b/src/gracenotegroup.ts
@@ -17,7 +17,7 @@ import { StaveTie, TieRenderCurve } from './stavetie';
 import { StemmableNote } from './stemmablenote';
 import { Tables } from './tables';
 import { TabTie } from './tabtie';
-import { Category, isStaveNote } from './typeguard';
+import { Category, isStaveNote, isTabNote } from './typeguard';
 import { log } from './util';
 import { Voice } from './voice';
 
@@ -236,6 +236,26 @@ export class GraceNoteGroup extends Modifier {
     return { left, right, top, bottom };
   }
 
+  private getRightmostNoteHead(note: StaveNote): GraceNoteSlurBounds {
+    return note.noteHeads
+      .map((noteHead) => noteHead.getBoundingBoxAt(note.getNoteHeadBeginX()))
+      .map((bounds) => ({
+        left: bounds.getX(),
+        right: bounds.getX() + bounds.getW(),
+        top: bounds.getY(),
+        bottom: bounds.getY() + bounds.getH(),
+      }))
+      .reduce((rightmost, bounds) => {
+        const rightmostCenter = (rightmost.left + rightmost.right) / 2;
+        const center = (bounds.left + bounds.right) / 2;
+        return center > rightmostCenter ? bounds : rightmost;
+      });
+  }
+
+  private getSlurEndNoteHead(note: StaveNote): GraceNoteSlurBounds {
+    return note.isChord() ? this.getRightmostNoteHead(note) : this.getNoteHeadSpan(note);
+  }
+
   private getAccidentalBounds(note: StaveNote): GraceNoteSlurBounds[] {
     return note.getModifiersByType(Category.Accidental).map((accidental) => {
       const index = accidental.getIndex() ?? 0;
@@ -295,7 +315,7 @@ export class GraceNoteGroup extends Modifier {
     const endIndex = notes.lastIndexes?.[0] ?? 0;
     const start = notes.firstNote.getSelectedNoteHeadBounds(startIndex);
     const end = notes.lastNote.isChord()
-      ? this.getNoteHeadSpan(notes.lastNote)
+      ? this.getRightmostNoteHead(notes.lastNote)
       : notes.lastNote.getSelectedNoteHeadBounds(endIndex);
     const startNotehead: GraceNoteSlurBounds = {
       left: start.left,
@@ -329,22 +349,88 @@ export class GraceNoteGroup extends Modifier {
     };
   }
 
-  private compactGraceNotesAgainstAccidentals(note: Note): void {
-    if (!this.showSlur || !isStaveNote(note) || this.position !== Modifier.Position.LEFT) return;
+  private getGraceNoteRightEdge(note: Note): number {
+    if (isTabNote(note)) return note.getAbsoluteX() + note.getWidth() / 2;
 
-    const accidentalBounds = this.getAccidentalBounds(note);
-    if (accidentalBounds.length === 0) return;
+    let right = note.getTieRightX();
+    if (isStaveNote(note) && note.shouldDrawFlag()) {
+      right = Math.max(right, note.getStemX() - Tables.STEM_WIDTH / 2 + note.getGlyphWidth());
+    }
+    if (isStaveNote(note)) {
+      note.getModifiersByType(Category.Dot).forEach((dot) => {
+        const index = dot.getIndex() ?? 0;
+        const start = note.getModifierStartXY(Modifier.Position.RIGHT, index, { forceFlagRight: true });
+        right = Math.max(right, start.x + dot.getXShift() + dot.getWidth());
+      });
+    }
+    return right;
+  }
 
-    const graceNote = this.getGraceNotes().at(-1);
-    if (!graceNote) return;
+  private getGraceNoteLeftEdge(note: Note): number {
+    if (isStaveNote(note)) {
+      const accidentalBounds = this.getAccidentalBounds(note);
+      return accidentalBounds.length > 0
+        ? Math.min(...accidentalBounds.map((bounds) => bounds.left))
+        : this.getNoteHeadSpan(note).left;
+    }
+    if (isTabNote(note)) return note.getAbsoluteX() - note.getWidth() / 2;
+    return note.getAbsoluteX();
+  }
 
-    const padding = Metrics.get('Accidental.noteheadAccidentalPadding');
-    const desiredRight = Math.min(...accidentalBounds.map((bounds) => bounds.left)) - padding;
-    const shift = desiredRight - graceNote.getTieRightX();
+  private getGraceNoteSpacingAfter(note: Note): number {
+    if (isStaveNote(note) && note.getModifiersByType(Category.Dot).length > 0) {
+      return 2 * StaveNote.minNoteheadPadding;
+    }
+    return StaveNote.minNoteheadPadding;
+  }
+
+  private spaceGraceNotesWithinGroup(): void {
+    const graceNotes = this.getGraceNotes();
+    for (let i = 1; i < graceNotes.length; i++) {
+      const currentGraceNote = graceNotes[i];
+      const previousRight = this.getGraceNoteRightEdge(graceNotes[i - 1]);
+      const currentLeft = this.getGraceNoteLeftEdge(currentGraceNote);
+      const desiredLeft = previousRight + this.getGraceNoteSpacingAfter(graceNotes[i - 1]);
+      const hasAccidental = isStaveNote(currentGraceNote) && this.getAccidentalBounds(currentGraceNote).length > 0;
+      const shift = desiredLeft - currentLeft;
+      if (shift < 0 && !hasAccidental) continue;
+      if (shift === 0) continue;
+
+      for (let j = i; j < graceNotes.length; j++) {
+        const tickContext = graceNotes[j].getTickContext();
+        tickContext.setXOffset(tickContext.getXOffset() + shift);
+      }
+    }
+  }
+
+  private spaceGraceNotesBeforeParent(note: Note): void {
+    if (!this.showSlur || this.position !== Modifier.Position.LEFT) return;
+
+    let parentLeft: number;
+    let padding = StaveNote.minNoteheadPadding;
+    if (isStaveNote(note)) {
+      const accidentalBounds = this.getAccidentalBounds(note);
+      if (accidentalBounds.length > 0) {
+        parentLeft = Math.min(...accidentalBounds.map((bounds) => bounds.left));
+        padding = Metrics.get('Accidental.noteheadAccidentalPadding');
+      } else {
+        parentLeft = this.getNoteHeadSpan(note).left;
+      }
+    } else if (isTabNote(note)) {
+      parentLeft = note.getAbsoluteX() - note.getWidth() / 2;
+    } else {
+      return;
+    }
+
+    const graceNotes = this.getGraceNotes();
+    const currentRight = Math.max(...graceNotes.map((graceNote) => this.getGraceNoteRightEdge(graceNote)));
+    const extraEndPadding = graceNotes.length > 1 ? StaveNote.minNoteheadPadding / 2 : 0;
+    const desiredRight = parentLeft - padding - extraEndPadding;
+    const shift = desiredRight - currentRight;
     if (Math.abs(shift) < 0.001) return;
 
-    this.getGraceNotes().forEach((note) => {
-      const tickContext = note.getTickContext();
+    graceNotes.forEach((graceNote) => {
+      const tickContext = graceNote.getTickContext();
       tickContext.setXOffset(tickContext.getXOffset() + shift);
     });
   }
@@ -357,7 +443,8 @@ export class GraceNoteGroup extends Modifier {
     L('Drawing grace note group for:', note);
 
     this.alignSubNotesWithNote(this.getGraceNotes(), note, this.position); // Modifier function
-    this.compactGraceNotesAgainstAccidentals(note);
+    this.spaceGraceNotesWithinGroup();
+    this.spaceGraceNotesBeforeParent(note);
 
     // Draw grace notes.
     this.graceNotes.forEach((graceNote) => graceNote.setContext(ctx).drawWithStyle());
@@ -418,11 +505,29 @@ export class GraceNoteGroup extends Modifier {
         const yShift = this.slur.renderOptions.yShift * direction;
         attachStemTip('start', slurStartNote, this.slur.getFirstX(), graceY + yShift);
         attachStemTip('end', note, this.slur.getLastX(), mainY + yShift);
+        if (this.slurStartAttachment === 'notehead' && isStaveNote(slurStartNote)) {
+          const startNotehead = slurStartNote.getSelectedNoteHeadBounds(0);
+          this.slur.renderOptions.firstXShift = startNotehead.centerX - this.slur.getFirstX();
+          this.slurStartAttachment = 'notehead-center';
+        }
         if (this.slurEndAttachment === 'notehead') {
-          const mainNotehead = this.getNoteHeadSpan(note);
+          const mainNotehead = this.getSlurEndNoteHead(note);
           this.slur.renderOptions.lastXShift = (mainNotehead.left + mainNotehead.right) / 2 - this.slur.getLastX();
+          if (note.isChord()) {
+            const clearY =
+              direction < 0
+                ? mainNotehead.top - StaveNote.minNoteheadPadding
+                : mainNotehead.bottom + StaveNote.minNoteheadPadding;
+            this.slur.renderOptions.lastYShift = clearY - (mainY + yShift);
+          }
           this.slurEndAttachment = 'notehead-center';
         }
+        const renderedStartY = graceY + yShift + this.slur.renderOptions.firstYShift;
+        const renderedEndY = mainY + yShift + this.slur.renderOptions.lastYShift;
+        const endpointSeparation = Math.abs(renderedEndY - renderedStartY);
+        const separationBasedControlHeight = endpointSeparation / 2;
+        this.slur.renderOptions.cp1 = Math.max(this.slur.renderOptions.cp1, separationBasedControlHeight);
+        this.slur.renderOptions.cp2 = Math.max(this.slur.renderOptions.cp2, separationBasedControlHeight + 4);
         if (this.slurStartIndex < this.graceNotes.length - 1) {
           // A multi-note grace slur starts at the first source grace stem and
           // must remain visibly above the intervening beam. For a quadratic
@@ -430,14 +535,11 @@ export class GraceNoteGroup extends Modifier {
           // point, so double both the endpoint delta and desired clearance.
           // This keeps the visible inner edge 0.6 staff-spaces outside the
           // higher endpoint even when the gesture is diagonal.
-          const renderedStartY = graceY + yShift + this.slur.renderOptions.firstYShift;
-          const renderedEndY = mainY + yShift + this.slur.renderOptions.lastYShift;
-          const controlHeight = Math.abs(renderedEndY - renderedStartY) + 1.2 * Tables.STAVE_LINE_DISTANCE;
+          const controlHeight = endpointSeparation + 1.2 * Tables.STAVE_LINE_DISTANCE;
           this.slur.renderOptions.cp1 = controlHeight;
           this.slur.renderOptions.cp2 = controlHeight + 4;
         }
       }
-      if (this.slurStartIndex >= this.graceNotes.length - 1) this.slur.renderOptions.cp2 = 12;
       if (this.slur instanceof StaveTie && isStavenote) this.clearSlurFromAccidentals(note);
       this.slur.setContext(ctx).drawWithStyle();
     }

--- a/src/modifiercontext.ts
+++ b/src/modifiercontext.ts
@@ -171,7 +171,10 @@ export class ModifierContext {
     if (this.postFormatted) return;
     L('Postformatting ModifierContext');
 
-    // If post-formatting is required for an element, add more lines below.
+    // Finalize beams and stems. Articulation geometry is calculated by the
+    // owning layout once the notes have their final staves and beam extents;
+    // draw() retains a legacy fallback for direct clients.
     StaveNote.postFormat(this.getMembers(Category.StaveNote) as Note[]);
+    this.postFormatted = true;
   }
 }

--- a/src/notehead.ts
+++ b/src/notehead.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2023-present VexFlow contributors: https://github.com/vexflow/vexflow/graphs/contributors
 // MIT License
 
+import { BoundingBox } from './boundingbox';
 import { ElementStyle } from './element';
 import { Note, NoteStruct } from './note';
 import { Stave } from './stave';
@@ -120,11 +121,30 @@ export class NoteHead extends Note {
     // to its tick context
     const x = !this.preFormatted ? this.x : super.getAbsoluteX();
 
-    // For a more natural displaced notehead, we adjust the displacement amount
-    // by half the stem width in order to maintain a slight overlap with the stem
-    const displacementStemAdjustment = Stem.WIDTH / 2;
+    return this.getRenderedX(x);
+  }
 
-    return x + (this.displaced ? (this.width - displacementStemAdjustment) * this.stemDirection : 0);
+  /**
+   * Return the rendered x coordinate for a notehead whose parent chord begins
+   * at `baseX`. Unlike `getAbsoluteX()`, this does not depend on or mutate the
+   * notehead's current draw state, so layout clients can query displaced chord
+   * heads before drawing.
+   */
+  getRenderedX(baseX: number): number {
+    // For a more natural displaced notehead, we adjust the displacement amount
+    // by half the stem width in order to maintain a slight overlap with the stem.
+    const displacementStemAdjustment = Stem.WIDTH / 2;
+    return baseX + (this.displaced ? (this.width - displacementStemAdjustment) * this.stemDirection : 0);
+  }
+
+  /**
+   * Return the exact glyph bounding box at the supplied parent-note x
+   * coordinate without changing the notehead's stored position.
+   */
+  getBoundingBoxAt(baseX: number): BoundingBox {
+    const boundingBox = super.getBoundingBox().clone();
+    boundingBox.setX(this.getRenderedX(baseX) + this.xShift);
+    return boundingBox;
   }
 
   /** Set notehead to a provided `stave`. */

--- a/src/stavenote.ts
+++ b/src/stavenote.ts
@@ -37,6 +37,19 @@ export interface StaveNoteHeadBounds {
   lowestNonDisplacedLine: number;
 }
 
+export interface StaveNoteSelectedNoteHeadBounds {
+  index: number;
+  boundingBox: BoundingBox;
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+  centerX: number;
+  centerY: number;
+  line: number;
+  displaced: boolean;
+}
+
 export interface StaveNoteFormatSettings {
   line: number;
   maxLine: number;
@@ -1030,6 +1043,46 @@ export class StaveNote extends StemmableNote {
     return this._noteHeads.slice();
   }
 
+  /**
+   * Return the exact pre-draw bounds for one selected head in a chord.
+   *
+   * The regular note bounding box includes stems, flags and modifiers. Slurs,
+   * ties and articulation layout instead need the glyph bounds for the exact
+   * MusicXML pitch they attach to, including VexFlow's chord-head displacement.
+   */
+  getNoteHeadBoundingBox(index: number): BoundingBox {
+    const noteHead = this._noteHeads[index];
+    if (!noteHead) {
+      throw new RuntimeError('BadArguments', `No notehead exists at index ${index}.`);
+    }
+    return noteHead.getBoundingBoxAt(this.getNoteHeadBeginX());
+  }
+
+  /** Return a serializable description of one selected notehead's geometry. */
+  getSelectedNoteHeadBounds(index: number): StaveNoteSelectedNoteHeadBounds {
+    const noteHead = this._noteHeads[index];
+    if (!noteHead) {
+      throw new RuntimeError('BadArguments', `No notehead exists at index ${index}.`);
+    }
+    const boundingBox = this.getNoteHeadBoundingBox(index);
+    const left = boundingBox.getX();
+    const top = boundingBox.getY();
+    const right = left + boundingBox.getW();
+    const bottom = top + boundingBox.getH();
+    return {
+      index,
+      boundingBox,
+      left,
+      right,
+      top,
+      bottom,
+      centerX: (left + right) / 2,
+      centerY: (top + bottom) / 2,
+      line: noteHead.getLine(),
+      displaced: noteHead.isDisplaced(),
+    };
+  }
+
   // Draw the ledger lines between the stave and the highest/lowest keys
   drawLedgerLines(): void {
     const stave = this.checkStave();
@@ -1148,6 +1201,27 @@ export class StaveNote extends StemmableNote {
     });
   }
 
+  /**
+   * Finalize notehead, stem, beam, and articulation geometry without drawing.
+   * Safe to call repeatedly after horizontal formatting or stave changes.
+   */
+  layoutArticulations(): void {
+    const xBegin = this.getNoteHeadBeginX();
+    this._noteHeads.forEach((notehead) => notehead.setX(xBegin));
+
+    if (this.stem) {
+      const stemX = this.getStemX();
+      this.stem.setNoteHeadXBounds(stemX, stemX);
+    }
+    this.beam?.postFormat();
+
+    for (const modifier of this.modifiers) {
+      if (modifier.getCategory() === Category.Articulation) {
+        (modifier as Modifier & { layout(): unknown }).layout();
+      }
+    }
+  }
+
   override drawStem(stemOptions?: StemOptions): void {
     // GCR TODO: I can't find any context in which this is called with the stemStruct
     // argument in the codebase or tests. Nor can I find a case where super.drawStem
@@ -1222,11 +1296,8 @@ export class StaveNote extends StemmableNote {
     const xBegin = this.getNoteHeadBeginX();
     const shouldRenderStem = this.hasStem() && !this.beam;
 
-    // Format note head x positions
     this._noteHeads.forEach((notehead) => notehead.setX(xBegin));
-
     if (this.stem) {
-      // Format stem x positions
       const stemX = this.getStemX();
       this.stem.setNoteHeadXBounds(stemX, stemX);
     }

--- a/src/stavenote.ts
+++ b/src/stavenote.ts
@@ -1206,6 +1206,11 @@ export class StaveNote extends StemmableNote {
    * Safe to call repeatedly after horizontal formatting or stave changes.
    */
   layoutArticulations(): void {
+    const articulations = this.modifiers.filter((modifier) => modifier.getCategory() === Category.Articulation);
+    if (articulations.length === 0) {
+      return;
+    }
+
     const xBegin = this.getNoteHeadBeginX();
     this._noteHeads.forEach((notehead) => notehead.setX(xBegin));
 
@@ -1215,10 +1220,8 @@ export class StaveNote extends StemmableNote {
     }
     this.beam?.postFormat();
 
-    for (const modifier of this.modifiers) {
-      if (modifier.getCategory() === Category.Articulation) {
-        (modifier as Modifier & { layout(): unknown }).layout();
-      }
+    for (const modifier of articulations) {
+      (modifier as Modifier & { layout(): unknown }).layout();
     }
   }
 

--- a/src/stavetie.ts
+++ b/src/stavetie.ts
@@ -39,6 +39,8 @@ export class StaveTie extends Element {
     cp2Short: number;
     firstXShift: number;
     lastXShift: number;
+    firstYShift: number;
+    lastYShift: number;
     tieSpacing: number;
     textShiftX: number;
     yShift: number;
@@ -74,6 +76,8 @@ export class StaveTie extends Element {
       textShiftX: 0,
       firstXShift: 0,
       lastXShift: 0,
+      firstYShift: 0,
+      lastYShift: 0,
       yShift: 7,
       tieSpacing: 0,
     };
@@ -163,22 +167,22 @@ export class StaveTie extends Element {
     lastYs: number[];
     firstYs: number[];
   }): TieRenderCurve[] {
+    const firstX = params.firstX + this.renderOptions.firstXShift;
+    const lastX = params.lastX + this.renderOptions.lastXShift;
     let cp1 = this.renderOptions.cp1;
     let cp2 = this.renderOptions.cp2;
-    if (Math.abs(params.lastX - params.firstX) < this.renderOptions.shortTieCutoff) {
+    if (Math.abs(lastX - firstX) < this.renderOptions.shortTieCutoff) {
       cp1 = this.renderOptions.cp1Short;
       cp2 = this.renderOptions.cp2Short;
     }
-    const firstX = params.firstX + this.renderOptions.firstXShift;
-    const lastX = params.lastX + this.renderOptions.lastXShift;
     const cpX = (lastX + firstX) / 2;
     const yShift = this.renderOptions.yShift * params.direction;
     const curves: TieRenderCurve[] = [];
     const firstIndexes = this.notes.firstIndexes!;
     const lastIndexes = this.notes.lastIndexes!;
     for (let index = 0; index < firstIndexes.length; index++) {
-      const firstY = params.firstYs[firstIndexes[index]] + yShift;
-      const lastY = params.lastYs[lastIndexes[index]] + yShift;
+      const firstY = params.firstYs[firstIndexes[index]] + yShift + this.renderOptions.firstYShift;
+      const lastY = params.lastYs[lastIndexes[index]] + yShift + this.renderOptions.lastYShift;
       if (isNaN(firstY) || isNaN(lastY)) {
         throw new RuntimeError('BadArguments', 'Bad indexes for tie rendering.');
       }

--- a/src/stavetie.ts
+++ b/src/stavetie.ts
@@ -18,6 +18,14 @@ export interface TieNotes {
   lastIndexes?: number[];
 }
 
+/** Final quadratic outlines in render-context pixels, shared by drawing and collision layout. */
+export interface TieRenderCurve {
+  start: { x: number; y: number };
+  topControl: { x: number; y: number };
+  end: { x: number; y: number };
+  bottomControl: { x: number; y: number };
+}
+
 export class StaveTie extends Element {
   static override get CATEGORY(): string {
     return Category.StaveTie;
@@ -134,49 +142,66 @@ export class StaveTie extends Element {
     }
 
     const ctx = this.checkContext();
-    let cp1 = this.renderOptions.cp1;
-    let cp2 = this.renderOptions.cp2;
-
-    if (Math.abs(params.lastX - params.firstX) < this.renderOptions.shortTieCutoff) {
-      // do not get super exaggerated curves for very short ties
-      cp1 = this.renderOptions.cp1Short;
-      cp2 = this.renderOptions.cp2Short;
-    }
-
-    const firstXShift = this.renderOptions.firstXShift;
-    const lastXShift = this.renderOptions.lastXShift;
-    const yShift = this.renderOptions.yShift * params.direction;
-
-    // setNotes(...) verified that firstIndexes and lastIndexes are not undefined.
-    // As a result, we use the ! non-null assertion operator here.
-
-    const firstIndexes = this.notes.firstIndexes!;
-
-    const lastIndexes = this.notes.lastIndexes!;
     const clsAttribute = this.getAttribute('class');
     ctx.openGroup('stavetie' + (clsAttribute ? ' ' + clsAttribute : ''), this.getAttribute('id'));
-    for (let i = 0; i < firstIndexes.length; ++i) {
-      const cpX = (params.lastX + lastXShift + (params.firstX + firstXShift)) / 2;
-      // firstY and lastY are specified in pixels.
-      const firstY = params.firstYs[firstIndexes[i]] + yShift;
-      const lastY = params.lastYs[lastIndexes[i]] + yShift;
-
-      if (isNaN(firstY) || isNaN(lastY)) {
-        throw new RuntimeError('BadArguments', 'Bad indexes for tie rendering.');
-      }
-
-      const topControlPointY = (firstY + lastY) / 2 + cp1 * params.direction;
-      const bottomControlPointY = (firstY + lastY) / 2 + cp2 * params.direction;
-
+    for (const curve of this.calculateRenderedTieCurves(params)) {
       ctx.beginPath();
-      ctx.moveTo(params.firstX + firstXShift, firstY);
-      ctx.quadraticCurveTo(cpX, topControlPointY, params.lastX + lastXShift, lastY);
-      ctx.quadraticCurveTo(cpX, bottomControlPointY, params.firstX + firstXShift, firstY);
+      ctx.moveTo(curve.start.x, curve.start.y);
+      ctx.quadraticCurveTo(curve.topControl.x, curve.topControl.y, curve.end.x, curve.end.y);
+      ctx.quadraticCurveTo(curve.bottomControl.x, curve.bottomControl.y, curve.start.x, curve.start.y);
       ctx.closePath();
       ctx.fill();
     }
     this.drawPointerRect();
     ctx.closeGroup();
+  }
+
+  private calculateRenderedTieCurves(params: {
+    direction: number;
+    firstX: number;
+    lastX: number;
+    lastYs: number[];
+    firstYs: number[];
+  }): TieRenderCurve[] {
+    let cp1 = this.renderOptions.cp1;
+    let cp2 = this.renderOptions.cp2;
+    if (Math.abs(params.lastX - params.firstX) < this.renderOptions.shortTieCutoff) {
+      cp1 = this.renderOptions.cp1Short;
+      cp2 = this.renderOptions.cp2Short;
+    }
+    const firstX = params.firstX + this.renderOptions.firstXShift;
+    const lastX = params.lastX + this.renderOptions.lastXShift;
+    const cpX = (lastX + firstX) / 2;
+    const yShift = this.renderOptions.yShift * params.direction;
+    const curves: TieRenderCurve[] = [];
+    const firstIndexes = this.notes.firstIndexes!;
+    const lastIndexes = this.notes.lastIndexes!;
+    for (let index = 0; index < firstIndexes.length; index++) {
+      const firstY = params.firstYs[firstIndexes[index]] + yShift;
+      const lastY = params.lastYs[lastIndexes[index]] + yShift;
+      if (isNaN(firstY) || isNaN(lastY)) {
+        throw new RuntimeError('BadArguments', 'Bad indexes for tie rendering.');
+      }
+      curves.push({
+        start: { x: firstX, y: firstY },
+        topControl: { x: cpX, y: (firstY + lastY) / 2 + cp1 * params.direction },
+        end: { x: lastX, y: lastY },
+        bottomControl: { x: cpX, y: (firstY + lastY) / 2 + cp2 * params.direction },
+      });
+    }
+    return curves;
+  }
+
+  /** Return the finalized tie outlines using exactly the geometry consumed by draw(). */
+  getRenderedTieCurves(): TieRenderCurve[] {
+    this.synchronizeIndexes();
+    return this.calculateRenderedTieCurves({
+      firstX: this.getFirstX(),
+      lastX: this.getLastX(),
+      firstYs: this.getFirstYs(),
+      lastYs: this.getLastYs(),
+      direction: this.getDirection(),
+    });
   }
 
   /**

--- a/tests/articulation_tests.ts
+++ b/tests/articulation_tests.ts
@@ -6,7 +6,7 @@
 import { VexFlow } from '../src/vexflow';
 import { TestOptions, VexFlowTests } from './vexflow_test_helpers';
 
-import { Articulation } from '../src/articulation';
+import { Articulation, ArticulationLayout } from '../src/articulation';
 import { Beam } from '../src/beam';
 import { Formatter } from '../src/formatter';
 import { Glyphs } from '../src/glyphs';
@@ -29,6 +29,9 @@ const ArticulationTests = {
     run('Vertical Placement', verticalPlacement, { drawBoundingBox: false });
     run('Vertical Placement (Glyph codes)', verticalPlacement2);
     run('Origin remains stable after positioning', originRemainsStable);
+    run('Pre-draw selected notehead layout', selectedNoteheadPreDrawLayout);
+    run('Final beam geometry precedes articulation layout', finalBeamGeometryLayout);
+    run('Outward displacement is absolute and idempotent', absoluteOutwardDisplacement);
     run('Staccato/Staccatissimo', drawArticulations, { sym1: 'a.', sym2: 'av' });
     run('Accent/Tenuto', drawArticulations, { sym1: 'a>', sym2: 'a-' });
     run('Marcato/L.H. Pizzicato', drawArticulations, { sym1: 'a^', sym2: 'a+' });
@@ -61,6 +64,94 @@ function originRemainsStable(options: TestOptions): void {
     articulation.getYShift(),
     initialYShift,
     'The glyph origin does not absorb the previous rendered y coordinate.'
+  );
+}
+
+function formatNotesToStave(stave: Stave, notes: StaveNote[], beats: number): void {
+  const voice = new Voice({ numBeats: beats, beatValue: 8 }).addTickables(notes);
+  new Formatter().joinVoices([voice]).formatToStave([voice], stave, { stave });
+}
+
+function assertClose(options: TestOptions, actual: number, expected: number, message: string): void {
+  options.assert.ok(Math.abs(actual - expected) <= 0.001, `${message}: expected ${expected}, got ${actual}`);
+}
+
+function selectedNoteheadPreDrawLayout(options: TestOptions, contextBuilder: ContextBuilder): void {
+  const ctx = contextBuilder(options.elementId, 420, 180);
+  const stave = new Stave(10, 40, 400).setContext(ctx);
+  const articulation = new Articulation('a.').setPosition(ModifierPosition.ABOVE);
+  const note = new StaveNote({
+    keys: ['b/4', 'c/5'],
+    duration: '8',
+    stemDirection: Stem.UP,
+  }).addModifier(articulation, 1);
+
+  formatNotesToStave(stave, [note], 1);
+
+  const selectedHead = note.getSelectedNoteHeadBounds(1);
+  note.layoutArticulations();
+  const firstLayout = articulation.getLayout();
+  const secondLayout = articulation.layout();
+  options.assert.ok(selectedHead.displaced, 'the selected upper chord head is displaced');
+  assertClose(
+    options,
+    firstLayout.x,
+    selectedHead.centerX,
+    'articulation is centered on the selected displaced notehead'
+  );
+  assertClose(options, secondLayout.x, firstLayout.x, 'repeated pre-draw layout keeps x stable');
+  assertClose(options, secondLayout.y, firstLayout.y, 'repeated pre-draw layout keeps y stable');
+
+  articulation.setContext(ctx);
+  articulation.draw();
+  const afterDraw = articulation.getLayout();
+  assertClose(options, afterDraw.x, firstLayout.x, 'draw consumes the calculated x without changing it');
+  assertClose(options, afterDraw.y, firstLayout.y, 'draw consumes the calculated y without changing it');
+}
+
+function finalBeamGeometryLayout(options: TestOptions, contextBuilder: ContextBuilder): void {
+  const ctx = contextBuilder(options.elementId, 420, 180);
+  const stave = new Stave(10, 40, 400).setContext(ctx);
+  const articulation = new Articulation('a>').setPosition(ModifierPosition.ABOVE);
+  const notes = [
+    new StaveNote({ keys: ['c/5'], duration: '8', stemDirection: Stem.UP }).addModifier(articulation, 0),
+    new StaveNote({ keys: ['g/5'], duration: '8', stemDirection: Stem.UP }),
+  ];
+  const beam = new Beam(notes);
+
+  formatNotesToStave(stave, notes, 2);
+
+  const firstLayout: ArticulationLayout = articulation.getLayout();
+  const firstStemTip = notes[0].getStemExtents().topY;
+  options.assert.ok(beam.postFormatted, 'beam geometry is finalized by formatter post-format');
+  options.assert.ok(firstLayout.y < firstStemTip, 'stem-side articulation clears the final beamed stem tip');
+
+  beam.postFormat();
+  const secondLayout = articulation.layout();
+  assertClose(options, secondLayout.x, firstLayout.x, 're-finalizing the beam does not move articulation x');
+  assertClose(options, secondLayout.y, firstLayout.y, 're-finalizing the beam does not move articulation y');
+}
+
+function absoluteOutwardDisplacement(options: TestOptions, contextBuilder: ContextBuilder): void {
+  const ctx = contextBuilder(options.elementId, 420, 180);
+  const stave = new Stave(10, 40, 400).setContext(ctx);
+  const articulation = new Articulation('a-').setPosition(ModifierPosition.ABOVE);
+  const note = new StaveNote({ keys: ['c/5'], duration: '8', stemDirection: Stem.DOWN }).addModifier(articulation, 0);
+
+  formatNotesToStave(stave, [note], 1);
+  const baseline = articulation.getLayout();
+  articulation.setOutwardShift(12);
+  const shifted = articulation.layout();
+  articulation.setOutwardShift(12);
+  const repeated = articulation.layout();
+
+  assertClose(options, shifted.y, baseline.y - 12, 'above articulation moves outward by the requested amount');
+  assertClose(options, repeated.y, shifted.y, 'reapplying the same outward shift does not accumulate');
+  assertClose(
+    options,
+    repeated.boundingBox.getY(),
+    shifted.boundingBox.getY(),
+    'the final articulation bounds remain stable'
   );
 }
 

--- a/tests/articulation_tests.ts
+++ b/tests/articulation_tests.ts
@@ -29,7 +29,7 @@ const ArticulationTests = {
     run('Vertical Placement', verticalPlacement, { drawBoundingBox: false });
     run('Vertical Placement (Glyph codes)', verticalPlacement2);
     run('Origin remains stable after positioning', originRemainsStable);
-    run('Pre-draw selected notehead layout', selectedNoteheadPreDrawLayout);
+    run('Pre-draw chord-column layout', chordColumnPreDrawLayout);
     run('Final beam geometry precedes articulation layout', finalBeamGeometryLayout);
     run('Notes without articulations leave beam geometry alone', noArticulationLayoutIsNoop);
     run('Outward displacement is absolute and idempotent', absoluteOutwardDisplacement);
@@ -77,7 +77,7 @@ function assertClose(options: TestOptions, actual: number, expected: number, mes
   options.assert.ok(Math.abs(actual - expected) <= 0.001, `${message}: expected ${expected}, got ${actual}`);
 }
 
-function selectedNoteheadPreDrawLayout(options: TestOptions, contextBuilder: ContextBuilder): void {
+function chordColumnPreDrawLayout(options: TestOptions, contextBuilder: ContextBuilder): void {
   const ctx = contextBuilder(options.elementId, 420, 180);
   const stave = new Stave(10, 40, 400).setContext(ctx);
   const articulation = new Articulation('a.').setPosition(ModifierPosition.ABOVE);
@@ -90,15 +90,17 @@ function selectedNoteheadPreDrawLayout(options: TestOptions, contextBuilder: Con
   formatNotesToStave(stave, [note], 1);
 
   const selectedHead = note.getSelectedNoteHeadBounds(1);
+  const otherHead = note.getSelectedNoteHeadBounds(0);
+  const chordCentre = (Math.min(selectedHead.left, otherHead.left) + Math.max(selectedHead.right, otherHead.right)) / 2;
   note.layoutArticulations();
   const firstLayout = articulation.getLayout();
   const secondLayout = articulation.layout();
   options.assert.ok(selectedHead.displaced, 'the selected upper chord head is displaced');
-  assertClose(
-    options,
+  assertClose(options, firstLayout.x, chordCentre, 'articulation is centered on the owning chord');
+  options.assert.notEqual(
     firstLayout.x,
     selectedHead.centerX,
-    'articulation is centered on the selected displaced notehead'
+    'displaced notehead does not pull the chord articulation aside'
   );
   assertClose(options, secondLayout.x, firstLayout.x, 'repeated pre-draw layout keeps x stable');
   assertClose(options, secondLayout.y, firstLayout.y, 'repeated pre-draw layout keeps y stable');

--- a/tests/articulation_tests.ts
+++ b/tests/articulation_tests.ts
@@ -31,6 +31,7 @@ const ArticulationTests = {
     run('Origin remains stable after positioning', originRemainsStable);
     run('Pre-draw selected notehead layout', selectedNoteheadPreDrawLayout);
     run('Final beam geometry precedes articulation layout', finalBeamGeometryLayout);
+    run('Notes without articulations leave beam geometry alone', noArticulationLayoutIsNoop);
     run('Outward displacement is absolute and idempotent', absoluteOutwardDisplacement);
     run('Staccato/Staccatissimo', drawArticulations, { sym1: 'a.', sym2: 'av' });
     run('Accent/Tenuto', drawArticulations, { sym1: 'a>', sym2: 'a-' });
@@ -130,6 +131,27 @@ function finalBeamGeometryLayout(options: TestOptions, contextBuilder: ContextBu
   const secondLayout = articulation.layout();
   assertClose(options, secondLayout.x, firstLayout.x, 're-finalizing the beam does not move articulation x');
   assertClose(options, secondLayout.y, firstLayout.y, 're-finalizing the beam does not move articulation y');
+}
+
+function noArticulationLayoutIsNoop(options: TestOptions, contextBuilder: ContextBuilder): void {
+  const ctx = contextBuilder(options.elementId, 420, 180);
+  const stave = new Stave(10, 40, 400).setContext(ctx);
+  const notes = [
+    new StaveNote({ keys: ['c/5'], duration: '8', stemDirection: Stem.UP }),
+    new StaveNote({ keys: ['g/5'], duration: '8', stemDirection: Stem.UP }),
+  ];
+  const beam = new Beam(notes);
+  formatNotesToStave(stave, notes, 2);
+
+  let postFormatCalls = 0;
+  const originalPostFormat = beam.postFormat.bind(beam);
+  beam.postFormat = (): void => {
+    postFormatCalls++;
+    originalPostFormat();
+  };
+
+  notes[0].layoutArticulations();
+  options.assert.strictEqual(postFormatCalls, 0, 'a note without articulations does not re-finalize its beam');
 }
 
 function absoluteOutwardDisplacement(options: TestOptions, contextBuilder: ContextBuilder): void {

--- a/tests/articulation_tests.ts
+++ b/tests/articulation_tests.ts
@@ -28,6 +28,7 @@ const ArticulationTests = {
     run('Bounding Box', verticalPlacement, { drawBoundingBox: true });
     run('Vertical Placement', verticalPlacement, { drawBoundingBox: false });
     run('Vertical Placement (Glyph codes)', verticalPlacement2);
+    run('Origin remains stable after positioning', originRemainsStable);
     run('Staccato/Staccatissimo', drawArticulations, { sym1: 'a.', sym2: 'av' });
     run('Accent/Tenuto', drawArticulations, { sym1: 'a>', sym2: 'a-' });
     run('Marcato/L.H. Pizzicato', drawArticulations, { sym1: 'a^', sym2: 'a+' });
@@ -41,6 +42,27 @@ const ArticulationTests = {
     run('TabNote Articulation', tabNotes, { sym1: 'a.', sym2: 'a.' });
   },
 };
+
+function originRemainsStable(options: TestOptions): void {
+  const articulation = new Articulation('a.');
+  articulation.setOrigin(0.5, 1);
+  const initialXShift = articulation.getXShift();
+  const initialYShift = articulation.getYShift();
+
+  articulation.setX(240).setY(160);
+  articulation.setOrigin(0.5, 1);
+
+  options.assert.strictEqual(
+    articulation.getXShift(),
+    initialXShift,
+    'The glyph origin does not absorb the previous rendered x coordinate.'
+  );
+  options.assert.strictEqual(
+    articulation.getYShift(),
+    initialYShift,
+    'The glyph origin does not absorb the previous rendered y coordinate.'
+  );
+}
 
 // Helper function for creating StaveNotes.
 function drawArticulations(options: TestOptions): void {

--- a/tests/beam_tests.ts
+++ b/tests/beam_tests.ts
@@ -70,7 +70,23 @@ function simple(options: TestOptions): void {
 
   f.Formatter().joinVoices([voice]).formatToStave([voice], stave);
 
+  const renderedBeam = voice
+    .getTickables()
+    .find((tickable) => (tickable as StemmableNote).getBeam?.()) as StemmableNote;
+  const vfBeam = renderedBeam.getBeam();
+  const polygonsBeforeDraw = vfBeam?.getRenderedBeamPolygons();
+  options.assert.ok(
+    polygonsBeforeDraw && polygonsBeforeDraw.length > 0,
+    'Finalized beam polygons are available before draw'
+  );
+
   f.draw();
+
+  options.assert.deepEqual(
+    vfBeam?.getRenderedBeamPolygons(),
+    polygonsBeforeDraw,
+    'Beam drawing consumes the same finalized polygons'
+  );
 
   options.assert.ok(true, 'Simple Test');
 }

--- a/tests/gracenote_tests.ts
+++ b/tests/gracenote_tests.ts
@@ -224,12 +224,13 @@ function basicSlurred(options: TestOptions): void {
   options.assert.strictEqual(slur?.getNotes().lastNote, notes[0], 'slur ends at main note');
   const curve = (firstGraceGroup as GraceNoteGroup).getRenderedSlurCurves()[0];
   const curveDirection = (firstGraceGroup as GraceNoteGroup).getSlurLayout()?.direction ?? 1;
+  const curveMidpointY = (curve.start.y + 2 * curve.topControl.y + curve.end.y) / 4;
   const beamClearance =
     curveDirection === -1
-      ? Math.min(curve.start.y, curve.end.y) - curve.topControl.y
-      : curve.topControl.y - Math.max(curve.start.y, curve.end.y);
+      ? Math.min(curve.start.y, curve.end.y) - curveMidpointY
+      : curveMidpointY - Math.max(curve.start.y, curve.end.y);
   options.assert.ok(curve.start.x < curve.end.x, 'slur follows the left-to-right musical order');
-  options.assert.ok(beamClearance >= 7.9, 'a source-spanning grace slur clears the beamed grace notes');
+  options.assert.ok(beamClearance >= 11.9, 'a source-spanning grace slur clears the beamed grace notes');
   options.assert.deepEqual(
     (firstGraceGroup as GraceNoteGroup).getSlurLayout()?.intersectedEndpointIds,
     [],

--- a/tests/gracenote_tests.ts
+++ b/tests/gracenote_tests.ts
@@ -19,6 +19,33 @@ import { GraceNote, GraceNoteStruct } from '../src/gracenote';
 import { GraceNoteGroup } from '../src/gracenotegroup';
 import { StaveNote, StaveNoteStruct } from '../src/stavenote';
 
+function curveIntersectsBounds(
+  curve: {
+    start: { x: number; y: number };
+    topControl: { x: number; y: number };
+    end: { x: number; y: number };
+    bottomControl: { x: number; y: number };
+  },
+  bounds: { left: number; right: number; top: number; bottom: number }
+): boolean {
+  for (let sample = 1; sample < 24; sample++) {
+    const t = sample / 24;
+    const oneMinusT = 1 - t;
+    const points = [curve.topControl, curve.bottomControl].map((control) => ({
+      x: oneMinusT * oneMinusT * curve.start.x + 2 * oneMinusT * t * control.x + t * t * curve.end.x,
+      y: oneMinusT * oneMinusT * curve.start.y + 2 * oneMinusT * t * control.y + t * t * curve.end.y,
+    }));
+    if (
+      points.some(
+        (point) => point.x > bounds.left && point.x < bounds.right && point.y > bounds.top && point.y < bounds.bottom
+      )
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
 const GraceNoteTests = {
   Start(): void {
     QUnit.module('Grace Notes');
@@ -192,24 +219,24 @@ function basicSlurred(options: TestOptions): void {
   Dot.buildAndAttach([gracenotes4[0]], { all: true });
 
   const firstGraceGroup = f.GraceNoteGroup({ notes: gracenotes0, slur: true, slurStartIndex: 0 }).beamNotes();
+  const secondGraceGroup = f.GraceNoteGroup({ notes: gracenotes1, slur: true }).beamNotes();
+  const thirdGraceGroup = f.GraceNoteGroup({ notes: gracenotes2, slur: true }).beamNotes();
+  const fourthGraceGroup = f.GraceNoteGroup({ notes: gracenotes3, slur: true }).beamNotes();
+  const fifthGraceGroup = f.GraceNoteGroup({ notes: gracenotes4, slur: true }).beamNotes();
   const steepGraceNotes = [{ keys: ['e/6'], duration: '8', stemDirection: 1 }].map(f.GraceNote.bind(f));
   const steepGraceGroup = f.GraceNoteGroup({ notes: steepGraceNotes, slur: true });
   const steepMainNote = f.StaveNote({ keys: ['a/4'], duration: '4', stemDirection: 1 });
+  const secondMainNote = f.StaveNote({ keys: ['c/5'], duration: '4', autoStem: true });
+  const secondAccidental = f.Accidental({ type: '#' });
+  const thirdMainNote = f.StaveNote({ keys: ['c/5', 'd/5'], duration: '4', autoStem: true });
+  const fourthMainNote = f.StaveNote({ keys: ['a/4'], duration: '4', autoStem: true });
+  const fifthMainNote = f.StaveNote({ keys: ['a/4'], duration: '4', autoStem: true });
   const notes = [
     f.StaveNote({ keys: ['b/4'], duration: '4', autoStem: true }).addModifier(firstGraceGroup, 0),
-    f
-      .StaveNote({ keys: ['c/5'], duration: '4', autoStem: true })
-      .addModifier(f.Accidental({ type: '#' }), 0)
-      .addModifier(f.GraceNoteGroup({ notes: gracenotes1, slur: true }).beamNotes(), 0),
-    f
-      .StaveNote({ keys: ['c/5', 'd/5'], duration: '4', autoStem: true })
-      .addModifier(f.GraceNoteGroup({ notes: gracenotes2, slur: true }).beamNotes(), 0),
-    f
-      .StaveNote({ keys: ['a/4'], duration: '4', autoStem: true })
-      .addModifier(f.GraceNoteGroup({ notes: gracenotes3, slur: true }).beamNotes(), 0),
-    f
-      .StaveNote({ keys: ['a/4'], duration: '4', autoStem: true })
-      .addModifier(f.GraceNoteGroup({ notes: gracenotes4, slur: true }).beamNotes(), 0),
+    secondMainNote.addModifier(secondAccidental, 0).addModifier(secondGraceGroup, 0),
+    thirdMainNote.addModifier(thirdGraceGroup, 0),
+    fourthMainNote.addModifier(fourthGraceGroup, 0),
+    fifthMainNote.addModifier(fifthGraceGroup, 0),
     steepMainNote.addModifier(steepGraceGroup, 0),
   ];
 
@@ -235,6 +262,44 @@ function basicSlurred(options: TestOptions): void {
     (firstGraceGroup as GraceNoteGroup).getSlurLayout()?.intersectedEndpointIds,
     [],
     'slur does not cross either connected notehead'
+  );
+  options.assert.strictEqual(
+    fourthGraceGroup.getSlur()?.getNotes().firstNote,
+    gracenotes3[0],
+    'the fourth-quarter slur includes every grace note in the group'
+  );
+  options.assert.strictEqual(
+    fifthGraceGroup.getSlur()?.getNotes().firstNote,
+    gracenotes4[0],
+    'the fifth-quarter slur includes every grace note in the group'
+  );
+
+  const thirdCurve = thirdGraceGroup.getRenderedSlurCurves()[0];
+  const thirdHeadBounds = thirdMainNote.noteHeads.map((noteHead) =>
+    noteHead.getBoundingBoxAt(thirdMainNote.getNoteHeadBeginX())
+  );
+  const thirdChordLeft = Math.min(...thirdHeadBounds.map((bounds) => bounds.getX()));
+  const thirdChordRight = Math.max(...thirdHeadBounds.map((bounds) => bounds.getX() + bounds.getW()));
+  options.assert.ok(
+    Math.abs(thirdCurve.end.x - (thirdChordLeft + thirdChordRight) / 2) < 0.001,
+    'the chord-ending slur attaches at the visual center of the chord'
+  );
+
+  const secondAccidentalBounds = secondAccidental.getBoundingBox();
+  const secondGraceRight = gracenotes1[0].getTieRightX();
+  options.assert.ok(
+    secondAccidentalBounds.getX() - secondGraceRight <= 1.001,
+    'the grace group uses compact spacing before the parent accidental'
+  );
+  const secondAccidentalRect = {
+    left: secondAccidentalBounds.getX(),
+    right: secondAccidentalBounds.getX() + secondAccidentalBounds.getW(),
+    top: secondAccidentalBounds.getY(),
+    bottom: secondAccidentalBounds.getY() + secondAccidentalBounds.getH(),
+  };
+  options.assert.notOk(
+    secondGraceGroup.getRenderedSlurCurves().some((curve) => curveIntersectsBounds(curve, secondAccidentalRect)),
+    'the second-quarter slur clears the parent accidental'
   );
   options.assert.strictEqual(
     (steepGraceGroup as GraceNoteGroup).getSlurLayout()?.direction,

--- a/tests/gracenote_tests.ts
+++ b/tests/gracenote_tests.ts
@@ -230,7 +230,7 @@ function basicSlurred(options: TestOptions): void {
       ? Math.min(curve.start.y, curve.end.y) - curveMidpointY
       : curveMidpointY - Math.max(curve.start.y, curve.end.y);
   options.assert.ok(curve.start.x < curve.end.x, 'slur follows the left-to-right musical order');
-  options.assert.ok(beamClearance >= 11.9, 'a source-spanning grace slur clears the beamed grace notes');
+  options.assert.ok(beamClearance >= 5.9, 'a source-spanning grace slur clears the beamed grace notes');
   options.assert.deepEqual(
     (firstGraceGroup as GraceNoteGroup).getSlurLayout()?.intersectedEndpointIds,
     [],

--- a/tests/gracenote_tests.ts
+++ b/tests/gracenote_tests.ts
@@ -191,11 +191,10 @@ function basicSlurred(options: TestOptions): void {
   gracenotes3[2].addModifier(f.Accidental({ type: 'n' }), 0);
   Dot.buildAndAttach([gracenotes4[0]], { all: true });
 
-  const firstGraceGroup = f.GraceNoteGroup({ notes: gracenotes0, slur: true }).beamNotes();
-  const steepGraceGroup = f.GraceNoteGroup({
-    notes: [{ keys: ['e/6'], duration: '8' }].map(f.GraceNote.bind(f)),
-    slur: true,
-  });
+  const firstGraceGroup = f.GraceNoteGroup({ notes: gracenotes0, slur: true, slurStartIndex: 0 }).beamNotes();
+  const steepGraceNotes = [{ keys: ['e/6'], duration: '8', stemDirection: 1 }].map(f.GraceNote.bind(f));
+  const steepGraceGroup = f.GraceNoteGroup({ notes: steepGraceNotes, slur: true });
+  const steepMainNote = f.StaveNote({ keys: ['a/4'], duration: '4', stemDirection: 1 });
   const notes = [
     f.StaveNote({ keys: ['b/4'], duration: '4', autoStem: true }).addModifier(firstGraceGroup, 0),
     f
@@ -211,7 +210,7 @@ function basicSlurred(options: TestOptions): void {
     f
       .StaveNote({ keys: ['a/4'], duration: '4', autoStem: true })
       .addModifier(f.GraceNoteGroup({ notes: gracenotes4, slur: true }).beamNotes(), 0),
-    f.StaveNote({ keys: ['a/4'], duration: '4', autoStem: true }).addModifier(steepGraceGroup, 0),
+    steepMainNote.addModifier(steepGraceGroup, 0),
   ];
 
   const voice = f.Voice().setStrict(false).addTickables(notes);
@@ -221,10 +220,16 @@ function basicSlurred(options: TestOptions): void {
   f.draw();
 
   const slur = (firstGraceGroup as GraceNoteGroup).getSlur();
-  options.assert.strictEqual(slur?.getNotes().firstNote, gracenotes0.at(-1), 'slur starts at nearest grace note');
+  options.assert.strictEqual(slur?.getNotes().firstNote, gracenotes0[0], 'slur preserves its source grace note');
   options.assert.strictEqual(slur?.getNotes().lastNote, notes[0], 'slur ends at main note');
   const curve = (firstGraceGroup as GraceNoteGroup).getRenderedSlurCurves()[0];
+  const curveDirection = (firstGraceGroup as GraceNoteGroup).getSlurLayout()?.direction ?? 1;
+  const beamClearance =
+    curveDirection === -1
+      ? Math.min(curve.start.y, curve.end.y) - curve.topControl.y
+      : curve.topControl.y - Math.max(curve.start.y, curve.end.y);
   options.assert.ok(curve.start.x < curve.end.x, 'slur follows the left-to-right musical order');
+  options.assert.ok(beamClearance >= 7.9, 'a source-spanning grace slur clears the beamed grace notes');
   options.assert.deepEqual(
     (firstGraceGroup as GraceNoteGroup).getSlurLayout()?.intersectedEndpointIds,
     [],
@@ -234,6 +239,26 @@ function basicSlurred(options: TestOptions): void {
     (steepGraceGroup as GraceNoteGroup).getSlurLayout()?.direction,
     -1,
     'a high grace note on a large descending leap routes its slur above'
+  );
+  const steepLayout = (steepGraceGroup as GraceNoteGroup).getSlurLayout();
+  const steepCurve = steepLayout?.curves[0];
+  options.assert.strictEqual(steepLayout?.startAttachment, 'stem-tip', 'steep slur starts at grace stem tip');
+  options.assert.strictEqual(steepLayout?.endAttachment, 'stem-tip', 'steep slur ends at main stem tip');
+  options.assert.ok(
+    Math.abs((steepCurve?.start.x ?? 0) - steepGraceNotes[0].getStemX()) < 0.001,
+    'steep slur starts at the grace stem x position'
+  );
+  options.assert.ok(
+    Math.abs((steepCurve?.end.x ?? 0) - steepMainNote.getStemX()) < 0.001,
+    'steep slur ends at the main stem x position'
+  );
+  options.assert.ok(
+    Math.abs((steepCurve?.start.y ?? 0) - steepGraceNotes[0].getStemExtents().topY) < 0.001,
+    'steep slur starts at the grace stem tip y position'
+  );
+  options.assert.ok(
+    Math.abs((steepCurve?.end.y ?? 0) - steepMainNote.getStemExtents().topY) < 0.001,
+    'steep slur ends at the main stem tip y position'
   );
 }
 

--- a/tests/gracenote_tests.ts
+++ b/tests/gracenote_tests.ts
@@ -16,6 +16,7 @@ import { Dot } from '../src/dot';
 import { Factory } from '../src/factory';
 import { Formatter } from '../src/formatter';
 import { GraceNote, GraceNoteStruct } from '../src/gracenote';
+import { GraceNoteGroup } from '../src/gracenotegroup';
 import { StaveNote, StaveNoteStruct } from '../src/stavenote';
 
 const GraceNoteTests = {
@@ -190,10 +191,13 @@ function basicSlurred(options: TestOptions): void {
   gracenotes3[2].addModifier(f.Accidental({ type: 'n' }), 0);
   Dot.buildAndAttach([gracenotes4[0]], { all: true });
 
+  const firstGraceGroup = f.GraceNoteGroup({ notes: gracenotes0, slur: true }).beamNotes();
+  const steepGraceGroup = f.GraceNoteGroup({
+    notes: [{ keys: ['e/6'], duration: '8' }].map(f.GraceNote.bind(f)),
+    slur: true,
+  });
   const notes = [
-    f
-      .StaveNote({ keys: ['b/4'], duration: '4', autoStem: true })
-      .addModifier(f.GraceNoteGroup({ notes: gracenotes0, slur: true }).beamNotes(), 0),
+    f.StaveNote({ keys: ['b/4'], duration: '4', autoStem: true }).addModifier(firstGraceGroup, 0),
     f
       .StaveNote({ keys: ['c/5'], duration: '4', autoStem: true })
       .addModifier(f.Accidental({ type: '#' }), 0)
@@ -207,7 +211,7 @@ function basicSlurred(options: TestOptions): void {
     f
       .StaveNote({ keys: ['a/4'], duration: '4', autoStem: true })
       .addModifier(f.GraceNoteGroup({ notes: gracenotes4, slur: true }).beamNotes(), 0),
-    f.StaveNote({ keys: ['a/4'], duration: '4', autoStem: true }),
+    f.StaveNote({ keys: ['a/4'], duration: '4', autoStem: true }).addModifier(steepGraceGroup, 0),
   ];
 
   const voice = f.Voice().setStrict(false).addTickables(notes);
@@ -216,7 +220,21 @@ function basicSlurred(options: TestOptions): void {
 
   f.draw();
 
-  options.assert.ok(true, 'GraceNoteBasic');
+  const slur = (firstGraceGroup as GraceNoteGroup).getSlur();
+  options.assert.strictEqual(slur?.getNotes().firstNote, gracenotes0.at(-1), 'slur starts at nearest grace note');
+  options.assert.strictEqual(slur?.getNotes().lastNote, notes[0], 'slur ends at main note');
+  const curve = (firstGraceGroup as GraceNoteGroup).getRenderedSlurCurves()[0];
+  options.assert.ok(curve.start.x < curve.end.x, 'slur follows the left-to-right musical order');
+  options.assert.deepEqual(
+    (firstGraceGroup as GraceNoteGroup).getSlurLayout()?.intersectedEndpointIds,
+    [],
+    'slur does not cross either connected notehead'
+  );
+  options.assert.strictEqual(
+    (steepGraceGroup as GraceNoteGroup).getSlurLayout()?.direction,
+    -1,
+    'a high grace note on a large descending leap routes its slur above'
+  );
 }
 
 /**

--- a/tests/gracenote_tests.ts
+++ b/tests/gracenote_tests.ts
@@ -18,6 +18,7 @@ import { Formatter } from '../src/formatter';
 import { GraceNote, GraceNoteStruct } from '../src/gracenote';
 import { GraceNoteGroup } from '../src/gracenotegroup';
 import { StaveNote, StaveNoteStruct } from '../src/stavenote';
+import { Tables } from '../src/tables';
 
 function curveIntersectsBounds(
   curve: {
@@ -44,6 +45,36 @@ function curveIntersectsBounds(
     }
   }
   return false;
+}
+
+function graceNoteRightEdge(note: StaveNote): number {
+  let right = note.getTieRightX();
+  if (note.shouldDrawFlag()) {
+    right = Math.max(right, note.getStemX() - Tables.STEM_WIDTH / 2 + note.getGlyphWidth());
+  }
+  note.getModifiersByType(Dot.CATEGORY).forEach((dot) => {
+    const index = dot.getIndex() ?? 0;
+    const start = note.getModifierStartXY(ModifierPosition.RIGHT, index, { forceFlagRight: true });
+    right = Math.max(right, start.x + dot.getXShift() + dot.getWidth());
+  });
+  return right;
+}
+
+function graceNoteLeftEdge(note: StaveNote): number {
+  const accidentals = note.getModifiersByType(Accidental.CATEGORY);
+  if (accidentals.length > 0) {
+    return Math.min(...accidentals.map((accidental) => accidental.getBoundingBox().getX()));
+  }
+  return Math.min(
+    ...note.noteHeads.map((noteHead) => {
+      const bounds = noteHead.getBoundingBoxAt(note.getNoteHeadBeginX());
+      return bounds.getX();
+    })
+  );
+}
+
+function noteheadLeftEdge(note: StaveNote): number {
+  return Math.min(...note.noteHeads.map((noteHead) => noteHead.getBoundingBoxAt(note.getNoteHeadBeginX()).getX()));
 }
 
 const GraceNoteTests = {
@@ -257,6 +288,15 @@ function basicSlurred(options: TestOptions): void {
       ? Math.min(curve.start.y, curve.end.y) - curveMidpointY
       : curveMidpointY - Math.max(curve.start.y, curve.end.y);
   options.assert.ok(curve.start.x < curve.end.x, 'slur follows the left-to-right musical order');
+  options.assert.strictEqual(
+    (firstGraceGroup as GraceNoteGroup).getSlurLayout()?.startAttachment,
+    'notehead-center',
+    'slur starts at the optical center of the first grace notehead'
+  );
+  options.assert.ok(
+    Math.abs(curve.start.x - gracenotes0[0].getSelectedNoteHeadBounds(0).centerX) < 0.001,
+    'slur onset uses the optical center of the first grace notehead'
+  );
   options.assert.ok(beamClearance >= 5.9, 'a source-spanning grace slur clears the beamed grace notes');
   options.assert.deepEqual(
     (firstGraceGroup as GraceNoteGroup).getSlurLayout()?.intersectedEndpointIds,
@@ -273,20 +313,61 @@ function basicSlurred(options: TestOptions): void {
     gracenotes4[0],
     'the fifth-quarter slur includes every grace note in the group'
   );
+  options.assert.ok(
+    graceNoteLeftEdge(gracenotes4[1]) - graceNoteRightEdge(gracenotes4[0]) >= 2 * StaveNote.minNoteheadPadding - 0.001,
+    'the dotted fifth-quarter grace note leaves room before the next grace notehead'
+  );
 
   const thirdCurve = thirdGraceGroup.getRenderedSlurCurves()[0];
   const thirdHeadBounds = thirdMainNote.noteHeads.map((noteHead) =>
     noteHead.getBoundingBoxAt(thirdMainNote.getNoteHeadBeginX())
   );
   const thirdChordLeft = Math.min(...thirdHeadBounds.map((bounds) => bounds.getX()));
-  const thirdChordRight = Math.max(...thirdHeadBounds.map((bounds) => bounds.getX() + bounds.getW()));
+  const thirdChordRightmostCenter = Math.max(...thirdHeadBounds.map((bounds) => bounds.getX() + bounds.getW() / 2));
   options.assert.ok(
-    Math.abs(thirdCurve.end.x - (thirdChordLeft + thirdChordRight) / 2) < 0.001,
-    'the chord-ending slur attaches at the visual center of the chord'
+    Math.abs(thirdCurve.end.x - thirdChordRightmostCenter) < 0.001,
+    'the chord-ending slur attaches at the visual center of the rightmost chord note'
+  );
+  options.assert.notOk(
+    curveIntersectsBounds(thirdCurve, {
+      left: thirdHeadBounds[1].getX(),
+      right: thirdHeadBounds[1].getX() + thirdHeadBounds[1].getW(),
+      top: thirdHeadBounds[1].getY(),
+      bottom: thirdHeadBounds[1].getY() + thirdHeadBounds[1].getH(),
+    }),
+    'the third-quarter slur clears the rightmost chord notehead'
+  );
+
+  const firstGraceSharp = gracenotes0[1].getModifiersByType(Accidental.CATEGORY)[0];
+  const fourthGraceNatural = gracenotes3[2].getModifiersByType(Accidental.CATEGORY)[0];
+  options.assert.ok(
+    firstGraceSharp.getBoundingBox().getX() - graceNoteRightEdge(gracenotes0[0]) <=
+      StaveNote.minNoteheadPadding + 0.001,
+    'the first-quarter grace sharp does not add unnecessary leading whitespace'
+  );
+  options.assert.ok(
+    fourthGraceNatural.getBoundingBox().getX() - graceNoteRightEdge(gracenotes3[1]) <=
+      StaveNote.minNoteheadPadding + 0.001,
+    'the fourth-quarter grace natural does not add unnecessary leading whitespace'
+  );
+  const minimumGraceGroupEndGap = 1.5 * StaveNote.minNoteheadPadding - 0.001;
+  options.assert.ok(
+    noteheadLeftEdge(notes[0]) - graceNoteRightEdge(gracenotes0[gracenotes0.length - 1]) >= minimumGraceGroupEndGap,
+    'the first-quarter grace group leaves a small end gap before the parent notehead'
+  );
+  options.assert.ok(
+    noteheadLeftEdge(fourthMainNote) - graceNoteRightEdge(gracenotes3[gracenotes3.length - 1]) >=
+      minimumGraceGroupEndGap,
+    'the fourth-quarter grace group leaves a small end gap before the parent notehead'
+  );
+  options.assert.ok(
+    noteheadLeftEdge(fifthMainNote) - graceNoteRightEdge(gracenotes4[gracenotes4.length - 1]) >=
+      minimumGraceGroupEndGap,
+    'the fifth-quarter grace group leaves a small end gap before the parent notehead'
   );
 
   const secondAccidentalBounds = secondAccidental.getBoundingBox();
-  const secondGraceRight = gracenotes1[0].getTieRightX();
+  const secondGraceRight = graceNoteRightEdge(gracenotes1[0]);
   options.assert.ok(
     secondAccidentalBounds.getX() - secondGraceRight <= 1.001,
     'the grace group uses compact spacing before the parent accidental'
@@ -300,6 +381,10 @@ function basicSlurred(options: TestOptions): void {
   options.assert.notOk(
     secondGraceGroup.getRenderedSlurCurves().some((curve) => curveIntersectsBounds(curve, secondAccidentalRect)),
     'the second-quarter slur clears the parent accidental'
+  );
+  options.assert.ok(
+    thirdChordLeft - graceNoteRightEdge(gracenotes2[0]) >= StaveNote.minNoteheadPadding - 0.001,
+    'the third-quarter grace flag clears the chord'
   );
   options.assert.strictEqual(
     (steepGraceGroup as GraceNoteGroup).getSlurLayout()?.direction,
@@ -325,6 +410,15 @@ function basicSlurred(options: TestOptions): void {
   options.assert.ok(
     Math.abs((steepCurve?.end.y ?? 0) - steepMainNote.getStemExtents().topY) < 0.001,
     'steep slur ends at the main stem tip y position'
+  );
+  const steepEndpointSeparation = Math.abs((steepCurve?.end.y ?? 0) - (steepCurve?.start.y ?? 0));
+  const steepControlClearance =
+    steepLayout?.direction === -1
+      ? ((steepCurve?.start.y ?? 0) + (steepCurve?.end.y ?? 0)) / 2 - (steepCurve?.topControl.y ?? 0)
+      : (steepCurve?.topControl.y ?? 0) - ((steepCurve?.start.y ?? 0) + (steepCurve?.end.y ?? 0)) / 2;
+  options.assert.ok(
+    steepControlClearance >= steepEndpointSeparation / 2 - 0.001,
+    'steep slur curvature scales with endpoint separation'
   );
 }
 

--- a/tests/gracetabnote_tests.ts
+++ b/tests/gracetabnote_tests.ts
@@ -101,8 +101,10 @@ function slurred(options: TestOptions, contextBuilder: ContextBuilder): void {
   const gracenotes0 = gracenoteGroup0.map(graceTabNote);
   const gracenotes1 = gracenoteGroup1.map(graceTabNote);
 
-  note0.addModifier(new GraceNoteGroup(gracenotes0, true), 0);
-  note1.addModifier(new GraceNoteGroup(gracenotes1, true), 0);
+  const slurredGroup0 = new GraceNoteGroup(gracenotes0, true);
+  const slurredGroup1 = new GraceNoteGroup(gracenotes1, true);
+  note0.addModifier(slurredGroup0, 0);
+  note1.addModifier(slurredGroup1, 0);
 
   const voice = new Voice(VexFlow.TIME4_4);
   voice.addTickables([note0, note1]);
@@ -111,6 +113,24 @@ function slurred(options: TestOptions, contextBuilder: ContextBuilder): void {
 
   voice.draw(context, stave);
 
+  options.assert.strictEqual(
+    slurredGroup0.getSlur()?.getNotes().firstNote,
+    gracenotes0[0],
+    'the first TAB slur starts at the first grace number'
+  );
+  options.assert.strictEqual(
+    slurredGroup1.getSlur()?.getNotes().firstNote,
+    gracenotes1[0],
+    'the second TAB slur starts at the first grace number'
+  );
+  options.assert.ok(
+    note0.getAbsoluteX() - note0.getWidth() / 2 > gracenotes0[1].getAbsoluteX() + gracenotes0[1].getWidth() / 2,
+    'the first TAB slur leaves the final grace number before the parent'
+  );
+  options.assert.ok(
+    note1.getAbsoluteX() - note1.getWidth() / 2 > gracenotes1[2].getAbsoluteX() + gracenotes1[2].getWidth() / 2,
+    'the second TAB slur leaves the final grace number before the parent'
+  );
   options.assert.ok(true, 'Slurred Test');
 }
 

--- a/tests/stavetie_tests.ts
+++ b/tests/stavetie_tests.ts
@@ -156,7 +156,16 @@ function tieAlgorithms(options: TestOptions): void {
     options: { direction: Stem.DOWN },
   });
   factory.Formatter().joinVoices([voice]).formatToStave([voice], stave);
+  const tieCurvesBeforeDraw = tie1.getRenderedTieCurves();
+  options.assert.equal(tieCurvesBeforeDraw.length, 1);
+  options.assert.equal(tieCurvesBeforeDraw[0].start.x, tie1.getFirstX());
+  options.assert.equal(tieCurvesBeforeDraw[0].end.x, tie1.getLastX());
   factory.draw();
+  options.assert.deepEqual(
+    tie1.getRenderedTieCurves(),
+    tieCurvesBeforeDraw,
+    'Tie drawing consumes the same finalized curves'
+  );
   options.assert.equal(tie1.getDirection(), Stem.UP);
   options.assert.equal(tie2.getDirection(), Stem.DOWN);
   options.assert.ok(tie1.getFirstX() < tie1.getLastX());


### PR DESCRIPTION
## Summary

- route grace-note slurs from finalized selected-head and stem geometry
- keep articulation layout stable when grace slurs share an endpoint
- expose deterministic source-spanning grace slur geometry for collision handling
- clear grace beams with a compact, configurable visual gap
- retain draw/layout idempotence across repeated rendering

## Dependency

This branch is stacked on #325, which supplies the finalized notehead, articulation, beam, and tie geometry used here. #325 is in turn stacked on #322. The dependency commits can be removed by rebasing as those prerequisite PRs merge.

## Validation

- VexFlow lint under Node 24
- VexFlow browser QUnit suite under Node 24
- 1,880 tests passed, including stem-attached, beamed, source-spanning, and repeated-layout grace slurs
